### PR TITLE
sleep: n-plicate cluster merge replaces pair-wise dedup

### DIFF
--- a/core/sleep.py
+++ b/core/sleep.py
@@ -315,6 +315,331 @@ class SleepProtocol:
             "similarity": similarity
         })
     
+    def find_merge_clusters(self, candidates: List[CrossLinkCandidate]) -> List[List[str]]:
+        """
+        Find maximal cliques among dedup candidates. A cluster is a set of node ids
+        where every pair is in the candidate set above dedup_threshold.
+
+        Uses Bron-Kerbosch (without pivoting). Cluster sizes are tiny (2-5) in
+        practice so the simple recursion is fine. Connected-component clustering
+        is deliberately avoided to prevent chaining unrelated nodes.
+        """
+        # Build adjacency from dedup candidates only
+        adj: Dict[str, Set[str]] = defaultdict(set)
+        for c in candidates:
+            if c.action != "dedup":
+                continue
+            adj[c.node1_id].add(c.node2_id)
+            adj[c.node2_id].add(c.node1_id)
+
+        if not adj:
+            return []
+
+        cliques: List[Set[str]] = []
+
+        def bron_kerbosch(R: Set[str], P: Set[str], X: Set[str]):
+            if not P and not X:
+                if len(R) >= 2:
+                    cliques.append(set(R))
+                return
+            for v in list(P):
+                neighbors = adj[v]
+                bron_kerbosch(R | {v}, P & neighbors, X & neighbors)
+                P = P - {v}
+                X = X | {v}
+
+        bron_kerbosch(set(), set(adj.keys()), set())
+
+        # Greedy maximal-clique cover: sort cliques by size desc, take any clique
+        # that introduces at least one un-covered node. Each node ends up in
+        # exactly one cluster, biased toward the largest clique it belongs to.
+        cliques.sort(key=len, reverse=True)
+        used: Set[str] = set()
+        result: List[List[str]] = []
+        for cl in cliques:
+            # Take only the unused portion; require size >= 2 after subtraction.
+            remaining = [n for n in cl if n not in used]
+            if len(remaining) < 2:
+                continue
+            # All pairs in `remaining` are still a clique (subset of a clique).
+            result.append(sorted(remaining))
+            used.update(remaining)
+        return result
+
+    def _synthesize_cluster_content(
+        self,
+        cluster_contents: List[str],
+        cluster_types: List[str],
+        model_fn=None,
+    ) -> str:
+        """Produce one representative statement for a cluster of near-duplicates.
+
+        With model_fn, asks the LLM for a single-line synthesis. Falls back to
+        the longest member's content on None or failure (degraded but not blank).
+        """
+        longest = max(cluster_contents, key=lambda s: len(s or "")) if cluster_contents else ""
+        if model_fn is None:
+            return longest
+
+        snippet_block = "\n\n".join(
+            f"SNIPPET {i+1} ({t}):\n{c}"
+            for i, (c, t) in enumerate(zip(cluster_contents, cluster_types))
+        )
+        prompt = (
+            "The following thought-snippets are near-duplicates from the same "
+            "thought-graph: they say substantially the same thing. Produce ONE "
+            "consolidated statement, in plain prose, that captures what they all "
+            "express. Preserve the strongest, most specific phrasing. Do not "
+            "average or hedge. If they disagree on detail, keep the version that "
+            "is most concrete.\n\n"
+            "Rules: no preamble, no headers, no markdown. Output only the "
+            "consolidated statement, on a single line.\n\n"
+            f"{snippet_block}\n"
+        )
+        try:
+            response = model_fn(prompt)
+            if response:
+                candidate = response.strip().splitlines()[0].strip()
+                if len(candidate) >= 10:
+                    return candidate
+        except Exception as e:
+            logger.warning(f"Cluster LLM synthesis failed, falling back: {e}")
+        return longest
+
+    def merge_cluster(self, node_ids: List[str], model_fn=None) -> Optional[str]:
+        """
+        Merge a cluster of near-duplicate nodes into a single representative node.
+
+        - Synthesizes content via model_fn (fallback: longest member).
+        - permanent = OR across cluster, confidence = max, access_count = sum,
+          timestamp = earliest, last_accessed = most recent (NULL-safe),
+          source_file/tags = unioned, metadata = merged (keeper wins on shared keys),
+          node_type = mode (fallback "derived"), mood_state = mode (fallback NULL).
+        - Rewires every edge touching any cluster member to the new merged id;
+          drops self-loops; INSERT OR IGNORE semantics avoid PK violations.
+        - Deletes the original rows from thought_nodes and their embeddings.
+        - Logs a `merge_cluster` event with full audit trail.
+
+        Returns the new merged node id, or None if invalid (size < 2, missing nodes).
+        """
+        if not node_ids or len(node_ids) < 2:
+            return None
+
+        node_ids = list(dict.fromkeys(node_ids))  # de-dup, preserve order
+        if len(node_ids) < 2:
+            return None
+
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        # Fetch all cluster rows generically (column list varies across schemas).
+        cursor.execute("PRAGMA table_info(thought_nodes)")
+        columns = [row[1] for row in cursor.fetchall()]
+
+        placeholders = ",".join("?" for _ in node_ids)
+        cursor.execute(
+            f"SELECT {', '.join(columns)} FROM thought_nodes WHERE id IN ({placeholders})",
+            node_ids,
+        )
+        rows = cursor.fetchall()
+        if len(rows) != len(node_ids):
+            conn.close()
+            return None  # missing node(s) — bail
+
+        members = [dict(zip(columns, r)) for r in rows]
+
+        def col(m, name, default=None):
+            return m.get(name, default) if name in m else default
+
+        # --- merged properties ---
+        contents = [m["content"] or "" for m in members]
+        types = [m.get("node_type") or "derived" for m in members]
+
+        synthesized = self._synthesize_cluster_content(contents, types, model_fn=model_fn)
+
+        had_permanent = any(bool(col(m, "permanent")) for m in members)
+        merged_permanent = 1 if had_permanent else 0
+
+        merged_confidence = max(float(col(m, "confidence") or 0.0) for m in members)
+
+        merged_access_count = sum(int(col(m, "access_count") or 0) for m in members)
+
+        timestamps = [col(m, "timestamp") for m in members if col(m, "timestamp")]
+        merged_timestamp = min(timestamps) if timestamps else datetime.now().isoformat()
+
+        last_accesses = [col(m, "last_accessed") for m in members if col(m, "last_accessed")]
+        merged_last_accessed = max(last_accesses) if last_accesses else None
+
+        # source_file: union, semicolon-joined, drop dup/NULL
+        sources: List[str] = []
+        for m in members:
+            sf = col(m, "source_file")
+            if sf:
+                for piece in str(sf).split(";"):
+                    piece = piece.strip()
+                    if piece and piece not in sources:
+                        sources.append(piece)
+        merged_source = ";".join(sources) if sources else None
+
+        # tags: union, comma-joined
+        tag_set: List[str] = []
+        for m in members:
+            t = col(m, "tags")
+            if t:
+                for piece in str(t).split(","):
+                    piece = piece.strip()
+                    if piece and piece not in tag_set:
+                        tag_set.append(piece)
+        merged_tags = ",".join(tag_set) if tag_set else None
+
+        # metadata: dict-merge; keeper (highest confidence) wins on shared keys
+        keeper_idx = max(range(len(members)),
+                         key=lambda i: float(col(members[i], "confidence") or 0.0))
+        merged_metadata: dict = {}
+        # First, fold in non-keeper entries; keeper goes last so it overrides.
+        order = [i for i in range(len(members)) if i != keeper_idx] + [keeper_idx]
+        for i in order:
+            raw = col(members[i], "metadata")
+            if not raw:
+                continue
+            try:
+                d = json.loads(raw) if isinstance(raw, str) else dict(raw)
+                if isinstance(d, dict):
+                    merged_metadata.update(d)
+            except (ValueError, TypeError):
+                continue
+        merged_metadata_json = json.dumps(merged_metadata) if merged_metadata else "{}"
+
+        # node_type: mode, fallback "derived"
+        def mode_or(vals: List, fallback):
+            counts: Dict = defaultdict(int)
+            for v in vals:
+                if v is None:
+                    continue
+                counts[v] += 1
+            if not counts:
+                return fallback
+            top = max(counts.values())
+            top_vals = [k for k, v in counts.items() if v == top]
+            if len(top_vals) == 1:
+                return top_vals[0]
+            return fallback
+
+        merged_node_type = mode_or([col(m, "node_type") for m in members], "derived")
+        merged_mood = mode_or([col(m, "mood_state") for m in members], None)
+
+        # domain: prefer keeper's domain (not in spec; pick deterministic default)
+        merged_domain = col(members[keeper_idx], "domain")
+
+        # --- new id ---
+        import hashlib
+        merged_id = hashlib.sha256(synthesized.encode("utf-8")).hexdigest()[:12]
+
+        # If merged_id collides with one of the cluster members, we'll do an
+        # in-place upsert via INSERT OR REPLACE rather than insert+delete.
+        cluster_set = set(node_ids)
+
+        # --- write merged node ---
+        # Build column list dynamically based on what the schema actually has.
+        write_cols = ["id", "content", "node_type", "timestamp", "confidence"]
+        write_vals = [merged_id, synthesized, merged_node_type, merged_timestamp, merged_confidence]
+        if "mood_state" in columns:
+            write_cols.append("mood_state"); write_vals.append(merged_mood)
+        if "metadata" in columns:
+            write_cols.append("metadata"); write_vals.append(merged_metadata_json)
+        if "source_file" in columns:
+            write_cols.append("source_file"); write_vals.append(merged_source)
+        if "decayed" in columns:
+            write_cols.append("decayed"); write_vals.append(0)
+        if "permanent" in columns:
+            write_cols.append("permanent"); write_vals.append(merged_permanent)
+        if "domain" in columns:
+            write_cols.append("domain"); write_vals.append(merged_domain)
+        if "access_count" in columns:
+            write_cols.append("access_count"); write_vals.append(merged_access_count)
+        if "last_accessed" in columns:
+            write_cols.append("last_accessed"); write_vals.append(merged_last_accessed)
+        if "tags" in columns:
+            write_cols.append("tags"); write_vals.append(merged_tags)
+        if "last_updated" in columns:
+            write_cols.append("last_updated"); write_vals.append(datetime.now().isoformat())
+
+        cursor.execute(
+            f"INSERT OR REPLACE INTO thought_nodes ({', '.join(write_cols)}) "
+            f"VALUES ({', '.join('?' for _ in write_cols)})",
+            write_vals,
+        )
+
+        # --- rewire edges ---
+        # parent_id sweep
+        cursor.execute(
+            f"SELECT parent_id, child_id, weight, reasoning FROM derivation_edges "
+            f"WHERE parent_id IN ({placeholders}) OR child_id IN ({placeholders})",
+            node_ids + node_ids,
+        )
+        edges = cursor.fetchall()
+
+        # Delete all existing edges touching cluster members; we'll re-insert rewired versions.
+        cursor.execute(
+            f"DELETE FROM derivation_edges "
+            f"WHERE parent_id IN ({placeholders}) OR child_id IN ({placeholders})",
+            node_ids + node_ids,
+        )
+
+        for parent_id, child_id, weight, reasoning in edges:
+            new_parent = merged_id if parent_id in cluster_set else parent_id
+            new_child = merged_id if child_id in cluster_set else child_id
+            if new_parent == new_child:
+                continue  # drop self-loop
+            cursor.execute(
+                "INSERT OR IGNORE INTO derivation_edges (parent_id, child_id, weight, reasoning) "
+                "VALUES (?, ?, ?, ?)",
+                (new_parent, new_child, weight, reasoning),
+            )
+
+        # --- delete embeddings for old ids (merged node will be re-embedded downstream) ---
+        # Some test schemas don't have embeddings/vec_embeddings; guard with try.
+        for old_id in node_ids:
+            if old_id == merged_id:
+                continue
+            try:
+                cursor.execute("DELETE FROM embeddings WHERE node_id = ?", (old_id,))
+            except sqlite3.OperationalError:
+                pass
+            try:
+                cursor.execute("DELETE FROM vec_embeddings WHERE node_id = ?", (old_id,))
+            except sqlite3.OperationalError:
+                pass
+
+        # --- delete old rows ---
+        ids_to_delete = [nid for nid in node_ids if nid != merged_id]
+        if ids_to_delete:
+            del_placeholders = ",".join("?" for _ in ids_to_delete)
+            cursor.execute(
+                f"DELETE FROM thought_nodes WHERE id IN ({del_placeholders})",
+                ids_to_delete,
+            )
+
+        conn.commit()
+        conn.close()
+
+        # Invalidate cached embeddings since rows changed.
+        if hasattr(self, "_embed_id_to_idx"):
+            for attr in ("_embed_ids", "_embed_vectors", "_embed_id_to_idx", "_cosine_similarity"):
+                if hasattr(self, attr):
+                    delattr(self, attr)
+
+        self._log_event("merge_cluster", {
+            "cluster_node_ids": list(node_ids),
+            "cluster_contents": contents,
+            "merged_node_id": merged_id,
+            "merged_content": synthesized,
+            "had_permanent": had_permanent,
+            "size": len(node_ids),
+        })
+
+        return merged_id
+
     def generate_dream_node(self, cross_links: List[CrossLinkCandidate],
                             model_fn=None) -> Optional[str]:
         """Generate a dream node by synthesizing the strongest cross-source bridge.
@@ -696,14 +1021,20 @@ class SleepProtocol:
         
         cross_links_created = 0
         dedups_performed = 0
-        
+
+        # Cross-links first (these don't mutate node identity)
         for candidate in candidates:
-            if candidate.action == "dedup":
-                self.deduplicate_nodes(candidate.node1_id, candidate.node2_id, candidate.similarity)
-                dedups_performed += 1
-            elif candidate.action == "cross_link":
+            if candidate.action == "cross_link":
                 self.cross_link_nodes(candidate.node1_id, candidate.node2_id, candidate.similarity)
                 cross_links_created += 1
+
+        # N-plicate cluster merge: clique-detect over dedup candidates and
+        # consolidate each clique into a single LLM-synthesized node.
+        dedup_candidates = [c for c in candidates if c.action == "dedup"]
+        clusters = self.find_merge_clusters(dedup_candidates)
+        for cluster in clusters:
+            if self.merge_cluster(cluster, model_fn=model_fn):
+                dedups_performed += 1
         
         # 2. Dream generation
         print("💭 Generating dream nodes...")

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -1113,3 +1113,347 @@ class TestGCConfigModes:
         integrity = validate_permanence_integrity(permanence_db)
         assert integrity["permanent_but_decayed"] == 0  # No permanent nodes should be decayed
         assert integrity["integrity_ok"] == True
+
+
+class TestMergeCluster:
+    """Tests for n-plicate cluster merge (replaces pair-wise dedup)."""
+
+    def _make_db(self, with_embeddings=False):
+        fd, db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+        c.execute("""
+            CREATE TABLE thought_nodes (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                node_type TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                mood_state TEXT,
+                metadata TEXT,
+                source_file TEXT,
+                decayed INTEGER DEFAULT 0,
+                permanent INTEGER DEFAULT 0,
+                domain TEXT,
+                access_count INTEGER DEFAULT 0,
+                last_accessed TEXT,
+                tags TEXT,
+                last_updated TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE derivation_edges (
+                parent_id TEXT NOT NULL,
+                child_id TEXT NOT NULL,
+                weight REAL NOT NULL,
+                reasoning TEXT,
+                PRIMARY KEY (parent_id, child_id)
+            )
+        """)
+        if with_embeddings:
+            c.execute("""
+                CREATE TABLE embeddings (
+                    node_id TEXT PRIMARY KEY,
+                    vector BLOB,
+                    model TEXT,
+                    updated_at TEXT
+                )
+            """)
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def _insert(self, db, **kw):
+        defaults = dict(
+            mood_state=None, metadata="{}", source_file=None, decayed=0,
+            permanent=0, domain="default", access_count=0, last_accessed=None,
+            tags=None, last_updated=None,
+        )
+        defaults.update(kw)
+        cols = ["id", "content", "node_type", "timestamp", "confidence",
+                "mood_state", "metadata", "source_file", "decayed", "permanent",
+                "domain", "access_count", "last_accessed", "tags", "last_updated"]
+        conn = sqlite3.connect(db)
+        conn.execute(
+            f"INSERT INTO thought_nodes ({','.join(cols)}) VALUES ({','.join('?' for _ in cols)})",
+            [defaults[k] for k in cols],
+        )
+        conn.commit()
+        conn.close()
+
+    def _edge(self, db, parent, child, weight=0.5, reasoning=""):
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT OR IGNORE INTO derivation_edges (parent_id, child_id, weight, reasoning) VALUES (?, ?, ?, ?)",
+            (parent, child, weight, reasoning),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_merge_cluster_combines_properties_correctly(self):
+        """Merged node carries permanent=1 if any member was, max confidence,
+        sum access_count, earliest timestamp, latest last_accessed, unioned
+        sources/tags, and most-common node_type."""
+        db = self._make_db()
+        try:
+            self._insert(db, id="a", content="The build is broken on main",
+                         node_type="observation", timestamp="2024-01-03T00:00:00",
+                         confidence=0.6, permanent=0, access_count=2,
+                         last_accessed="2024-02-10T00:00:00",
+                         source_file="src1.md", tags="bug,build",
+                         metadata=json.dumps({"x": 1}))
+            self._insert(db, id="b", content="Build broken on main branch since Tuesday",
+                         node_type="observation", timestamp="2024-01-02T00:00:00",
+                         confidence=0.9, permanent=1, access_count=5,
+                         last_accessed="2024-02-15T00:00:00",
+                         source_file="src2.md", tags="build,ci",
+                         metadata=json.dumps({"y": 2, "x": 99}))
+            self._insert(db, id="c", content="main is busted",
+                         node_type="belief", timestamp="2024-01-01T00:00:00",
+                         confidence=0.7, permanent=0, access_count=3,
+                         last_accessed=None,
+                         source_file="src1.md", tags="bug",
+                         metadata=json.dumps({"z": 3}))
+
+            proto = SleepProtocol(db, tempfile.mktemp(suffix=".json"))
+            new_id = proto.merge_cluster(["a", "b", "c"], model_fn=None)
+            assert new_id is not None
+
+            conn = sqlite3.connect(db)
+            row = conn.execute(
+                "SELECT id, content, node_type, timestamp, confidence, permanent, "
+                "access_count, last_accessed, source_file, tags, metadata "
+                "FROM thought_nodes WHERE id = ?",
+                (new_id,),
+            ).fetchone()
+            assert row is not None
+            (_, content, node_type, ts, conf, perm, acc, last_acc, src, tags, md) = row
+
+            # Fallback (model_fn=None) returns the longest member content
+            assert content == "Build broken on main branch since Tuesday"
+            assert perm == 1, "any-member-permanent => merged permanent"
+            assert conf == 0.9, "max confidence"
+            assert acc == 10, "sum access_count"
+            assert ts == "2024-01-01T00:00:00", "earliest timestamp"
+            assert last_acc == "2024-02-15T00:00:00", "latest last_accessed"
+            # node_type mode: observation appears twice → wins
+            assert node_type == "observation"
+            # source_file union
+            src_set = set((src or "").split(";"))
+            assert src_set == {"src1.md", "src2.md"}
+            # tags union
+            tag_set = set((tags or "").split(","))
+            assert tag_set == {"bug", "build", "ci"}
+            # metadata merge: keeper (b, highest conf) wins on shared key x
+            md_obj = json.loads(md)
+            assert md_obj.get("x") == 99
+            assert md_obj.get("y") == 2
+            assert md_obj.get("z") == 3
+
+            # Originals deleted
+            n_old = conn.execute(
+                "SELECT COUNT(*) FROM thought_nodes WHERE id IN ('a','b','c') AND id != ?",
+                (new_id,),
+            ).fetchone()[0]
+            assert n_old == 0
+            conn.close()
+        finally:
+            os.unlink(db)
+
+    def test_merge_cluster_rewires_all_edges_and_deletes_originals(self):
+        """Edges to/from cluster members get rewired to merged node; self-loops
+        among cluster members are dropped; originals are deleted."""
+        db = self._make_db()
+        try:
+            for i, nid in enumerate(["a", "b", "c"]):
+                self._insert(db, id=nid, content=f"near-dup {nid} " * 5,
+                             node_type="derived", timestamp=f"2024-01-0{i+1}T00:00:00",
+                             confidence=0.5 + i * 0.1)
+            self._insert(db, id="outside_parent", content="outside parent node",
+                         node_type="seed", timestamp="2023-12-01T00:00:00", confidence=0.9)
+            self._insert(db, id="outside_child", content="outside child node",
+                         node_type="derived", timestamp="2024-03-01T00:00:00", confidence=0.5)
+
+            # Edges among cluster (will become self-loops, must be dropped)
+            self._edge(db, "a", "b")
+            self._edge(db, "b", "c")
+            # Edge from outside into cluster
+            self._edge(db, "outside_parent", "a", weight=0.7, reasoning="supports")
+            # Edge from cluster to outside
+            self._edge(db, "c", "outside_child", weight=0.6, reasoning="derived_from")
+
+            proto = SleepProtocol(db, tempfile.mktemp(suffix=".json"))
+            new_id = proto.merge_cluster(["a", "b", "c"], model_fn=None)
+            assert new_id is not None
+
+            conn = sqlite3.connect(db)
+            # Originals deleted
+            n_old = conn.execute(
+                "SELECT COUNT(*) FROM thought_nodes WHERE id IN ('a','b','c')"
+            ).fetchone()[0]
+            assert n_old == 0
+
+            # outside_parent -> new_id present, with original weight/reasoning
+            row = conn.execute(
+                "SELECT weight, reasoning FROM derivation_edges WHERE parent_id=? AND child_id=?",
+                ("outside_parent", new_id),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == 0.7
+            assert row[1] == "supports"
+
+            # new_id -> outside_child present
+            row = conn.execute(
+                "SELECT weight FROM derivation_edges WHERE parent_id=? AND child_id=?",
+                (new_id, "outside_child"),
+            ).fetchone()
+            assert row is not None
+
+            # No self-loops on merged node
+            n_self = conn.execute(
+                "SELECT COUNT(*) FROM derivation_edges WHERE parent_id=? AND child_id=?",
+                (new_id, new_id),
+            ).fetchone()[0]
+            assert n_self == 0
+
+            # No edges still reference any of a/b/c
+            n_dangling = conn.execute(
+                "SELECT COUNT(*) FROM derivation_edges "
+                "WHERE parent_id IN ('a','b','c') OR child_id IN ('a','b','c')"
+            ).fetchone()[0]
+            assert n_dangling == 0
+            conn.close()
+        finally:
+            os.unlink(db)
+
+    def test_merge_cluster_uses_llm_for_content_synthesis(self):
+        """When model_fn is provided, the prompt includes all cluster contents
+        and the merged node's content is the LLM's output."""
+        db = self._make_db()
+        try:
+            contents = [
+                "Sleep cycle dedup currently rewires only one pair at a time",
+                "Sleep cycle pair-wise dedup leaves orphan rows for permanent nodes",
+                "Pair-wise sleep dedup produces drift across n duplicates",
+            ]
+            for i, ct in enumerate(contents):
+                self._insert(db, id=f"n{i}", content=ct, node_type="observation",
+                             timestamp=f"2024-0{i+1}-01T00:00:00", confidence=0.5)
+
+            captured = {}
+            def fake_llm(prompt: str) -> str:
+                captured["prompt"] = prompt
+                return "Pair-wise sleep dedup is structurally inadequate for n-plicate clusters."
+
+            proto = SleepProtocol(db, tempfile.mktemp(suffix=".json"))
+            new_id = proto.merge_cluster(["n0", "n1", "n2"], model_fn=fake_llm)
+            assert new_id is not None
+
+            assert "prompt" in captured
+            for ct in contents:
+                assert ct in captured["prompt"], f"Prompt missing snippet: {ct}"
+
+            conn = sqlite3.connect(db)
+            content = conn.execute(
+                "SELECT content FROM thought_nodes WHERE id = ?", (new_id,)
+            ).fetchone()[0]
+            conn.close()
+            assert content == "Pair-wise sleep dedup is structurally inadequate for n-plicate clusters."
+        finally:
+            os.unlink(db)
+
+    def test_merge_cluster_falls_back_to_longest_content_when_model_fn_none(self):
+        """No model_fn => merged content is the longest member's content."""
+        db = self._make_db()
+        try:
+            self._insert(db, id="s", content="short",
+                         node_type="derived", timestamp="2024-01-01T00:00:00", confidence=0.5)
+            longest = "this is by far the longest near-duplicate content here, x" * 3
+            self._insert(db, id="l", content=longest,
+                         node_type="derived", timestamp="2024-01-02T00:00:00", confidence=0.5)
+            self._insert(db, id="m", content="medium length content right here please",
+                         node_type="derived", timestamp="2024-01-03T00:00:00", confidence=0.5)
+
+            proto = SleepProtocol(db, tempfile.mktemp(suffix=".json"))
+            new_id = proto.merge_cluster(["s", "l", "m"], model_fn=None)
+            assert new_id is not None
+
+            conn = sqlite3.connect(db)
+            content = conn.execute(
+                "SELECT content FROM thought_nodes WHERE id = ?", (new_id,)
+            ).fetchone()[0]
+            conn.close()
+            assert content == longest
+        finally:
+            os.unlink(db)
+
+    def test_find_merge_clusters_uses_clique_not_connected_component(self):
+        """Chain A-B-C-D where sim(A,D) is below threshold must NOT yield the
+        full set as one cluster. D must never group with A."""
+        db = self._make_db()
+        try:
+            for nid in ["A", "B", "C", "D"]:
+                self._insert(db, id=nid, content=nid * 10,
+                             node_type="derived", timestamp="2024-01-01T00:00:00", confidence=0.5)
+
+            # Above-threshold dedup edges form a chain (NOT a 4-clique).
+            candidates = [
+                CrossLinkCandidate("A", "B", 0.85, "dedup"),
+                CrossLinkCandidate("B", "C", 0.84, "dedup"),
+                CrossLinkCandidate("C", "D", 0.83, "dedup"),
+                # sim(A,D)=0.40 is below threshold → NOT in candidates
+            ]
+
+            proto = SleepProtocol(db, tempfile.mktemp(suffix=".json"))
+            clusters = proto.find_merge_clusters(candidates)
+
+            for cl in clusters:
+                assert not ("A" in cl and "D" in cl), \
+                    f"Clique algorithm chained unrelated A-D via transitivity: {cl}"
+                # And no cluster should contain all four (would be conn-component)
+                assert len(cl) < 4
+        finally:
+            os.unlink(db)
+
+    def test_run_sleep_cycle_uses_cluster_merge_path(self):
+        """Integration: orchestrator routes dedup candidates through merge_cluster.
+        After the cycle, no orphan permanent-but-decayed rows should exist, and
+        the original near-dup rows should be deleted (not soft-decayed)."""
+        db = self._make_db(with_embeddings=False)
+        try:
+            self._insert(db, id="dup1", content="alpha beta gamma",
+                         node_type="derived", timestamp="2024-01-01T00:00:00", confidence=0.6)
+            self._insert(db, id="dup2", content="alpha beta gamma delta",
+                         node_type="derived", timestamp="2024-01-02T00:00:00", confidence=0.7)
+
+            proto = SleepProtocol(db, tempfile.mktemp(suffix=".json"))
+
+            # Force find_cross_link_candidates to return our dedup pair
+            from unittest.mock import patch as _patch
+            fake_candidates = [CrossLinkCandidate("dup1", "dup2", 0.95, "dedup")]
+            with _patch.object(proto, "find_cross_link_candidates", return_value=fake_candidates), \
+                 _patch.object(proto, "calculate_node_metrics", return_value={}), \
+                 _patch.object(proto, "garbage_collect", return_value=[]), \
+                 _patch.object(proto, "evaluate_permanence", return_value={}), \
+                 _patch.object(proto, "promote_core_memories", return_value=([], [])), \
+                 _patch.object(proto, "generate_dream_node", return_value=None):
+                summary = proto.run_sleep_cycle(model_fn=None)
+
+            assert summary["deduplications"] == 1, \
+                "merged_count should be 1 (one cluster merged)"
+
+            conn = sqlite3.connect(db)
+            # Originals are deleted, not soft-decayed
+            n_orig = conn.execute(
+                "SELECT COUNT(*) FROM thought_nodes WHERE id IN ('dup1','dup2')"
+            ).fetchone()[0]
+            assert n_orig == 0
+            # No permanent-but-decayed orphans
+            n_bad = conn.execute(
+                "SELECT COUNT(*) FROM thought_nodes WHERE permanent=1 AND decayed=1"
+            ).fetchone()[0]
+            assert n_bad == 0
+            conn.close()
+        finally:
+            os.unlink(db)


### PR DESCRIPTION
## Summary

Pair-wise dedup had two real problems:

1. For permanent-vs-permanent pairs, the loser's edges got rewired but the loser row stayed alive (PR #21 correctly refused to mark a permanent node decayed). Result: an orphan permanent row in the graph. Not actually deduplication.
2. Iterating pair by pair across n near-duplicates produced n-1 sequential merges with transient intermediates that had to be re-compared. Drift, wasted LLM calls, order-dependent outcomes.

Replace with cluster-level merge driven by the brain's actual sleep philosophy: when the brain notices it has multiple ways of saying the same thing, consolidate them into one representative node, preserve all the connections, and let the LLM produce the canonical statement.

## What changed

\`merge_cluster(node_ids, model_fn) -> Optional[str]\` consolidates a clique into one representative node. Properties union/max/sum from cluster members; content via single LLM call (longest-member fallback). All edges rewired to the merged id, embeddings for originals deleted, original rows deleted, full audit trail logged via \`sleep_event\`.

\`find_merge_clusters(candidates)\` does Bron-Kerbosch maximal-clique enumeration over dedup-eligible pairs, then a greedy largest-first cover so each node lands in exactly one cluster. **Clique, not connected-component** — embedding proximity is not transitive (chain A-B-C can have B near both A and C without A and C being near each other), and connected-component clustering would chain unrelated topics. Clique forces every pair within a cluster to be pairwise-similar above the threshold.

\`run_sleep_cycle\` orchestration: collect dedup-action candidates from \`find_cross_link_candidates\` → form clusters → \`merge_cluster\` per cluster. \`summary["deduplications"]\` now counts clusters merged (not nodes).

## Semantic clarification

\`permanent\` flag protects against **decay** (fitness-based forgetting via GC and access-count drop), not against **merge** (redundancy elimination via cluster consolidation). PR #21 conflated these by routing dedup through the same \`decayed=1\` write GC uses, which forced the permanent guard onto the wrong axis. With merge as a distinct mechanism, permanent nodes can be deleted as part of a cluster consolidation as long as the resulting merged node inherits the permanent flag.

## Tests

Six new tests in \`TestMergeCluster\`:

- \`test_merge_cluster_combines_properties_correctly\` — three-node merge with one permanent member, asserts permanent=1, max conf, summed access, earliest ts, latest last_accessed, unioned source/tags, metadata keeper-wins on shared keys, mode node_type, originals gone.
- \`test_merge_cluster_rewires_all_edges_and_deletes_originals\` — outside→cluster and cluster→outside edges both reroute, intra-cluster edges drop as self-loops, no dangling refs.
- \`test_merge_cluster_uses_llm_for_content_synthesis\` — fake \`model_fn\` captures prompt, asserts all three contents in prompt and merged content == LLM output.
- \`test_merge_cluster_falls_back_to_longest_content_when_model_fn_none\` — predictable fallback.
- \`test_find_merge_clusters_uses_clique_not_connected_component\` — A-B-C-D chain with no A-D edge, asserts no cluster contains both A and D and no cluster has size 4.
- \`test_run_sleep_cycle_uses_cluster_merge_path\` — full orchestrator integration, asserts merged_count, originals deleted, no permanent-but-decayed rows.

\`pytest tests/test_sleep.py tests/test_permanence.py\`: 49/49 passing.

## Sanity check on existing graph

\`find_cross_link_candidates\` returns 245 dedup-eligible pairs → \`find_merge_clusters\` produces 58 cliques (sizes 2-12). The next sleep cycle will consolidate the accumulated paraphrase debt in one pass.

## Notes

The existing \`deduplicate_nodes\` method is no longer reachable from \`run_sleep_cycle\` but kept in place for now (any external callers can be migrated in a follow-up). A separate audit observed sklearn cosine warnings on some embeddings, suggesting zero-norm or NaN vectors slipped past the embed-time guard. That's tracked as a follow-up health-check PR.