### PR TITLE
feat(schema): public init API, migration contract, and version marker

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -109,6 +109,45 @@ CREATE VIRTUAL TABLE vec_embeddings USING vec0(
 );
 ```
 
+### Schema Ownership Contract
+
+Cashew is embeddable as a library: downstream consumers (e.g. `hermes-cashew`) layer their own tables on top of cashew's database. This section defines what cashew owns and what extension points consumers can rely on.
+
+**Cashew-owned tables** — schema is managed by `core.db.ensure_schema()`, may change across cashew versions under the rules below:
+
+- `thought_nodes`
+- `derivation_edges`
+- `embeddings`
+- `hotspots`
+- `metrics`
+- `vec_embeddings` (virtual, when sqlite-vec is available)
+
+**Cashew-owned columns** on `thought_nodes`: `id`, `content`, `node_type`, `domain`, `timestamp`, `access_count`, `last_accessed`, `confidence`, `source_file`, `decayed`, `metadata`, `last_updated`, `mood_state`, `permanent`, `tags`, `referent_time`.
+
+**Cashew-owned columns** on `derivation_edges`: `parent_id`, `child_id`, `weight`, `reasoning`, `confidence`, `timestamp`.
+
+**Migration policy**
+
+- Additive-only within a major version. Cashew will add columns or tables in minor releases; it will never drop or rename an owned column or table without a major version bump.
+- `ensure_schema()` is idempotent and safe to call on empty databases, legacy databases missing columns, and fully-current databases.
+- `PRAGMA user_version` carries the applied schema version. `core.db.get_schema_version(db)` reads it; `core.db.schema_version()` returns the version this build produces.
+
+**Extension points for downstream consumers**
+
+- Consumers may create their own tables (use a clear prefix, e.g. `hermes_*`) — cashew will not touch them.
+- Consumers may add columns prefixed `ext_` to cashew-owned tables. Cashew will never introduce an `ext_`-prefixed column.
+- Consumers should call `ensure_schema(db)` before running their own migrations, then branch on `get_schema_version(db)` to decide whether their own migration ladder needs to run.
+
+Example downstream pattern:
+
+```python
+from core.db import ensure_schema, get_schema_version
+
+ensure_schema(db_path)                  # cashew applies its migrations
+if get_schema_version(db_path) >= 1:
+    apply_my_layer(db_path)             # downstream layers on top
+```
+
 ### Node Types (Current Implementation)
 - **fact** — Data points and factual observations
 - **observation** — Personal experiences and direct observations

--- a/core/db.py
+++ b/core/db.py
@@ -144,10 +144,34 @@ def list_tables(conn: sqlite3.Connection) -> list[str]:
 
 
 def ensure_schema(db_path: Optional[str] = None) -> None:
-    """Delegate to core.session._ensure_schema — kept here so callers never
-    have to import the private name themselves."""
+    """Public, idempotent schema init / migration entrypoint.
+
+    Creates cashew's canonical tables from scratch if they don't exist,
+    applies additive column migrations to legacy databases, and stamps
+    `PRAGMA user_version` with the current schema version.
+
+    Safe for downstream library consumers to call before layering their
+    own schema additions. See DESIGN.md for the ownership contract.
+    """
     from core.session import _ensure_schema  # noqa: WPS433
     _ensure_schema(resolve_db_path(db_path))
+
+
+def get_schema_version(db_path: Optional[str] = None) -> int:
+    """Return the cashew schema version applied to this database.
+
+    Reads `PRAGMA user_version`. Returns 0 for databases that have never
+    been through `ensure_schema`. Downstream consumers can branch on this
+    to decide whether to apply their own layered migrations.
+    """
+    from core.session import get_schema_version as _get  # noqa: WPS433
+    return _get(resolve_db_path(db_path))
+
+
+def schema_version() -> int:
+    """The schema version this build of cashew knows how to produce."""
+    from core.session import SCHEMA_VERSION  # noqa: WPS433
+    return SCHEMA_VERSION
 
 
 def execute_migration(sql: str, db_path: Optional[str] = None) -> None:

--- a/core/session.py
+++ b/core/session.py
@@ -66,38 +66,152 @@ def _get_connection(db_path: str) -> sqlite3.Connection:
     """Get database connection"""
     return sqlite3.connect(db_path)
 
-def _ensure_schema(db_path: str):
-    """Ensure required tables and columns exist"""
-    conn = _get_connection(db_path)
-    cursor = conn.cursor()
-    
-    # Check if last_accessed column exists, add if missing
-    cursor.execute("PRAGMA table_info(thought_nodes)")
-    columns = [row[1] for row in cursor.fetchall()]
-    
-    if 'last_accessed' not in columns:
-        cursor.execute("ALTER TABLE thought_nodes ADD COLUMN last_accessed TEXT")
-    
-    if 'access_count' not in columns:
-        cursor.execute("ALTER TABLE thought_nodes ADD COLUMN access_count INTEGER DEFAULT 0")
+# ----- Schema contract ----------------------------------------------------
+# Cashew owns these tables and the columns listed below. See DESIGN.md
+# ("Schema ownership contract") for the full policy. Downstream consumers
+# (e.g. hermes-cashew) may add their own tables and columns — the contract
+# is that cashew will never rename or drop its own columns within a major
+# version, and will only add columns in minor versions.
+#
+# SCHEMA_VERSION is stored in `PRAGMA user_version`. Bump it whenever a new
+# migration is appended to _MIGRATIONS.
+SCHEMA_VERSION = 1
 
-    # referent_time: event clock (when the fact/event actually happened),
-    # distinct from `timestamp` which is the ingestion clock. Nullable.
-    # See DESIGN notes: operational readers (decay/GC/declassify/embeddings/
-    # recent-activity) stay on `timestamp`. User-facing/biographical readers
-    # use COALESCE(referent_time, timestamp).
-    if 'referent_time' not in columns:
-        cursor.execute("ALTER TABLE thought_nodes ADD COLUMN referent_time TEXT")
+
+def _apply_v1(cursor: sqlite3.Cursor) -> None:
+    """Canonical from-scratch schema. Idempotent."""
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS thought_nodes (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            node_type TEXT NOT NULL,
+            domain TEXT,
+            timestamp TEXT,
+            access_count INTEGER DEFAULT 0,
+            last_accessed TEXT,
+            confidence REAL,
+            source_file TEXT,
+            decayed INTEGER DEFAULT 0,
+            metadata TEXT DEFAULT '{}',
+            last_updated TEXT,
+            mood_state TEXT,
+            permanent INTEGER DEFAULT 0,
+            tags TEXT,
+            referent_time TEXT
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS derivation_edges (
+            parent_id TEXT,
+            child_id TEXT,
+            weight REAL,
+            reasoning TEXT,
+            confidence REAL,
+            timestamp TEXT,
+            PRIMARY KEY (parent_id, child_id),
+            FOREIGN KEY (parent_id) REFERENCES thought_nodes(id),
+            FOREIGN KEY (child_id) REFERENCES thought_nodes(id)
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS embeddings (
+            node_id TEXT PRIMARY KEY,
+            vector BLOB NOT NULL,
+            model TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (node_id) REFERENCES thought_nodes(id)
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS hotspots (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            status TEXT,
+            domain TEXT,
+            file_pointers TEXT,
+            cluster_node_ids TEXT,
+            tags TEXT,
+            created TEXT,
+            last_updated TEXT
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            metric_name TEXT NOT NULL,
+            metric_value REAL NOT NULL,
+            tags TEXT
+        )
+    """)
+    for stmt in (
+        "CREATE INDEX IF NOT EXISTS idx_nodes_domain ON thought_nodes(domain)",
+        "CREATE INDEX IF NOT EXISTS idx_nodes_timestamp ON thought_nodes(timestamp)",
+        "CREATE INDEX IF NOT EXISTS idx_nodes_confidence ON thought_nodes(confidence)",
+        "CREATE INDEX IF NOT EXISTS idx_nodes_referent_time ON thought_nodes(referent_time)",
+        "CREATE INDEX IF NOT EXISTS idx_edges_parent ON derivation_edges(parent_id)",
+        "CREATE INDEX IF NOT EXISTS idx_edges_child ON derivation_edges(child_id)",
+    ):
         try:
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS idx_nodes_referent_time "
-                "ON thought_nodes(referent_time)"
-            )
+            cursor.execute(stmt)
         except sqlite3.OperationalError:
             pass
 
-    conn.commit()
-    conn.close()
+
+# Legacy column patch-ups for databases created before the canonical schema
+# was centralised. Additive only; cashew will not drop or rename columns
+# within a major version.
+_LEGACY_NODE_COLUMNS = (
+    ("domain",        "ALTER TABLE thought_nodes ADD COLUMN domain TEXT"),
+    ("access_count",  "ALTER TABLE thought_nodes ADD COLUMN access_count INTEGER DEFAULT 0"),
+    ("last_accessed", "ALTER TABLE thought_nodes ADD COLUMN last_accessed TEXT"),
+    ("confidence",    "ALTER TABLE thought_nodes ADD COLUMN confidence REAL"),
+    ("source_file",   "ALTER TABLE thought_nodes ADD COLUMN source_file TEXT"),
+    ("decayed",       "ALTER TABLE thought_nodes ADD COLUMN decayed INTEGER DEFAULT 0"),
+    ("metadata",      "ALTER TABLE thought_nodes ADD COLUMN metadata TEXT DEFAULT '{}'"),
+    ("last_updated",  "ALTER TABLE thought_nodes ADD COLUMN last_updated TEXT"),
+    ("mood_state",    "ALTER TABLE thought_nodes ADD COLUMN mood_state TEXT"),
+    ("permanent",     "ALTER TABLE thought_nodes ADD COLUMN permanent INTEGER DEFAULT 0"),
+    ("tags",          "ALTER TABLE thought_nodes ADD COLUMN tags TEXT"),
+    ("referent_time", "ALTER TABLE thought_nodes ADD COLUMN referent_time TEXT"),
+)
+
+
+def _ensure_schema(db_path: str):
+    """Create or upgrade the cashew schema in place.
+
+    Idempotent. Safe to call on an empty file, a legacy database missing
+    some columns, or an already-current database. This is the blessed
+    entry point for both CLI init and library consumers.
+    """
+    conn = _get_connection(db_path)
+    cursor = conn.cursor()
+    try:
+        _apply_v1(cursor)
+
+        cursor.execute("PRAGMA table_info(thought_nodes)")
+        existing = {row[1] for row in cursor.fetchall()}
+        for col, sql in _LEGACY_NODE_COLUMNS:
+            if col not in existing:
+                try:
+                    cursor.execute(sql)
+                except sqlite3.OperationalError:
+                    pass
+
+        cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_schema_version(db_path: str) -> int:
+    """Return the applied schema version (PRAGMA user_version). 0 means unmanaged."""
+    conn = _get_connection(db_path)
+    try:
+        row = conn.execute("PRAGMA user_version").fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        conn.close()
 
 def _normalize_referent_time(value: Optional[str]) -> Optional[str]:
     """Normalize a caller-supplied event time to UTC ISO8601.

--- a/tests/test_schema_api.py
+++ b/tests/test_schema_api.py
@@ -1,0 +1,122 @@
+"""Tests for the public schema API (issues #4, #5, #6).
+
+Covers:
+- ensure_schema bootstraps a fresh database from scratch
+- ensure_schema is idempotent
+- ensure_schema upgrades a legacy database missing newer columns
+- PRAGMA user_version carries the applied schema version
+- core.db exposes get_schema_version / schema_version / ensure_schema
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from core.session import SCHEMA_VERSION, _ensure_schema, get_schema_version
+from core import db as cdb
+
+
+OWNED_TABLES = {
+    "thought_nodes",
+    "derivation_edges",
+    "embeddings",
+    "hotspots",
+    "metrics",
+}
+
+OWNED_NODE_COLUMNS = {
+    "id", "content", "node_type", "domain", "timestamp",
+    "access_count", "last_accessed", "confidence", "source_file",
+    "decayed", "metadata", "last_updated", "mood_state", "permanent",
+    "tags", "referent_time",
+}
+
+
+def _tables(db_path: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        conn.close()
+
+
+def _columns(db_path: str, table: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    finally:
+        conn.close()
+
+
+def test_ensure_schema_creates_fresh_database(tmp_path):
+    db = str(tmp_path / "fresh.db")
+    _ensure_schema(db)
+    assert OWNED_TABLES.issubset(_tables(db))
+    assert OWNED_NODE_COLUMNS.issubset(_columns(db, "thought_nodes"))
+
+
+def test_ensure_schema_is_idempotent(tmp_path):
+    db = str(tmp_path / "idem.db")
+    _ensure_schema(db)
+    _ensure_schema(db)
+    _ensure_schema(db)
+    assert get_schema_version(db) == SCHEMA_VERSION
+
+
+def test_ensure_schema_migrates_legacy_database(tmp_path):
+    db = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE thought_nodes ("
+        " id TEXT PRIMARY KEY, content TEXT, node_type TEXT, timestamp TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+    _ensure_schema(db)
+
+    assert OWNED_NODE_COLUMNS.issubset(_columns(db, "thought_nodes"))
+    assert OWNED_TABLES.issubset(_tables(db))
+    assert get_schema_version(db) == SCHEMA_VERSION
+
+
+def test_fresh_database_accepts_writes(tmp_path):
+    db = str(tmp_path / "write.db")
+    _ensure_schema(db)
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "INSERT INTO thought_nodes(id, content, node_type) VALUES (?,?,?)",
+            ("n1", "hello", "fact"),
+        )
+        conn.execute(
+            "INSERT INTO derivation_edges(parent_id, child_id, weight) VALUES (?,?,?)",
+            ("n1", "n1", 1.0),
+        )
+        conn.commit()
+        assert conn.execute("SELECT COUNT(*) FROM thought_nodes").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_version_zero_for_unmanaged_database(tmp_path):
+    db = str(tmp_path / "unmanaged.db")
+    sqlite3.connect(db).close()
+    assert get_schema_version(db) == 0
+
+
+def test_core_db_exposes_public_api(tmp_path, monkeypatch):
+    db = str(tmp_path / "api.db")
+    # Force resolve_db_path to use our temp file regardless of config.
+    monkeypatch.setenv("CASHEW_DB_PATH", db)
+
+    cdb.ensure_schema()
+    assert cdb.get_schema_version() == cdb.schema_version() == SCHEMA_VERSION


### PR DESCRIPTION
Closes #4, #5, #6.

## Summary
- `ensure_schema()` now creates tables from scratch on an empty database in addition to the existing ALTER-column migrations. Fresh init no longer crashes with `no such table: thought_nodes` (#4).
- `PRAGMA user_version` is stamped with `SCHEMA_VERSION`; exposed via `core.db.get_schema_version()` and `core.db.schema_version()` so downstream layers can branch on the applied version (#6).
- `DESIGN.md` documents cashew-owned tables/columns, the additive-only migration policy within a major version, and an `ext_*` namespace reserved for downstream columns (#5).

The canonical schema now lives in one place (`core.session._apply_v1`). `cashew_cli.py` and `scripts/cashew_init.py` continue to work via their existing paths.

## Downstream usage
```python
from core.db import ensure_schema, get_schema_version

ensure_schema(db_path)                  # cashew applies its migrations
if get_schema_version(db_path) >= 1:
    apply_downstream_layer(db_path)     # hermes-cashew etc. layer on top
```

## Test plan
- [x] 357 pytest tests pass (6 new in `tests/test_schema_api.py`, 351 pre-existing)
- [x] Fresh database init creates all owned tables and stamps version 1
- [x] Legacy database (partial columns) upgrades additively
- [x] `ensure_schema` is idempotent across repeated calls
- [x] `get_schema_version` returns 0 for unmanaged databases