### PR TITLE
extractors: log raw LLM response at debug level

### DIFF
--- a/extractors/markdown_dir.py
+++ b/extractors/markdown_dir.py
@@ -128,6 +128,7 @@ Extract only meaningful information, skip formatting, navigation, or boilerplate
 
         try:
             response = model_fn(prompt)
+            logger.debug(f"LLM raw ({source_tag}):\n{response}\n---")
             statements = parse_extraction_lines(response)
             
             return [{

--- a/extractors/obsidian.py
+++ b/extractors/obsidian.py
@@ -142,6 +142,7 @@ Focus on substantive content, not formatting or structure."""
 
         try:
             response = model_fn(prompt)
+            logger.debug(f"LLM raw ({source_tag}):\n{response}\n---")
             statements = parse_extraction_lines(response)
             
             return [{

--- a/extractors/sessions.py
+++ b/extractors/sessions.py
@@ -173,6 +173,7 @@ Focus on substantive content and skip pleasantries or routine interactions."""
 
         try:
             response = model_fn(prompt)
+            logger.debug(f"LLM raw ({session_id}):\n{response}\n---")
             statements = parse_extraction_lines(response)
             
             # Event clock: use the latest message timestamp in this batch as the

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -4,12 +4,11 @@ Tests for cashew extractor plugins.
 """
 
 import json
-import os
 import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -277,6 +276,19 @@ Another paragraph with useful information.""")
         self.assertEqual(nodes[0]['content'], "Extracted insight 1 with sufficient length")
         self.assertEqual(nodes[1]['content'], "Extracted insight 2 with also enough content")
 
+    def test_llm_debug_logging(self):
+        """Raw LLM response is logged at debug level after extraction."""
+        note_file = self.vault_path / "note.md"
+        note_file.write_text("Content long enough to trigger LLM extraction path.")
+
+        def mock_model_fn(prompt):
+            return "raw obsidian response with enough length here"
+
+        with patch("extractors.obsidian.logger") as mock_logger:
+            ObsidianExtractor().extract(str(self.vault_path), mock_model_fn, str(self.db_path))
+            debug_calls = " ".join(str(c) for c in mock_logger.debug.call_args_list)
+            self.assertIn("raw obsidian response", debug_calls)
+
 
 class TestSessionExtractor(unittest.TestCase):
     """Test SessionExtractor."""
@@ -412,6 +424,25 @@ class TestSessionExtractor(unittest.TestCase):
         self.assertEqual(len(nodes), 3)
         self.assertTrue(any("React and Vue" in node['content'] for node in nodes))
 
+    def test_llm_debug_logging(self):
+        """Raw LLM response is logged at debug level after extraction."""
+        session_file = self.session_dir / "session.jsonl"
+        messages = [
+            {"role": "user", "content": "A" * 60},
+            {"role": "assistant", "content": "B" * 60},
+        ]
+        with open(session_file, "w") as f:
+            for m in messages:
+                f.write(json.dumps(m) + "\n")
+
+        def mock_model_fn(prompt):
+            return "raw session response with enough length here"
+
+        with patch("extractors.sessions.logger") as mock_logger:
+            SessionExtractor().extract(str(self.session_dir), mock_model_fn, str(self.db_path))
+            debug_calls = " ".join(str(c) for c in mock_logger.debug.call_args_list)
+            self.assertIn("raw session response", debug_calls)
+
 
 class TestMarkdownDirExtractor(unittest.TestCase):
     """Test MarkdownDirExtractor."""
@@ -498,6 +529,19 @@ class TestMarkdownDirExtractor(unittest.TestCase):
 
         self.assertGreater(len(nodes), 0)
         self.assertTrue(all('single.md' in node['source_file'] for node in nodes))
+
+    def test_llm_debug_logging(self):
+        """Raw LLM response is logged at debug level after extraction."""
+        md_file = self.notes_dir / "note.md"
+        md_file.write_text("Content long enough to trigger LLM extraction path.")
+
+        def mock_model_fn(prompt):
+            return "raw markdown response with enough length here"
+
+        with patch("extractors.markdown_dir.logger") as mock_logger:
+            MarkdownDirExtractor().extract(str(self.notes_dir), mock_model_fn, str(self.db_path))
+            debug_calls = " ".join(str(c) for c in mock_logger.debug.call_args_list)
+            self.assertIn("raw markdown response", debug_calls)
 
 
 class TestExtractorRegistry(unittest.TestCase):


### PR DESCRIPTION
Diagnosing extraction quality problems requires knowing what the model actually returned before the statement parser processes it. Without this, the only option is adding temporary print statements to the extractor source.

Adds `logger.debug` calls in all three extractors (sessions, markdown, obsidian) immediately after the `model_fn` response is received. With `--debug`, each extraction now logs:

`cashew.extractors.sessions DEBUG: LLM raw (session-id): [fact] SNR stability used as reliability proxy... [decision] Rebase approach: extract final state...`

Safe to merge: zero behavior change without `--debug`.