### PR TITLE
config: document commitment as a distinct core node type

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,7 +20,8 @@ node_types:
   core:
     belief: a held opinion or conviction
     insight: a non-obvious connection or pattern discovered
-    decision: a commitment or choice made
+    decision: a choice made between alternatives
+    commitment: a stated intention or planned action
     observation: a factual pattern noticed
     fact: a concrete verifiable fact
   custom: {}

--- a/core/config.py
+++ b/core/config.py
@@ -132,7 +132,8 @@ class CashewConfig:
                 'core': {
                     'belief': 'a held opinion or conviction',
                     'insight': 'a non-obvious connection or pattern discovered',
-                    'decision': 'a commitment or choice made',
+                    'decision': 'a choice made between alternatives',
+                    'commitment': 'a stated intention or planned action',
                     'observation': 'a factual pattern noticed',
                     'fact': 'a concrete verifiable fact',
                 },
@@ -161,7 +162,8 @@ class CashewConfig:
                 'core': [
                     {'belief': 'a held opinion or conviction'},
                     {'insight': 'a non-obvious connection or pattern discovered'},
-                    {'decision': 'a commitment or choice made'},
+                    {'decision': 'a choice made between alternatives'},
+                    {'commitment': 'a stated intention or planned action'},
                     {'observation': 'a factual pattern noticed'},
                     {'fact': 'a concrete verifiable fact'},
                 ],

--- a/scripts/cashew_init.py
+++ b/scripts/cashew_init.py
@@ -321,8 +321,9 @@ def build_config(interactive: bool = True, config_path: str = None, global_confi
         'node_types': {
             'core': {
                 'belief': 'a held opinion or conviction',
-                'insight': 'a non-obvious connection or pattern discovered', 
-                'decision': 'a commitment or choice made',
+                'insight': 'a non-obvious connection or pattern discovered',
+                'decision': 'a choice made between alternatives',
+                'commitment': 'a stated intention or planned action',
                 'observation': 'a factual pattern noticed',
                 'fact': 'a concrete verifiable fact'
             },

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -466,6 +466,24 @@ class TestCashewConfig:
             del os.environ['CASHEW_ACCESS_WEIGHT']
             del os.environ['CASHEW_TEMPORAL_WEIGHT']
 
+    def test_extractor_types_match_config(self):
+        """All extractor _VALID_TYPES must be present in default config node types."""
+        from extractors.sessions import SessionExtractor
+        from extractors.markdown_dir import MarkdownDirExtractor
+        from extractors.obsidian import ObsidianExtractor
+
+        config = CashewConfig()
+        configured = config.node_type_names
+
+        for extractor_cls in (SessionExtractor, MarkdownDirExtractor, ObsidianExtractor):
+            if hasattr(extractor_cls, '_VALID_TYPES'):
+                for t in extractor_cls._VALID_TYPES:
+                    assert t in configured, (
+                        f"{extractor_cls.__name__}._VALID_TYPES contains '{t}' "
+                        f"which is not in CashewConfig default node types"
+                    )
+
+
 class TestSessionDataClasses:
     """Test the dataclass structures"""
     


### PR DESCRIPTION
`commitment` is already emitted by the extractors but absent from `config.example.yaml`, the `core/config.py` defaults, and `cashew_init.py`. This leaves the taxonomy incomplete; a user inspecting the config or running `cashew init` would not see `commitment` listed, even though the extractors produce it.

This PR adds `commitment` alongside the existing core types and updates the `decision` definition to remove the redundant "a commitment or" prefix. The two types are now distinct: `decision` is a choice made between alternatives; `commitment` is a stated intention or planned action.

Also adds a test to `TestCashewConfig` asserting that all extractor `_VALID_TYPES` are present in the default config node types, to catch this class of divergence in future.

Safe to merge: `commitment` was already emitted by extractors; PR only updates config to enrich display of existing type. 
