### PR TITLE
fix(llm): work around Claude Code plugin inheritance in headless claude -p calls

### DIFF
--- a/core/llm.py
+++ b/core/llm.py
@@ -62,24 +62,12 @@ class ClaudeCodeBackend(LLMBackend):
             raise RuntimeError("`claude` CLI not found on PATH")
 
     def _generate(self, prompt: str) -> tuple[str, int, int]:
-        # Suppress plugin loading in headless subprocesses. When the parent
-        # Claude session has the telegram plugin loaded, a child `claude -p`
-        # also loading it spawns a second bun MCP, which races for the
-        # Telegram long-poll lock and shuts the parent's bun down. Watchdog
-        # then kills the parent session. See bunny-claude-bridge for the
-        # symptom — diagnosed via telegram-mcp-deaths.log.
-        empty_mcp = os.environ.get(
-            "CASHEW_EMPTY_MCP_CONFIG",
-            "/Users/bunny/bunny-claude-bridge/scripts/empty-mcp.json",
-        )
-        cmd = [self._bin, "-p", prompt,
-               "--model", self.model,
-               "--output-format", "json",
-               "--permission-mode", "bypassPermissions"]
-        if os.path.exists(empty_mcp):
-            cmd += ["--strict-mcp-config", "--mcp-config", empty_mcp]
         proc = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=300,
+            [self._bin, "-p", prompt,
+             "--model", self.model,
+             "--output-format", "json",
+             "--permission-mode", "bypassPermissions"],
+            capture_output=True, text=True, timeout=300,
         )
         if proc.returncode != 0:
             raise RuntimeError(f"claude -p failed (rc={proc.returncode}): {proc.stderr[:500]}")

--- a/core/llm.py
+++ b/core/llm.py
@@ -62,12 +62,24 @@ class ClaudeCodeBackend(LLMBackend):
             raise RuntimeError("`claude` CLI not found on PATH")
 
     def _generate(self, prompt: str) -> tuple[str, int, int]:
+        # Suppress plugin loading in headless subprocesses. When the parent
+        # Claude session has the telegram plugin loaded, a child `claude -p`
+        # also loading it spawns a second bun MCP, which races for the
+        # Telegram long-poll lock and shuts the parent's bun down. Watchdog
+        # then kills the parent session. See bunny-claude-bridge for the
+        # symptom — diagnosed via telegram-mcp-deaths.log.
+        empty_mcp = os.environ.get(
+            "CASHEW_EMPTY_MCP_CONFIG",
+            "/Users/bunny/bunny-claude-bridge/scripts/empty-mcp.json",
+        )
+        cmd = [self._bin, "-p", prompt,
+               "--model", self.model,
+               "--output-format", "json",
+               "--permission-mode", "bypassPermissions"]
+        if os.path.exists(empty_mcp):
+            cmd += ["--strict-mcp-config", "--mcp-config", empty_mcp]
         proc = subprocess.run(
-            [self._bin, "-p", prompt,
-             "--model", self.model,
-             "--output-format", "json",
-             "--permission-mode", "bypassPermissions"],
-            capture_output=True, text=True, timeout=300,
+            cmd, capture_output=True, text=True, timeout=300,
         )
         if proc.returncode != 0:
             raise RuntimeError(f"claude -p failed (rc={proc.returncode}): {proc.stderr[:500]}")

--- a/core/llm.py
+++ b/core/llm.py
@@ -15,8 +15,34 @@ import json
 import os
 import shutil
 import subprocess
+import tempfile
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Callable, Optional
+
+
+_EMPTY_MCP_CONFIG = '{"mcpServers":{}}'
+
+
+def _ensure_empty_mcp_config() -> Optional[str]:
+    """Write a one-time empty MCP config to tempdir.
+
+    Headless `claude -p` invocations launched from inside a parent Claude
+    Code session inherit the parent's plugin set. Plugins that own a
+    long-lived external resource (telegram bot poller, etc.) cannot tolerate
+    a second instance running concurrently. Passing `--strict-mcp-config`
+    plus this empty config suppresses plugin-supplied MCP servers in the
+    headless child without disturbing the parent.
+
+    Returns the absolute path, or None if the file cannot be created.
+    """
+    try:
+        path = Path(tempfile.gettempdir()) / "cashew-empty-mcp.json"
+        if not path.exists():
+            path.write_text(_EMPTY_MCP_CONFIG, encoding="utf-8")
+        return str(path)
+    except OSError:
+        return None
 
 
 class LLMBackend(ABC):
