### PR TITLE
sleep: LLM-backed dream synthesis with template fallback

### DIFF
--- a/core/sleep.py
+++ b/core/sleep.py
@@ -315,8 +315,15 @@ class SleepProtocol:
             "similarity": similarity
         })
     
-    def generate_dream_node(self, cross_links: List[CrossLinkCandidate]) -> Optional[str]:
-        """Generate dream nodes connecting separate thought chains"""
+    def generate_dream_node(self, cross_links: List[CrossLinkCandidate],
+                            model_fn=None) -> Optional[str]:
+        """Generate a dream node by synthesizing the strongest cross-source bridge.
+
+        With model_fn, the LLM is asked to surface the underlying pattern,
+        assumption, or risk that the two snippets jointly point at — the dream
+        is a synthesis, not a templated restatement. Without model_fn, falls
+        back to a stub template so the node still exists in the graph.
+        """
         if not cross_links:
             return None
         
@@ -357,8 +364,37 @@ class SleepProtocol:
         # Generate dream content
         content1, type1 = nodes[0]
         content2, type2 = nodes[1]
-        
-        dream_content = f"Connection discovered: '{content1[:50]}...' relates to '{content2[:50]}...'"
+
+        dream_content = None
+        if model_fn is not None:
+            prompt = (
+                "Two thought-snippets surfaced from the same body of work. They were "
+                "embedded close in vector space, suggesting they share something. Read "
+                "them and find what they JOINTLY point at: a shared assumption, a hidden "
+                "invariant, a recurring failure mode, a deeper principle, or a contradiction. "
+                "Output ONE statement, in plain prose, that captures the synthesis. "
+                "Be specific. Name the concrete thing they share. If they don't share "
+                "anything meaningful, output a one-line note about WHY the embedding "
+                "linked them anyway (lexical overlap, structural similarity, etc.).\n\n"
+                "Rules: no preamble, no headers, no markdown. Output only the synthesis "
+                "statement, on a single line.\n\n"
+                f"SNIPPET A ({type1}):\n{content1}\n\n"
+                f"SNIPPET B ({type2}):\n{content2}\n"
+            )
+            try:
+                response = model_fn(prompt)
+                if response:
+                    candidate = response.strip().splitlines()[0].strip()
+                    if len(candidate) > 20:
+                        dream_content = candidate
+            except Exception as e:
+                logging.warning(f"Dream LLM synthesis failed, falling back: {e}")
+
+        if not dream_content:
+            dream_content = (
+                f"Connection discovered: '{content1[:50]}...' relates to "
+                f"'{content2[:50]}...'"
+            )
         
         # Create dream node
         import hashlib
@@ -672,7 +708,7 @@ class SleepProtocol:
         # 2. Dream generation
         print("💭 Generating dream nodes...")
         cross_link_candidates = [c for c in candidates if c.action == "cross_link"]
-        dream_id = self.generate_dream_node(cross_link_candidates)
+        dream_id = self.generate_dream_node(cross_link_candidates, model_fn=model_fn)
         
         # 3. Calculate metrics
         print("📊 Calculating node metrics...")

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -362,6 +362,87 @@ class TestSleepProtocol:
             dream_events = [e for e in sleep_protocol.events if e.event_type == "dream"]
             assert len(dream_events) == 1
     
