### PR TITLE
sleep: protect permanent nodes from GC and dedup decay paths

### DIFF
--- a/core/sleep.py
+++ b/core/sleep.py
@@ -298,9 +298,12 @@ class SleepProtocol:
             WHERE parent_id = ? AND child_id = ?
         """, (keep_id, keep_id))
         
-        # Mark the duplicate as decayed instead of deleting
+        # Mark the duplicate as decayed instead of deleting.
+        # Skip if the loser was promoted to permanent — permanent nodes must
+        # never end up with decayed=1 (violates integrity check).
         cursor.execute("""
-            UPDATE thought_nodes SET decayed = 1 WHERE id = ?
+            UPDATE thought_nodes SET decayed = 1
+            WHERE id = ? AND (permanent IS NULL OR permanent = 0)
         """, (remove_id,))
         
         conn.commit()
@@ -511,13 +514,19 @@ class SleepProtocol:
             metric = metrics[node_id]
 
             cursor.execute(
-                "SELECT node_type, source_file, last_accessed FROM thought_nodes WHERE id = ?",
+                "SELECT node_type, source_file, last_accessed, permanent FROM thought_nodes WHERE id = ?",
                 (node_id,),
             )
             row = cursor.fetchone()
             if not row:
                 continue
-            node_type, source_file, last_accessed = row
+            node_type, source_file, last_accessed, is_permanent = row
+
+            # Permanent nodes are protected regardless of node_type.
+            # gc_protect_types only covers a hardcoded subset (seed, core_memory)
+            # and misses derived/fact/insight/etc. that sleep promoted to permanent.
+            if is_permanent:
+                continue
 
             # Protect configured types
             if node_type in gc_protect_types:

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -627,6 +627,42 @@ class TestGCConfigModes:
             assert row[0] == 1, f"Node {nid} should be decayed=1"
         conn.close()
 
+    def test_gc_protects_permanent_nodes_regardless_of_type(self, gc_db):
+        """Permanent nodes must never be GC'd, even when their node_type is
+        not in gc_protect_types. Regression test for the integrity_ok=False
+        bug where 127 derived/decision/fact/insight/observation/belief nodes
+        ended up with permanent=1 AND decayed=1 because gc_protect_types
+        only covered ['seed', 'core_memory']."""
+        # Promote one of the 'derived' GC candidates to permanent.
+        conn = sqlite3.connect(gc_db)
+        c = conn.cursor()
+        c.execute("UPDATE thought_nodes SET permanent = 1 WHERE id = 'gc05'")
+        conn.commit()
+        conn.close()
+
+        protocol = SleepProtocol(gc_db, tempfile.mktemp(suffix=".json"))
+        metrics = self._make_metrics(gc_db, fitness=0.0)
+
+        with patch("core.sleep.config") as mock_cfg:
+            mock_cfg.gc_mode = "soft"
+            mock_cfg.gc_threshold = 10.0  # everything below threshold
+            mock_cfg.gc_grace_days = 0    # no grace
+            mock_cfg.gc_protect_types = ["seed", "core_memory"]  # NOT 'derived'
+            mock_cfg.gc_protect_hotspots = False
+            mock_cfg.gc_think_cycle_penalty = 1.0
+
+            with patch("random.sample", return_value=["gc05"]):
+                result = protocol.garbage_collect(metrics, k_nodes=1)
+
+        assert "gc05" not in result, "Permanent node was GC'd despite permanent=1"
+
+        # Integrity check: no row should ever have permanent=1 AND decayed=1.
+        conn = sqlite3.connect(gc_db)
+        c = conn.cursor()
+        c.execute("SELECT COUNT(*) FROM thought_nodes WHERE permanent>0 AND decayed>0")
+        assert c.fetchone()[0] == 0, "permanent_but_decayed integrity violation"
+        conn.close()
+
     def test_gc_hard_deletes_nodes(self, gc_db):
         """GC mode=hard should DELETE nodes and their edges/embeddings."""
         protocol = SleepProtocol(gc_db, tempfile.mktemp(suffix=".json"))


### PR DESCRIPTION
## Summary

Two write sites in `core/sleep.py` were stamping `decayed=1` without checking `permanent`, leaving the graph with rows in the impossible `permanent=1 AND decayed=1` state and `validate_permanence_integrity()` returning `integrity_ok=False` on every run.

## What was broken

**GC soft path (`garbage_collect`):** the SELECT pulled only `node_type, source_file, last_accessed`. Protection was via `gc_protect_types`, which defaults to `['seed', 'core_memory']`. Sleep promotes nodes of many types (`derived`, `fact`, `insight`, `decision`, `observation`, `belief`) to permanent based on access patterns; those got picked up by the random K-node sweep and decayed on fitness alone.

**Dedup path (`deduplicate_nodes`):** the merge-loser was unconditionally marked decayed. If sleep had promoted the loser to permanent, the integrity invariant broke immediately.

## Fixes

- `garbage_collect`: include `permanent` in the per-node SELECT, skip if `is_permanent` before any `node_type` check. Permanent now wins regardless of type.
- `deduplicate_nodes`: add a `permanent IS NULL OR permanent = 0` guard to the UPDATE clause.

## Existing rows

Rows already in the impossible state can be repaired with:

\`\`\`sql
UPDATE thought_nodes SET decayed = 0 WHERE permanent > 0 AND decayed > 0;
\`\`\`

## Test

Added `test_gc_protects_permanent_nodes_regardless_of_type`: promotes a `derived` node to permanent, runs GC with default protect_types (which excludes `derived`), asserts the node survives and the integrity check returns clean.

`pytest tests/test_sleep.py tests/test_permanence.py`: 40/40 passing.