### PR TITLE
build: add PyPI trusted-publishing release workflow + CHANGELOG (closes #1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+# Release workflow for cashew-brain.
+#
+# Trigger: a GitHub Release is published (either via the web UI or the `gh release create` CLI).
+# The release's tag (e.g. `v1.0.0`) determines the version that ships to PyPI — PyPI rejects
+# duplicate versions, so the tag and pyproject.toml `version` must agree.
+#
+# Auth: PyPI trusted publishing (OIDC). No API tokens are stored in this repo.
+#       See https://docs.pypi.org/trusted-publishers/ for the one-time PyPI-side setup:
+#         Publisher   : GitHub
+#         Owner       : rajkripal
+#         Repository  : cashew
+#         Workflow    : release.yml
+#         Environment : pypi
+#
+# The `environment: pypi` gate is recommended — it lets you require manual approval
+# on every publish and gives a clean audit trail in the GitHub Actions UI.
+
+name: Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+  # Allow manual dispatch for testing the build pipeline without publishing.
+  # When dispatched manually, the publish step is skipped (see `if:` guard below).
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Verify distributions
+        run: python -m twine check --strict dist/*
+
+      - name: Upload artifact for publish job
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish on actual release events — skip for workflow_dispatch (build-only smoke).
+    if: github.event_name == 'release'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cashew-brain
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No `with:` block — trusted publishing via OIDC uses the workflow identity.
+        # No `password` / `user` parameters; setting them would disable OIDC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - TBD
+
+First public release on PyPI. `pip install cashew-brain` now works.
+
+### Added
+- Persistent thought-graph memory backed by SQLite.
+- Local embeddings via `sentence-transformers` (default model: `all-MiniLM-L6-v2`).
+- `ContextRetriever` for RAG-style context generation from prior turns.
+- Knowledge extraction from completed turns with configurable `model_fn`.
+- Autonomous think cycles with organic decay.
+- CLI entry point (`cashew`).
+- PyPI trusted-publishing release workflow (OIDC, no API tokens).
+
+### Notes
+- Release date will be filled in when the v1.0.0 tag is cut and the workflow publishes.
+
+[Unreleased]: https://github.com/rajkripal/cashew/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/rajkripal/cashew/releases/tag/v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
 Homepage = "https://github.com/rajkripal/cashew"
 Repository = "https://github.com/rajkripal/cashew"
 Issues = "https://github.com/rajkripal/cashew/issues"
+Changelog = "https://github.com/rajkripal/cashew/blob/main/CHANGELOG.md"
 
 [project.scripts]
 cashew = "cashew_cli:main"


### PR DESCRIPTION
Unblocks `pip install cashew-brain` for downstream consumers (e.g. [hermes-cashew](https://github.com/magnus919/hermes-cashew)) per your ask in #1.

## What's in this PR

1. **`.github/workflows/release.yml`** — PyPI trusted-publishing (OIDC) workflow.
   - Triggered on GitHub Release publish.
   - Builds sdist + wheel with `python -m build`.
   - Validates with `twine check --strict`.
   - Publishes via `pypa/gh-action-pypi-publish@release/v1`.
   - No API tokens stored in the repo.
   - `environment: pypi` gate — lets you require manual approval per publish if you want; gives a clean audit trail in the Actions UI.
   - Also accepts `workflow_dispatch` for build-only smoke tests (skips the publish step).

2. **`CHANGELOG.md`** — Keep-a-Changelog format with a 1.0.0 stub. Release date left TBD; fill in when the tag is cut.

3. **`pyproject.toml`** — adds `Changelog` URL to `[project.urls]` so PyPI surfaces it in the project sidebar. That's the only metadata tweak I thought was worth it — everything else you already have is PyPI-ready.

## Local verification

```
$ python -m build
Successfully built cashew_brain-1.0.0.tar.gz and cashew_brain-1.0.0-py3-none-any.whl

$ twine check --strict dist/*
Checking dist/cashew_brain-1.0.0-py3-none-any.whl: PASSED
Checking dist/cashew_brain-1.0.0.tar.gz: PASSED
```

## One-time PyPI-side setup (before the first release)

Go to https://pypi.org/manage/account/publishing/ → "Add a new pending publisher" and enter:

```
PyPI Project Name: cashew-brain
Owner:             rajkripal
Repository:        cashew
Workflow filename: release.yml
Environment name:  pypi
```

(The "pending" part means PyPI reserves the name and accepts the OIDC identity even before the first upload exists. Once the workflow successfully publishes 1.0.0, it becomes a normal — non-pending — publisher.)

## Cutting v1.0.0

Once this PR lands + the PyPI publisher is registered:

```
gh release create v1.0.0 --generate-notes
```

The workflow fires on `release: published`, builds, and pushes to PyPI. If you set up the `pypi` GitHub environment with protection rules, you'll get a one-click approval prompt before the publish step runs.

## Compatibility note

Once 1.0.0 lands on PyPI, hermes-cashew will swap its `git+SHA` pin for `cashew-brain>=1.0.0,<2.0.0` (compat range per your SemVer plan in #1). If you want me to test against a TestPyPI upload first, I can also contribute a `release-testpypi.yml` that fires on pre-release tags — happy to follow up in a separate PR.

Thanks again for being receptive. 🙏