+    def test_generate_dream_node_uses_llm_when_model_fn_provided(self, sleep_protocol):
+        """When model_fn is passed, dream content should come from the LLM
+        synthesis, not from the templated 'Connection discovered' fallback."""
+        candidates = [
+            CrossLinkCandidate("isolated1", "seed1", 0.8, "cross_link"),
+            CrossLinkCandidate("isolated2", "different1", 0.75, "cross_link"),
+        ]
+
+        captured_prompts = []
+
+        def fake_model(prompt):
+            captured_prompts.append(prompt)
+            return "Both snippets share an unstated assumption that scheduling is synchronous."
+
+        dream_id = sleep_protocol.generate_dream_node(candidates, model_fn=fake_model)
+        assert dream_id is not None, "dream should be generated when bridge exists"
+
+        conn = sleep_protocol._get_connection()
+        c = conn.cursor()
+        c.execute("SELECT content FROM thought_nodes WHERE id = ?", (dream_id,))
+        content = c.fetchone()[0]
+        conn.close()
+
+        # LLM output landed, not the template fallback
+        assert "Connection discovered:" not in content
+        assert "unstated assumption" in content
+        # The prompt should have been built and sent
+        assert len(captured_prompts) == 1
+        assert "SNIPPET A" in captured_prompts[0]
+        assert "SNIPPET B" in captured_prompts[0]
+
+    def test_generate_dream_node_falls_back_to_template_on_llm_failure(self, sleep_protocol):
+        """If model_fn raises, the dream should still be created using the
+        templated fallback so the graph isn't left without a dream node."""
+        candidates = [
+            CrossLinkCandidate("isolated1", "seed1", 0.8, "cross_link"),
+            CrossLinkCandidate("isolated2", "different1", 0.75, "cross_link"),
+        ]
+
+        def broken_model(prompt):
+            raise RuntimeError("LLM unavailable")
+
+        dream_id = sleep_protocol.generate_dream_node(candidates, model_fn=broken_model)
+        assert dream_id is not None
+
+        conn = sleep_protocol._get_connection()
+        c = conn.cursor()
+        c.execute("SELECT content FROM thought_nodes WHERE id = ?", (dream_id,))
+        content = c.fetchone()[0]
+        conn.close()
+
+        assert content.startswith("Connection discovered:"), (
+            "LLM failure must fall back to templated dream, not drop the dream"
+        )
+
+    def test_run_sleep_cycle_threads_model_fn_into_dream_generation(self, sleep_protocol):
+        """run_sleep_cycle(model_fn=...) must thread the model into dream synthesis.
+        Regression for the bug where main's run_sleep_cycle accepted model_fn but
+        called generate_dream_node without passing it through, leaving dreams
+        permanently templated even when the LLM was wired up."""
+        called_with = []
+
+        def fake_model(prompt):
+            called_with.append(prompt)
+            return "Synthesized: both anchor on the same hidden invariant about ordering."
+
+        sleep_protocol.run_sleep_cycle(model_fn=fake_model)
+
+        # If a dream was generated this cycle, the model must have been invoked.
+        # If no dream, the test still passes (no cross-link bridge available);
+        # what we're guarding against is "dream generated but model bypassed".
+        conn = sleep_protocol._get_connection()
+        c = conn.cursor()
+        c.execute("SELECT content FROM thought_nodes WHERE node_type='dream'")
+        dreams = [r[0] for r in c.fetchall()]
+        conn.close()
+        if dreams:
+            assert any("Synthesized:" in d for d in dreams), (
+                "run_sleep_cycle generated a dream but bypassed the supplied model_fn"
+            )
+
     @patch('random.sample')
     def test_garbage_collect_uses_random_sampling(self, mock_sample, sleep_protocol):
         """Test that GC uses random sampling"""


### PR DESCRIPTION
## Summary

\`generate_dream_node\` was a hardcoded f-string that produced shallow dream nodes restating the obvious (\"Connection discovered: 'X...' relates to 'Y...'\") instead of synthesizing what the bridge between two cross-linked snippets actually meant. This PR adds an LLM-backed synthesis path with a templated fallback, and threads \`model_fn\` through \`run_sleep_cycle\` so the LLM is actually used when the caller wires one up.

## What changed

**\`generate_dream_node\`** now takes an optional \`model_fn\`. When provided, the LLM is prompted to surface the underlying pattern, assumption, invariant, failure mode, principle, or contradiction the two snippets jointly point at. If \`model_fn\` is \`None\` or raises, falls back to the original templated string so the dream node still exists either way.

**\`run_sleep_cycle\`** now passes its \`model_fn\` argument to \`generate_dream_node\`. Previously it accepted \`model_fn\` but didn't forward it, leaving dreams permanently templated even when the caller (e.g. \`scripts/cashew_context.py\`) wired up an LLM.

## Tests

- \`test_generate_dream_node_uses_llm_when_model_fn_provided\` — asserts the LLM output lands in the dream node, not the template.
- \`test_generate_dream_node_falls_back_to_template_on_llm_failure\` — asserts a raising \`model_fn\` doesn't drop the dream, just degrades to template.
- \`test_run_sleep_cycle_threads_model_fn_into_dream_generation\` — regression test for the missing forward-pass.

\`pytest tests/test_sleep.py tests/test_permanence.py\`: 43/43 passing.

## Notes

The synthesis prompt explicitly asks the LLM to call out lexical/structural similarity when the cross-link is a near-duplicate rather than two genuinely distinct ideas. In practice this surfaces a separate upstream issue (cross-link selection sometimes feeds dream synthesis near-restatements that should have been caught by dedup). That's tractable but out of scope here.