### PR TITLE
extractors: add .cashewignore support to SessionExtractor

### DIFF
--- a/extractors/sessions.py
+++ b/extractors/sessions.py
@@ -8,7 +8,7 @@ Features:
 - Focus on assistant + user content
 - Skip tool calls and system messages
 - Extract knowledge using model_fn
-- .cashewignore support (consistent with other extractors)
+- .cashewignore support
 """
 
 import json

--- a/extractors/sessions.py
+++ b/extractors/sessions.py
@@ -8,6 +8,7 @@ Features:
 - Focus on assistant + user content
 - Skip tool calls and system messages
 - Extract knowledge using model_fn
+- .cashewignore support (consistent with other extractors)
 """
 
 import json
@@ -20,7 +21,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.extractors import BaseExtractor
-from extractors.utils import parse_extraction_lines
+from extractors.utils import load_ignore_patterns, parse_extraction_lines, should_ignore
 
 logger = logging.getLogger("cashew.extractors.sessions")
 
@@ -49,7 +50,11 @@ class SessionExtractor(BaseExtractor):
         if source_dir.is_file() and source_dir.suffix == '.jsonl':
             session_files = [source_dir]
         elif source_dir.is_dir():
-            session_files = list(source_dir.glob("*.jsonl"))
+            ignore_patterns = load_ignore_patterns(source_dir / ".cashewignore")
+            session_files = [
+                f for f in source_dir.glob("*.jsonl")
+                if not should_ignore(f, source_dir, ignore_patterns)
+            ]
         else:
             logger.error(f"Invalid source path: {source_path}")
             return []

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -443,6 +443,30 @@ class TestSessionExtractor(unittest.TestCase):
             debug_calls = " ".join(str(c) for c in mock_logger.debug.call_args_list)
             self.assertIn("raw session response", debug_calls)
 
+    def test_cashewignore(self):
+        """Test .cashewignore skips matched session files."""
+        def _write(name, text="x"):
+            p = self.session_dir / name
+            msg = {"role": "assistant", "content": text * 60}
+            p.write_text(json.dumps(msg) + "\n", encoding="utf-8")
+
+        _write("keep.jsonl")
+        _write("skip.jsonl")
+        _write("internal-a.jsonl")
+        _write("internal-b.jsonl")
+        (self.session_dir / ".cashewignore").write_text(
+            "skip.jsonl\ninternal-*.jsonl\n", encoding="utf-8"
+        )
+
+        extractor = SessionExtractor()
+        extractor.extract(str(self.session_dir), None, str(self.db_path))
+
+        processed = {Path(k).name for k in extractor._processed}
+        self.assertIn("keep.jsonl", processed)
+        self.assertNotIn("skip.jsonl", processed)
+        self.assertNotIn("internal-a.jsonl", processed)
+        self.assertNotIn("internal-b.jsonl", processed)
+
 
 class TestMarkdownDirExtractor(unittest.TestCase):
     """Test MarkdownDirExtractor."""


### PR DESCRIPTION
`SessionExtractor` does not read `.cashewignore`. Any patterns in the file have no effect on which JSONL files get processed, while `MarkdownDirExtractor` and `ObsidianExtractor` both already use `load_ignore_patterns` / `should_ignore` from `extractors.utils`. In practice this means files that should be excluded are ingested on every run, including internal extraction sessions that feed back into subsequent ingest cycles in a positive feedback loop when auto-extraction is enabled. 

Fix is minimal: import the two utilities and filter the `glob("*.jsonl")` result against `.cashewignore` patterns in the source directory.

Regression test added to `TestSessionExtractor` in `test_extractors.py`, following the structure of the existing `test_cashewignore` test in `TestMarkdownDirExtractor`.
