### PR TITLE
chore(release): SHA-pin release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -52,7 +52,7 @@ jobs:
         run: python -m twine check --strict dist/*
 
       - name: Upload artifact for publish job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: dist/
@@ -72,12 +72,12 @@ jobs:
       id-token: write  # required for OIDC trusted publishing
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         # No `with:` block — trusted publishing via OIDC uses the workflow identity.
         # No `password` / `user` parameters; setting them would disable OIDC.


### PR DESCRIPTION
## Summary
- Pins the five third-party actions in `release.yml` to commit SHAs, with a trailing `# version` comment so the version intent stays visible.
- Follow-up to #2; does not change behavior.

## Why
Mutable refs like `@v4` or `@release/v1` resolve at run time, so a tag move or branch force-push on the upstream action would ship into our release pipeline. Since this workflow has PyPI trusted-publishing permissions, that is the one place where a hardening pin is worth doing even for first-party `actions/*`.

## Test plan
- [ ] Workflow parses (no Actions syntax errors on next dispatch).
- [ ] `workflow_dispatch` build-only run succeeds; publish step skipped as before.