@@ -62,12 +88,15 @@ class ClaudeCodeBackend(LLMBackend):
             raise RuntimeError("`claude` CLI not found on PATH")
 
     def _generate(self, prompt: str) -> tuple[str, int, int]:
+        cmd = [self._bin, "-p", prompt,
+               "--model", self.model,
+               "--output-format", "json",
+               "--permission-mode", "bypassPermissions"]
+        empty_mcp = _ensure_empty_mcp_config()
+        if empty_mcp:
+            cmd += ["--strict-mcp-config", "--mcp-config", empty_mcp]
         proc = subprocess.run(
-            [self._bin, "-p", prompt,
-             "--model", self.model,
-             "--output-format", "json",
-             "--permission-mode", "bypassPermissions"],
-            capture_output=True, text=True, timeout=300,
+            cmd, capture_output=True, text=True, timeout=300,
         )
         if proc.returncode != 0:
             raise RuntimeError(f"claude -p failed (rc={proc.returncode}): {proc.stderr[:500]}")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -69,6 +69,43 @@ class TestClaudeCodeBackend:
         b = ClaudeCodeBackend(model="explicit")
         assert b.model == "explicit"
 
+    def test_generate_passes_strict_mcp_config(self, monkeypatch):
+        """Headless `claude -p` must isolate MCP config so plugins from a
+        surrounding Claude Code session do not double-spawn in the child."""
+        import json as _json
+        import subprocess as _subprocess
+
+        monkeypatch.setattr("shutil.which", lambda _: "/fake/claude")
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            class R:
+                returncode = 0
+                stdout = _json.dumps({"result": "ok",
+                                      "usage": {"input_tokens": 1,
+                                                "output_tokens": 1}})
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(_subprocess, "run", fake_run)
+
+        b = ClaudeCodeBackend()
+        b("hi")
+
+        cmd = captured["cmd"]
+        assert "--strict-mcp-config" in cmd, (
+            "ClaudeCodeBackend must pass --strict-mcp-config to suppress "
+            "plugin-supplied MCP servers in the headless subprocess"
+        )
+        idx = cmd.index("--mcp-config")
+        cfg_path = cmd[idx + 1]
+        # The config file must exist and be a valid empty MCP config.
+        with open(cfg_path) as fh:
+            data = _json.load(fh)
+        assert data == {"mcpServers": {}}
+
 
 class TestBuildBackend:
     def test_unknown_backend_returns_none(self):


### PR DESCRIPTION
This is a workaround for upstream Claude Code behavior, not a cashew bug.

When a process running inside a Claude Code session (cashew via `ClaudeCodeBackend`, but the same applies to anything else doing this) shells out to `claude -p`, the child inherits the parent's plugin set. Plugins that own a long-lived exclusive external resource (e.g. a Telegram long-poller, which the Bot API allows only one of per token) cannot tolerate two instances. The child's plugin instance fights the parent's, the parent's shuts down, and from the parent's side this looks like a plugin MCP crash.

The right fix is upstream in Claude Code (suppress plugin-supplied MCP servers in `-p` children by default, or at minimum surface a clean opt-in flag). Filing that separately. Until it lands, cashew users hitting any plugin-with-external-resource scenario need this workaround.

## What this patch does

Pass `--strict-mcp-config` plus an empty MCP config to every headless invocation. The empty config is generated once in the system tempdir on first call and reused. OAuth/keychain auth is preserved (unlike `--bare`, which forces `ANTHROPIC_API_KEY`).

No-op for cashew users not running inside a Claude Code session, since the flag suppresses an inheritance that doesn't exist.

## Scope

This only covers cashew's own `claude -p` invocations. Other tools spawning claude from inside a session (cron jobs, sub-agents, wrapper scripts) need the same workaround independently until upstream fixes it.

## Test

`tests/test_llm.py::test_generate_passes_strict_mcp_config` captures the subprocess argv and asserts both flags are present and the config file parses to `{"mcpServers": {}}`. 11/11 tests pass.

## TODO

Remove this workaround once Claude Code upstream fixes plugin inheritance in `-p` subprocesses.