### PR TITLE
fix(sleep): align dedup_threshold with DESIGN.md (0.9 -> 0.82)

### DIFF
--- a/core/sleep.py
+++ b/core/sleep.py
@@ -56,7 +56,7 @@ class SleepProtocol:
         self.db_path = db_path
         self.sleep_log_path = sleep_log_path
         self.sleep_frequency = 10  # Sleep every N thoughts (tunable)
-        self.dedup_threshold = 0.9
+        self.dedup_threshold = 0.82
         self.cross_link_threshold = 0.7
         # GC settings from config
         self.gc_mode = getattr(config, 'gc_mode', 'soft')

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -137,6 +137,34 @@ class TestSleepProtocol:
         )
         assert sim4 == 1.0  # Should be identical
     
+    def test_default_dedup_threshold_matches_design(self, sleep_protocol):
+        """dedup_threshold default must be 0.82 per DESIGN.md §10.
+
+        DESIGN.md specifies dedup at >0.82 similarity; cross-link at 0.7-0.85.
+        A pair scoring 0.82-0.89 is near-identical restatement (same fact, different
+        wording) and should be merged, not cross-linked. At 0.9 that band becomes
+        cross-links, inflating hub degree without adding knowledge.
+        """
+        assert sleep_protocol.dedup_threshold == 0.82, (
+            f"dedup_threshold is {sleep_protocol.dedup_threshold}; "
+            "DESIGN.md §10 specifies >0.82 — update code or design, not this test"
+        )
+
+    def test_high_similarity_pair_routes_to_dedup_not_cross_link(self, sleep_protocol):
+        """A pair with similarity in the 0.82-0.89 range must be a dedup candidate.
+
+        With dedup_threshold=0.9 (old default), similarity=0.85 falls into the
+        cross-link band. With the corrected 0.82 threshold it routes to dedup.
+        """
+        # Patch _text_similarity to return a controlled value in the 0.82-0.89 band
+        with patch.object(sleep_protocol, '_text_similarity', return_value=0.85):
+            candidates = sleep_protocol._find_cross_link_candidates_text_fallback()
+
+        dedup = [c for c in candidates if c.action == "dedup"]
+        cross = [c for c in candidates if c.action == "cross_link" and c.similarity == 0.85]
+        assert len(dedup) > 0, "similarity=0.85 should produce at least one dedup candidate"
+        assert len(cross) == 0, "similarity=0.85 must not produce cross_link candidates"
+
     def test_find_cross_link_candidates(self, sleep_protocol):
         """Test finding cross-link candidates"""
         # Lower thresholds for testing

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -138,32 +138,16 @@ class TestSleepProtocol:
         assert sim4 == 1.0  # Should be identical
     
     def test_default_dedup_threshold_matches_design(self, sleep_protocol):
-        """dedup_threshold default must be 0.82 per DESIGN.md §10.
+        """Test that dedup_threshold default matches DESIGN.md (>0.82)"""
+        assert sleep_protocol.dedup_threshold == 0.82
 
-        DESIGN.md specifies dedup at >0.82 similarity; cross-link at 0.7-0.85.
-        A pair scoring 0.82-0.89 is near-identical restatement (same fact, different
-        wording) and should be merged, not cross-linked. At 0.9 that band becomes
-        cross-links, inflating hub degree without adding knowledge.
-        """
-        assert sleep_protocol.dedup_threshold == 0.82, (
-            f"dedup_threshold is {sleep_protocol.dedup_threshold}; "
-            "DESIGN.md §10 specifies >0.82 — update code or design, not this test"
-        )
-
-    def test_high_similarity_pair_routes_to_dedup_not_cross_link(self, sleep_protocol):
-        """A pair with similarity in the 0.82-0.89 range must be a dedup candidate.
-
-        With dedup_threshold=0.9 (old default), similarity=0.85 falls into the
-        cross-link band. With the corrected 0.82 threshold it routes to dedup.
-        """
-        # Patch _text_similarity to return a controlled value in the 0.82-0.89 band
+    def test_high_similarity_routes_to_dedup_not_cross_link(self, sleep_protocol):
+        """Test that similarity in 0.82-0.89 band routes to dedup, not cross-link"""
         with patch.object(sleep_protocol, '_text_similarity', return_value=0.85):
             candidates = sleep_protocol._find_cross_link_candidates_text_fallback()
 
-        dedup = [c for c in candidates if c.action == "dedup"]
-        cross = [c for c in candidates if c.action == "cross_link" and c.similarity == 0.85]
-        assert len(dedup) > 0, "similarity=0.85 should produce at least one dedup candidate"
-        assert len(cross) == 0, "similarity=0.85 must not produce cross_link candidates"
+        assert any(c.action == "dedup" for c in candidates)
+        assert not any(c.action == "cross_link" and c.similarity == 0.85 for c in candidates)
 
     def test_find_cross_link_candidates(self, sleep_protocol):
         """Test finding cross-link candidates"""


### PR DESCRIPTION
## What's broken

The default dedup_threshold of 0.9 left the 0.82-0.89 similarity band routed to cross-link instead of dedup. DESIGN.md section 10 specifies deduplication at >0.82. Pairs in that band are near-identical restatements of the same fact across sessions and are dedup candidates by per stated design, not cross-link candidates. Discovered by ingesting a large technical corpus and multiple sessions of work within it. Evaluation of cross-link edge samples at different similarity bands showed the 0.80-0.89 range was overwhelmingly _same-idea-different-wording_, not _related-but-distinct-ideas_ across domains. The 0.70-0.79 band was ~70% genuinely related-but-distinct and aligns with the design intent. At scale, the misrouting inflates hub degree: popular topics accumulate many near-identical nodes across ingestion sessions, each pair becomes a cross-link edge, and the cross_link count term in the sleep score formula amplifies the effect over successive cycles.

## The fix

The fix is a single constant change. Behavior at 0.7-0.81 is unchanged. Behavior above 0.82 shifts from cross-link to dedup, which is what the design specifies. If the 0.9 value was a deliberate tuning decision that supersedes the design doc, updating DESIGN.md
to reflect that is the right resolution, and/or making this a setting in config.yaml.

## Merge Safety

Safe to merge: the change affects only the default threshold value, does not touch graph structure or retrieval logic, and is covered by two regression tests -- one asserting the default value, one verifying that similarity=0.85 routes to dedup rather than cross-link. All existing tests pass.
