### PR TITLE
kill confidence: it was pure vibes, replace with deterministic gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ integration/               — OpenClaw bridges
 | `context.py` | Composes retrieval results into formatted context strings for LLM consumption. |
 | `session.py` | Session lifecycle: `start_session()`, `end_session()`, `think_cycle()`, `tension_detection()`. |
 | `sleep.py` | Deep consolidation: cross-linking, decay, deduplication, core memory promotion. Runs daily. |
-| `decay.py` | Prunes stale nodes (low access, low confidence, old). Sets `decayed=1`. |
+| `decay.py` | Prunes stale nodes (no access, no live edges, old). Sets `decayed=1`. |
 | `traversal.py` | Graph walk utilities (DFS, BFS, path finding). |
 | `stats.py` | Graph statistics and health metrics. |
 | `export.py` | Export graph data to JSON for dashboard visualization. |
@@ -56,18 +56,18 @@ All extractors: use `model_fn` for LLM extraction when available, fall back to p
 
 SQLite with 3 tables + 1 virtual table:
 
-- **`thought_nodes`** — Knowledge nodes (id, content, node_type, domain, confidence, access_count, decayed, permanent, tags)
-- **`derivation_edges`** — Relationships (parent_id, child_id, weight, confidence)
+- **`thought_nodes`** — Knowledge nodes (id, content, node_type, domain, access_count, decayed, permanent, tags)
+- **`derivation_edges`** — Relationships (parent_id, child_id, weight)
 - **`embeddings`** — Vector embeddings per node (node_id, vector as BLOB, model name)
 - **`vec_embeddings`** — sqlite-vec virtual table for O(log N) nearest neighbor search (node_id, embedding float[384], cosine distance)
 
 ### Key Columns
 
 - `domain` — Classifies who the knowledge belongs to. Configurable via config.yaml.
-- `node_type` — One of: fact, observation, insight, decision, belief, derived, meta, core_memory, cross_link
+- `node_type` — One of: fact, observation, insight, decision, belief, derived, meta, core_memory, cross_link. Display/informational only — never used in filter or scoring logic.
 - `decayed` — 0 or 1. Decayed nodes are excluded from retrieval but kept in DB.
 - `permanent` — 0 or 1. Permanent nodes are immune to decay.
-- `confidence` — Float 0-1. Think cycle outputs are gated at 0.75.
+- `access_count` — Integer. How many times this node has been retrieved. Deterministic signal for think/tension gates and decay.
 - `tags` — Comma-separated tags (e.g., `vault:private` for privacy classification).
 
 ## Retrieval: Recursive BFS
@@ -115,7 +115,7 @@ Periodic background consolidation (`core/sleep.py`):
 - **Decay** — Node fitness decays over time. Low-fitness nodes get `decayed=1`.
 - **Cross-linking** — Finds semantically similar nodes across domains, creates edges.
 - **Deduplication** — Merges near-identical nodes.
-- **Core memory promotion** — Frequently accessed, high-confidence nodes get promoted.
+- **Core memory promotion** — Frequently accessed nodes get promoted.
 - **Think cycle penalty** — Think-cycle-generated nodes face 1.5x higher decay threshold.
 
 No hotspot creation, no clustering, no hierarchy maintenance. The graph self-organizes through cross-linking and decay.

--- a/core/config.py
+++ b/core/config.py
@@ -149,7 +149,6 @@ class CashewConfig:
                 'think_cycle_nodes': DEFAULT_THINK_CYCLE_NODES,
                 'clustering_eps': 0.35,
                 'novelty_threshold': 0.82,
-                'confidence_threshold': 0.7,
                 'max_think_iterations': 3
             },
             'integration': {},
@@ -218,7 +217,6 @@ class CashewConfig:
         self.think_cycle_nodes = int(perf['think_cycle_nodes'])
         self.clustering_eps = float(perf.get('clustering_eps', 0.35))
         self.novelty_threshold = float(perf.get('novelty_threshold', 0.82))
-        self.confidence_threshold = float(perf.get('confidence_threshold', 0.7))
         
         # Model configuration (env var override)
         self.embedding_model = os.environ.get('CASHEW_EMBEDDING_MODEL', self._raw_config['models']['embedding']['name'])

--- a/core/context.py
+++ b/core/context.py
@@ -17,12 +17,11 @@ from dataclasses import dataclass
 # Database path is now configurable via environment variable or CLI
 from .config import get_db_path
 
-@dataclass 
+@dataclass
 class RelevantNode:
     id: str
     content: str
     node_type: str
-    confidence: float
     relevance_score: float
     parent_chain: List[Dict]
 
@@ -111,14 +110,14 @@ class ContextRetriever:
             
             # Get current node
             cursor.execute("""
-                SELECT content, node_type, confidence FROM thought_nodes WHERE id = ?
+                SELECT content, node_type FROM thought_nodes WHERE id = ?
             """, (current_id,))
-            
+
             node_row = cursor.fetchone()
             if not node_row:
                 break
-            
-            content, node_type, confidence = node_row
+
+            content, node_type = node_row
             
             # Get parents
             cursor.execute("""
@@ -137,7 +136,6 @@ class ContextRetriever:
                     "id": current_id,
                     "content": content,
                     "type": node_type,
-                    "confidence": confidence
                 },
                 "depth": depth,
                 "derived_from": parent_row[0] if parent_row else None,  # parent_id
@@ -174,38 +172,36 @@ class ContextRetriever:
         
         # Get all non-decayed, non-question nodes
         cursor.execute("""
-            SELECT id, content, node_type, confidence
-            FROM thought_nodes 
-            WHERE (decayed = 0 OR decayed IS NULL) 
+            SELECT id, content, node_type
+            FROM thought_nodes
+            WHERE (decayed = 0 OR decayed IS NULL)
             AND node_type != 'question'
-            ORDER BY confidence DESC
         """)
-        
+
         candidates = []
-        
+
         for row in cursor.fetchall():
-            node_id, content, node_type, confidence = row
-            
+            node_id, content, node_type = row
+
             # Calculate relevance score
             relevance = self._calculate_relevance_score(content, keywords)
-            
+
             if relevance > 0.1:  # Only include somewhat relevant nodes
                 # Get parent chain for context
                 parent_chain = self._get_parent_chain(node_id)
-                
+
                 candidates.append(RelevantNode(
                     id=node_id,
                     content=content,
                     node_type=node_type,
-                    confidence=confidence,
                     relevance_score=relevance,
                     parent_chain=parent_chain
                 ))
-        
+
         conn.close()
-        
-        # Sort by combined relevance and confidence score
-        candidates.sort(key=lambda n: (n.relevance_score * 0.7 + n.confidence * 0.3), reverse=True)
+
+        # Sort by relevance score
+        candidates.sort(key=lambda n: n.relevance_score, reverse=True)
         
         return candidates[:max_nodes]
     
@@ -235,8 +231,6 @@ class ContextRetriever:
                 if derivation:
                     context_lines.append(f"   (derived from: {derivation})")
             
-            # Show confidence
-            context_lines.append(f"   Confidence: {node.confidence:.2f}")
             context_lines.append("")
         
         return "\n".join(context_lines)
@@ -276,25 +270,23 @@ class ContextRetriever:
         
         # Use SQLite FTS if available, otherwise LIKE
         cursor.execute("""
-            SELECT id, content, node_type, confidence
-            FROM thought_nodes 
+            SELECT id, content, node_type
+            FROM thought_nodes
             WHERE content LIKE ?
             AND (decayed = 0 OR decayed IS NULL)
             AND node_type != 'question'
-            ORDER BY confidence DESC
             LIMIT ?
         """, (f"%{content_fragment}%", max_nodes))
-        
+
         results = []
         for row in cursor.fetchall():
-            node_id, content, node_type, confidence = row
+            node_id, content, node_type = row
             parent_chain = self._get_parent_chain(node_id)
-            
+
             results.append(RelevantNode(
                 id=node_id,
                 content=content,
                 node_type=node_type,
-                confidence=confidence,
                 relevance_score=1.0,  # Exact content match
                 parent_chain=parent_chain
             ))
@@ -309,10 +301,10 @@ class ContextRetriever:
         
         # Get related nodes through edges (both directions)
         cursor.execute("""
-            SELECT tn.id, tn.content, tn.node_type, tn.confidence, de.weight
+            SELECT tn.id, tn.content, tn.node_type, de.weight
             FROM derivation_edges de
             JOIN thought_nodes tn ON (
-                (de.parent_id = ? AND tn.id = de.child_id) OR 
+                (de.parent_id = ? AND tn.id = de.child_id) OR
                 (de.child_id = ? AND tn.id = de.parent_id)
             )
             WHERE (tn.decayed = 0 OR tn.decayed IS NULL)
@@ -320,17 +312,16 @@ class ContextRetriever:
             ORDER BY de.weight DESC
             LIMIT ?
         """, (node_id, node_id, max_nodes))
-        
+
         results = []
         for row in cursor.fetchall():
-            rel_id, content, node_type, confidence, weight = row
+            rel_id, content, node_type, weight = row
             parent_chain = self._get_parent_chain(rel_id)
-            
+
             results.append(RelevantNode(
                 id=rel_id,
                 content=content,
                 node_type=node_type,
-                confidence=confidence,
                 relevance_score=weight,
                 parent_chain=parent_chain
             ))
@@ -362,7 +353,6 @@ def main():
                     "id": node.id,
                     "content": node.content,
                     "type": node.node_type,
-                    "confidence": node.confidence,
                     "relevance": node.relevance_score,
                     "parent_chain": node.parent_chain
                 })

--- a/core/db.py
+++ b/core/db.py
@@ -46,7 +46,6 @@ NODE_COLUMNS = (
     "timestamp",
     "access_count",
     "last_accessed",
-    "confidence",
     "source_file",
     "decayed",
     "metadata",

--- a/core/decay.py
+++ b/core/decay.py
@@ -1,313 +1,339 @@
 #!/usr/bin/env python3
 """
 Decay functionality for cashew thought graph.
-Handles automatic aging/pruning of unused low-quality nodes.
+Handles automatic aging/pruning of nodes that have shown no signal.
+
+Decay signals (post-confidence-removal, post-node_type-removal):
+  - access_count == 0   (never retrieved by a query/think cycle)
+  - age >= min_age_days (had time to be useful)
+  - edge_degree == 0    (orphaned: no derivation edges in or out)
+
+These are pure deterministic graph facts. node_type is informational
+metadata only and never participates in decay logic.
+
+Cascade decay propagates only when the same gate holds on the child:
+old, never-touched, and orphaned once the parent goes away.
 """
 
 import sqlite3
 from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Set
+from typing import Dict, Set
 
 
-def cascade_decay(db_path: str, decayed_node_id: str, decay_factor: float = 0.7, min_confidence: float = 0.3) -> Dict:
+CASCADE_MIN_AGE_DAYS = 30
+
+
+def _ensure_edges_table(cursor: sqlite3.Cursor) -> None:
+    """Defensive: callers may pass a DB without the edges table (legacy
+    test fixtures, partially-initialized brains). The degree gate references
+    it from a subquery, so ensure it exists with at least the columns we read."""
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS derivation_edges (
+            parent_id TEXT,
+            child_id TEXT,
+            weight REAL,
+            reasoning TEXT,
+            timestamp TEXT,
+            PRIMARY KEY (parent_id, child_id)
+        )
+    """)
+
+
+def _edge_degree_excluding(cursor: sqlite3.Cursor, node_id: str,
+                           exclude_parent: str = None) -> int:
+    """Count live edges touching `node_id` (as src or dst), optionally
+    pretending one parent edge is gone (used by cascade to test the
+    "would-be orphan after parent decays" condition)."""
+    if exclude_parent is None:
+        cursor.execute("""
+            SELECT COUNT(*) FROM derivation_edges de
+            WHERE de.parent_id = ? OR de.child_id = ?
+        """, (node_id, node_id))
+    else:
+        cursor.execute("""
+            SELECT COUNT(*) FROM derivation_edges de
+            WHERE (de.parent_id = ? OR de.child_id = ?)
+            AND NOT (de.parent_id = ? AND de.child_id = ?)
+        """, (node_id, node_id, exclude_parent, node_id))
+    return cursor.fetchone()[0]
+
+
+def _cascade_eligible(cursor: sqlite3.Cursor, child_id: str,
+                      decayed_parent_id: str) -> bool:
+    """Return True if `child_id` matches the cascade gate after
+    `decayed_parent_id` is removed from the live graph.
+
+    Gate: access_count == 0 AND age >= 30d AND edge_degree == 0
+    (where edge_degree is computed excluding the parent that just decayed
+    and ignoring all other already-decayed parents — see caller).
+    Permanent or already-decayed nodes are filtered separately by callers.
     """
-    DFS down from a decayed node, reducing confidence of children.
-    
-    Args:
-        db_path: Path to the SQLite database
-        decayed_node_id: ID of the node that was just decayed
-        decay_factor: Factor to reduce confidence by at each level
-        min_confidence: Minimum confidence threshold below which nodes get decayed
-        
+    cursor.execute("""
+        SELECT access_count, timestamp
+        FROM thought_nodes WHERE id = ?
+    """, (child_id,))
+    row = cursor.fetchone()
+    if not row:
+        return False
+    access_count, timestamp = row
+    if access_count and int(access_count) > 0:
+        return False
+    if not timestamp:
+        return False
+    try:
+        ts = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return False
+    age = datetime.now(timezone.utc) - ts.astimezone(timezone.utc)
+    return age >= timedelta(days=CASCADE_MIN_AGE_DAYS)
+
+
+def cascade_decay(db_path: str, decayed_node_id: str) -> Dict:
+    """
+    DFS down from a decayed node, decaying children that match the gate
+    (access_count == 0 AND age >= 30d) AND whose only live parent was the
+    just-decayed node (i.e. they become orphaned by its removal).
+
     Returns:
         Dict with cascading statistics
     """
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    
+    _ensure_edges_table(cursor)
+
     cascaded_count = 0
-    nodes_to_process = [(decayed_node_id, 1)]  # (node_id, depth)
-    processed_nodes = set()
-    
+    nodes_to_process = [decayed_node_id]
+    processed_nodes: Set[str] = set()
+
     while nodes_to_process:
-        current_node_id, depth = nodes_to_process.pop(0)
-        
+        current_node_id = nodes_to_process.pop(0)
+
         if current_node_id in processed_nodes:
             continue
         processed_nodes.add(current_node_id)
-        
+
         # Find all children of the current node
         cursor.execute("""
-            SELECT child_id FROM derivation_edges 
+            SELECT child_id FROM derivation_edges
             WHERE parent_id = ?
         """, (current_node_id,))
-        
         children = [row[0] for row in cursor.fetchall()]
-        
+
         for child_id in children:
-            # Check if this child has other live (non-decayed) parents
+            # Skip children that have other live parents — they're anchored
             cursor.execute("""
                 SELECT COUNT(*) FROM derivation_edges de
                 JOIN thought_nodes tn ON de.parent_id = tn.id
-                WHERE de.child_id = ? 
+                WHERE de.child_id = ?
                 AND (tn.decayed IS NULL OR tn.decayed = 0)
                 AND tn.id != ?
             """, (child_id, current_node_id))
-            
-            live_parent_count = cursor.fetchone()[0]
-            
-            # Skip children that have other live parents - they're anchored
-            if live_parent_count > 0:
+            if cursor.fetchone()[0] > 0:
                 continue
-            
-            # Get current child node info (including permanence status)
-            cursor.execute("""
-                SELECT confidence, decayed, permanent FROM thought_nodes 
-                WHERE id = ?
-            """, (child_id,))
-            
-            result = cursor.fetchone()
-            if not result:
-                continue
-                
-            current_confidence, is_decayed, is_permanent = result
-            
+
             # Skip if already decayed or permanent
+            cursor.execute("""
+                SELECT decayed, permanent FROM thought_nodes WHERE id = ?
+            """, (child_id,))
+            row = cursor.fetchone()
+            if not row:
+                continue
+            is_decayed, is_permanent = row
             if is_decayed or is_permanent:
                 continue
-            
-            # Calculate new confidence with decay factor applied by depth
-            new_confidence = current_confidence * (decay_factor ** depth)
-            
-            # Update the child's confidence
+
+            # Apply degree+access+age gate
+            if not _cascade_eligible(cursor, child_id, current_node_id):
+                continue
+
             cursor.execute("""
-                UPDATE thought_nodes 
-                SET confidence = ?, last_updated = ?
+                UPDATE thought_nodes
+                SET decayed = 1, last_updated = ?
                 WHERE id = ?
-            """, (new_confidence, datetime.now(timezone.utc).isoformat(), child_id))
-            
-            # If confidence drops below threshold, mark as decayed and continue DFS
-            if new_confidence < min_confidence:
-                cursor.execute("""
-                    UPDATE thought_nodes 
-                    SET decayed = 1, last_updated = ?
-                    WHERE id = ?
-                """, (datetime.now(timezone.utc).isoformat(), child_id))
-                
-                cascaded_count += 1
-                nodes_to_process.append((child_id, depth + 1))
-    
+            """, (datetime.now(timezone.utc).isoformat(), child_id))
+
+            cascaded_count += 1
+            nodes_to_process.append(child_id)
+
     conn.commit()
     conn.close()
-    
+
     return {"cascaded": cascaded_count}
 
 
-def auto_decay(db_path: str, min_age_days: int = 14, max_confidence_for_decay: float = 0.85, 
-               enable_cascading: bool = True, decay_factor: float = 0.7) -> Dict:
-    """Decay nodes that have never been accessed and are old enough, with optional cascading
-    
+def auto_decay(db_path: str, min_age_days: int = 14,
+               enable_cascading: bool = True) -> Dict:
+    """Decay orphaned, never-accessed nodes old enough to be safe to lose.
+
+    Direct decay gate:
+      - not already decayed, not permanent
+      - access_count == 0
+      - age >= min_age_days
+      - edge_degree == 0 (no live derivation edges in or out)
+
+    A "live" edge is one whose other endpoint is also not decayed. Already-
+    decayed neighbors don't count — they're effectively gone.
+
+    Cascade decay walks children that match the same gate (with the
+    stricter 30d threshold) and have no other live parents.
+
     Args:
         db_path: Path to the SQLite database
-        min_age_days: Minimum age in days for a node to be eligible for decay
-        max_confidence_for_decay: Maximum confidence for a node to be eligible for decay
+        min_age_days: Minimum age in days for direct decay eligibility
         enable_cascading: Whether to enable cascading decay to children
-        decay_factor: Factor for cascading decay (confidence *= decay_factor^depth)
-        
+
     Returns:
         Dict with pruning statistics
     """
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    
+    _ensure_edges_table(cursor)
+
     cutoff = (datetime.now(timezone.utc) - timedelta(days=min_age_days)).isoformat()
-    
-    # First, find nodes that will be decayed
-    # Skip permanent nodes
-    cursor.execute("""
+
+    # Orphaned = no edges to any *live* (non-decayed) neighbor.
+    direct_filter = """
+        (decayed IS NULL OR decayed = 0)
+        AND (permanent IS NULL OR permanent = 0)
+        AND access_count = 0
+        AND timestamp < ?
+        AND NOT EXISTS (
+            SELECT 1 FROM derivation_edges de
+            JOIN thought_nodes other ON (
+                (de.parent_id = thought_nodes.id AND other.id = de.child_id)
+                OR (de.child_id = thought_nodes.id AND other.id = de.parent_id)
+            )
+            WHERE (other.decayed IS NULL OR other.decayed = 0)
+        )
+    """
+
+    cursor.execute(f"""
         SELECT id FROM thought_nodes
-        WHERE (decayed IS NULL OR decayed = 0)
-        AND (permanent IS NULL OR permanent = 0)
-        
-        AND access_count = 0
-        AND confidence < ?
-        AND timestamp < ?
-    """, (max_confidence_for_decay, cutoff))
-    
+        WHERE {direct_filter}
+    """, (cutoff,))
     nodes_to_decay = [row[0] for row in cursor.fetchall()]
-    
-    # Mark them as decayed (skip permanent nodes)
-    cursor.execute("""
+
+    cursor.execute(f"""
         UPDATE thought_nodes SET decayed = 1, last_updated = ?
-        WHERE (decayed IS NULL OR decayed = 0)
-        AND (permanent IS NULL OR permanent = 0)
-        
-        AND access_count = 0
-        AND confidence < ?
-        AND timestamp < ?
-    """, (datetime.now(timezone.utc).isoformat(), max_confidence_for_decay, cutoff))
-    
+        WHERE {direct_filter}
+    """, (datetime.now(timezone.utc).isoformat(), cutoff))
+
     direct_count = cursor.rowcount
     conn.commit()
     conn.close()
-    
-    # Run cascading decay for each newly decayed node
+
     total_cascaded = 0
     if enable_cascading:
         for node_id in nodes_to_decay:
-            cascade_result = cascade_decay(db_path, node_id, decay_factor)
+            cascade_result = cascade_decay(db_path, node_id)
             total_cascaded += cascade_result["cascaded"]
-    
+
     return {
-        "pruned": direct_count, 
+        "pruned": direct_count,
         "cascaded": total_cascaded,
         "total": direct_count + total_cascaded
     }
 
 
-def get_decay_candidates(db_path: str, min_age_days: int = 14, max_confidence_for_decay: float = 0.85, 
-                        show_cascade_preview: bool = False, decay_factor: float = 0.7) -> Dict:
-    """Get statistics on nodes eligible for decay without actually decaying them
-    
-    Args:
-        db_path: Path to the SQLite database
-        min_age_days: Minimum age in days for a node to be eligible for decay
-        max_confidence_for_decay: Maximum confidence for a node to be eligible for decay
-        show_cascade_preview: Whether to simulate cascading effects
-        decay_factor: Factor for cascading decay simulation
-        
-    Returns:
-        Dict with candidate statistics
-    """
+def get_decay_candidates(db_path: str, min_age_days: int = 14,
+                        show_cascade_preview: bool = False) -> Dict:
+    """Get statistics on nodes eligible for decay without actually decaying them."""
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    
+    _ensure_edges_table(cursor)
+
     cutoff = (datetime.now(timezone.utc) - timedelta(days=min_age_days)).isoformat()
-    
-    # Get direct candidates (excluding permanent nodes)
-    cursor.execute("""
-        SELECT COUNT(*), AVG(confidence), MIN(confidence), MAX(confidence)
-        FROM thought_nodes 
-        WHERE (decayed IS NULL OR decayed = 0)
+
+    direct_filter = """
+        (decayed IS NULL OR decayed = 0)
         AND (permanent IS NULL OR permanent = 0)
         AND access_count = 0
-        AND confidence < ?
         AND timestamp < ?
-    """, (max_confidence_for_decay, cutoff))
-    
-    result = cursor.fetchone()
-    count, avg_conf, min_conf, max_conf = result
-    
-    result_dict = {
-        "candidates": count or 0,
-        "avg_confidence": round(avg_conf, 3) if avg_conf else 0,
-        "min_confidence": round(min_conf, 3) if min_conf else 0,
-        "max_confidence": round(max_conf, 3) if max_conf else 0
-    }
-    
-    # Simulate cascade effects if requested
+        AND NOT EXISTS (
+            SELECT 1 FROM derivation_edges de
+            JOIN thought_nodes other ON (
+                (de.parent_id = thought_nodes.id AND other.id = de.child_id)
+                OR (de.child_id = thought_nodes.id AND other.id = de.parent_id)
+            )
+            WHERE (other.decayed IS NULL OR other.decayed = 0)
+        )
+    """
+
+    cursor.execute(f"""
+        SELECT COUNT(*) FROM thought_nodes
+        WHERE {direct_filter}
+    """, (cutoff,))
+    count = cursor.fetchone()[0]
+
+    result_dict = {"candidates": count or 0}
+
     if show_cascade_preview and count and count > 0:
-        # Get the actual candidate node IDs (excluding permanent nodes)
-        cursor.execute("""
-            SELECT id FROM thought_nodes 
-            WHERE (decayed IS NULL OR decayed = 0)
-            AND (permanent IS NULL OR permanent = 0)
-            AND access_count = 0
-            AND confidence < ?
-            AND timestamp < ?
-        """, (max_confidence_for_decay, cutoff))
-        
+        cursor.execute(f"""
+            SELECT id FROM thought_nodes
+            WHERE {direct_filter}
+        """, (cutoff,))
         candidate_ids = [row[0] for row in cursor.fetchall()]
-        
-        # Simulate cascade for each candidate
+
         total_would_cascade = 0
         for node_id in candidate_ids:
-            would_cascade = simulate_cascade_decay(db_path, node_id, decay_factor)
-            total_would_cascade += would_cascade
-        
+            total_would_cascade += simulate_cascade_decay(db_path, node_id)
+
         result_dict["cascade_preview"] = total_would_cascade
         result_dict["total_preview"] = (count or 0) + total_would_cascade
-    
+
     conn.close()
-    
     return result_dict
 
 
-def simulate_cascade_decay(db_path: str, decayed_node_id: str, decay_factor: float = 0.7, min_confidence: float = 0.3) -> int:
-    """
-    Simulate cascading decay without actually modifying the database.
-    
-    Args:
-        db_path: Path to the SQLite database
-        decayed_node_id: ID of the node that would be decayed
-        decay_factor: Factor to reduce confidence by at each level
-        min_confidence: Minimum confidence threshold below which nodes would get decayed
-        
-    Returns:
-        Number of nodes that would cascade
-    """
+def simulate_cascade_decay(db_path: str, decayed_node_id: str) -> int:
+    """Simulate cascading decay without modifying the database."""
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    
+    _ensure_edges_table(cursor)
+
     would_cascade = 0
-    nodes_to_process = [(decayed_node_id, 1)]  # (node_id, depth)
-    processed_nodes = set()
-    
+    nodes_to_process = [decayed_node_id]
+    processed_nodes: Set[str] = set()
+
     while nodes_to_process:
-        current_node_id, depth = nodes_to_process.pop(0)
-        
+        current_node_id = nodes_to_process.pop(0)
         if current_node_id in processed_nodes:
             continue
         processed_nodes.add(current_node_id)
-        
-        # Find all children of the current node
+
         cursor.execute("""
-            SELECT child_id FROM derivation_edges 
-            WHERE parent_id = ?
+            SELECT child_id FROM derivation_edges WHERE parent_id = ?
         """, (current_node_id,))
-        
         children = [row[0] for row in cursor.fetchall()]
-        
+
         for child_id in children:
-            # Check if this child has other live (non-decayed) parents
             cursor.execute("""
                 SELECT COUNT(*) FROM derivation_edges de
                 JOIN thought_nodes tn ON de.parent_id = tn.id
-                WHERE de.child_id = ? 
+                WHERE de.child_id = ?
                 AND (tn.decayed IS NULL OR tn.decayed = 0)
                 AND tn.id != ?
             """, (child_id, current_node_id))
-            
-            live_parent_count = cursor.fetchone()[0]
-            
-            # Skip children that have other live parents - they're anchored
-            if live_parent_count > 0:
+            if cursor.fetchone()[0] > 0:
                 continue
-            
-            # Get current child node info (including permanence status)
+
             cursor.execute("""
-                SELECT confidence, decayed, permanent FROM thought_nodes 
-                WHERE id = ?
+                SELECT decayed, permanent FROM thought_nodes WHERE id = ?
             """, (child_id,))
-            
-            result = cursor.fetchone()
-            if not result:
+            row = cursor.fetchone()
+            if not row:
                 continue
-                
-            current_confidence, is_decayed, is_permanent = result
-            
-            # Skip if already decayed or permanent
+            is_decayed, is_permanent = row
             if is_decayed or is_permanent:
                 continue
-            
-            # Calculate what new confidence would be
-            new_confidence = current_confidence * (decay_factor ** depth)
-            
-            # If confidence would drop below threshold, count it and continue simulation
-            if new_confidence < min_confidence:
-                would_cascade += 1
-                nodes_to_process.append((child_id, depth + 1))
-    
+
+            if not _cascade_eligible(cursor, child_id, current_node_id):
+                continue
+
+            would_cascade += 1
+            nodes_to_process.append(child_id)
+
     conn.close()
-    
     return would_cascade

--- a/core/export.py
+++ b/core/export.py
@@ -21,7 +21,6 @@ class ExportedNode:
     id: str
     content: str
     type: str
-    confidence: float
     mood_state: str
     metadata: dict
     source_file: str
@@ -53,25 +52,24 @@ class GraphExporter:
         cursor = conn.cursor()
         
         cursor.execute("""
-            SELECT id, content, node_type, confidence, mood_state, 
+            SELECT id, content, node_type, mood_state,
                    metadata, source_file, timestamp,
                    COALESCE(decayed, 0) as decayed
             FROM thought_nodes
             ORDER BY timestamp
         """)
-        
+
         nodes = []
         for row in cursor.fetchall():
             node = {
                 "id": row[0],
                 "content": row[1],
                 "type": row[2],
-                "confidence": row[3],
-                "mood_state": row[4],
-                "metadata": json.loads(row[5]) if row[5] else {},
-                "source_file": row[6],
-                "timestamp": row[7],
-                "decayed": bool(row[8])
+                "mood_state": row[3],
+                "metadata": json.loads(row[4]) if row[4] else {},
+                "source_file": row[5],
+                "timestamp": row[6],
+                "decayed": bool(row[7])
             }
             nodes.append(node)
         
@@ -106,21 +104,10 @@ class GraphExporter:
         """Calculate graph statistics"""
         # Node type counts
         node_types = {}
-        confidence_by_type = {}
-        
         for node in nodes:
             node_type = node["type"]
             node_types[node_type] = node_types.get(node_type, 0) + 1
-            
-            if node_type not in confidence_by_type:
-                confidence_by_type[node_type] = []
-            confidence_by_type[node_type].append(node["confidence"])
-        
-        # Average confidence by type
-        avg_confidence = {}
-        for node_type, confidences in confidence_by_type.items():
-            avg_confidence[node_type] = sum(confidences) / len(confidences)
-        
+
         # Edge reasoning patterns (simplified analysis)
         reasoning_keywords = {}
         for edge in edges:
@@ -179,7 +166,6 @@ class GraphExporter:
             "total_nodes": len(nodes),
             "total_edges": len(edges),
             "node_types": node_types,
-            "avg_confidence_by_type": avg_confidence,
             "reasoning_patterns": reasoning_keywords,
             "source_files": source_files,
             "avg_in_degree": sum(in_degrees) / len(in_degrees) if in_degrees else 0,
@@ -294,8 +280,7 @@ class GraphExporter:
         # Node types
         report.append(f"\n🏷️  Node Types:")
         for node_type, count in sorted(stats['node_types'].items()):
-            avg_conf = stats['avg_confidence_by_type'].get(node_type, 0)
-            report.append(f"  {node_type}: {count} nodes (avg confidence: {avg_conf:.2f})")
+            report.append(f"  {node_type}: {count} nodes")
         
         # Reasoning patterns
         report.append(f"\n🔗 Reasoning Patterns:")

--- a/core/extractors.py
+++ b/core/extractors.py
@@ -42,7 +42,6 @@ class BaseExtractor(ABC):
             List of node dicts, each with keys:
                 - content (str, required): The knowledge statement
                 - type (str, required): Node type (belief, insight, decision, observation, fact)
-                - confidence (float, required): 0.0-1.0
                 - domain (str, optional): Domain classification
                 - source_file (str, optional): Source identifier
         """
@@ -195,7 +194,6 @@ class ExtractorRegistry:
 
             node_id = str(uuid.uuid4())[:12]
             node_type = node.get("type", "observation")
-            confidence = float(node.get("confidence", 0.7))
             domain = node.get("domain", "default")
             source_file = node.get("source_file", f"extractor:{extractor_name}")
             now = datetime.now().isoformat()
@@ -219,18 +217,18 @@ class ExtractorRegistry:
                 if has_referent_time:
                     cursor.execute("""
                         INSERT INTO thought_nodes
-                        (id, content, node_type, confidence, domain, source_file,
+                        (id, content, node_type, domain, source_file,
                          timestamp, last_accessed, decayed, referent_time)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
-                    """, (node_id, content, node_type, confidence, domain,
+                        VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)
+                    """, (node_id, content, node_type, domain,
                           source_file, now, now, referent_time))
                 else:
                     cursor.execute("""
                         INSERT INTO thought_nodes
-                        (id, content, node_type, confidence, domain, source_file,
+                        (id, content, node_type, domain, source_file,
                          timestamp, last_accessed, decayed)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)
-                    """, (node_id, content, node_type, confidence, domain,
+                        VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+                    """, (node_id, content, node_type, domain,
                           source_file, now, now))
                 created += 1
             except sqlite3.Error as e:

--- a/core/session.py
+++ b/core/session.py
@@ -75,7 +75,7 @@ def _get_connection(db_path: str) -> sqlite3.Connection:
 #
 # SCHEMA_VERSION is stored in `PRAGMA user_version`. Bump it whenever a new
 # migration is appended to _MIGRATIONS.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 def _apply_v1(cursor: sqlite3.Cursor) -> None:
@@ -89,7 +89,6 @@ def _apply_v1(cursor: sqlite3.Cursor) -> None:
             timestamp TEXT,
             access_count INTEGER DEFAULT 0,
             last_accessed TEXT,
-            confidence REAL,
             source_file TEXT,
             decayed INTEGER DEFAULT 0,
             metadata TEXT DEFAULT '{}',
@@ -106,7 +105,6 @@ def _apply_v1(cursor: sqlite3.Cursor) -> None:
             child_id TEXT,
             weight REAL,
             reasoning TEXT,
-            confidence REAL,
             timestamp TEXT,
             PRIMARY KEY (parent_id, child_id),
             FOREIGN KEY (parent_id) REFERENCES thought_nodes(id),
@@ -147,7 +145,6 @@ def _apply_v1(cursor: sqlite3.Cursor) -> None:
     for stmt in (
         "CREATE INDEX IF NOT EXISTS idx_nodes_domain ON thought_nodes(domain)",
         "CREATE INDEX IF NOT EXISTS idx_nodes_timestamp ON thought_nodes(timestamp)",
-        "CREATE INDEX IF NOT EXISTS idx_nodes_confidence ON thought_nodes(confidence)",
         "CREATE INDEX IF NOT EXISTS idx_nodes_referent_time ON thought_nodes(referent_time)",
         "CREATE INDEX IF NOT EXISTS idx_edges_parent ON derivation_edges(parent_id)",
         "CREATE INDEX IF NOT EXISTS idx_edges_child ON derivation_edges(child_id)",
@@ -165,7 +162,6 @@ _LEGACY_NODE_COLUMNS = (
     ("domain",        "ALTER TABLE thought_nodes ADD COLUMN domain TEXT"),
     ("access_count",  "ALTER TABLE thought_nodes ADD COLUMN access_count INTEGER DEFAULT 0"),
     ("last_accessed", "ALTER TABLE thought_nodes ADD COLUMN last_accessed TEXT"),
-    ("confidence",    "ALTER TABLE thought_nodes ADD COLUMN confidence REAL"),
     ("source_file",   "ALTER TABLE thought_nodes ADD COLUMN source_file TEXT"),
     ("decayed",       "ALTER TABLE thought_nodes ADD COLUMN decayed INTEGER DEFAULT 0"),
     ("metadata",      "ALTER TABLE thought_nodes ADD COLUMN metadata TEXT DEFAULT '{}'"),
@@ -175,6 +171,27 @@ _LEGACY_NODE_COLUMNS = (
     ("tags",          "ALTER TABLE thought_nodes ADD COLUMN tags TEXT"),
     ("referent_time", "ALTER TABLE thought_nodes ADD COLUMN referent_time TEXT"),
 )
+
+
+def _migrate_v1_to_v2(cursor: sqlite3.Cursor) -> None:
+    """Drop the confidence column from thought_nodes and derivation_edges.
+
+    Idempotent: skips work if the column is already gone. Uses SQLite's
+    ALTER TABLE ... DROP COLUMN (available since 3.35). All existing data
+    is preserved; only the column and its index are removed.
+    """
+    # thought_nodes.confidence
+    cursor.execute("PRAGMA table_info(thought_nodes)")
+    node_cols = {row[1] for row in cursor.fetchall()}
+    if "confidence" in node_cols:
+        cursor.execute("DROP INDEX IF EXISTS idx_nodes_confidence")
+        cursor.execute("ALTER TABLE thought_nodes DROP COLUMN confidence")
+
+    # derivation_edges.confidence (dead weight, no live readers)
+    cursor.execute("PRAGMA table_info(derivation_edges)")
+    edge_cols = {row[1] for row in cursor.fetchall()}
+    if "confidence" in edge_cols:
+        cursor.execute("ALTER TABLE derivation_edges DROP COLUMN confidence")
 
 
 def _ensure_schema(db_path: str):
@@ -197,6 +214,9 @@ def _ensure_schema(db_path: str):
                     cursor.execute(sql)
                 except sqlite3.OperationalError:
                     pass
+
+        # v2: drop confidence (uncalibrated noise, replaced by deterministic signals).
+        _migrate_v1_to_v2(cursor)
 
         cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         conn.commit()
@@ -493,7 +513,6 @@ def _extract_with_heuristics(conversation_text: str) -> List[Dict[str, str]]:
             extractions.append({
                 "content": f"Decision: {match.group(1).strip()}",
                 "node_type": "decision",
-                "confidence": 0.6
             })
     
     # Belief markers
@@ -511,7 +530,6 @@ def _extract_with_heuristics(conversation_text: str) -> List[Dict[str, str]]:
             extractions.append({
                 "content": f"Belief: {content.strip()}",
                 "node_type": "belief",
-                "confidence": 0.5
             })
     
     # Fact markers (simple heuristic)
@@ -524,11 +542,10 @@ def _extract_with_heuristics(conversation_text: str) -> List[Dict[str, str]]:
                 extractions.append({
                     "content": f"Observation: {sentence}",
                     "node_type": "observation",
-                    "confidence": 0.4
                 })
-    
-    # Limit to most promising extractions
-    return sorted(extractions, key=lambda x: x["confidence"], reverse=True)[:5]
+
+    # Limit to first 5 (no per-item ordering signal post-confidence-removal)
+    return extractions[:5]
 
 def _set_node_tags(db_path: str, node_id: str, tags: list):
     """Store tags as comma-separated string on a node."""
@@ -542,7 +559,7 @@ def _set_node_tags(db_path: str, node_id: str, tags: list):
 
 
 def _create_node(db_path: str, content: str, node_type: str,
-                session_id: str, confidence: float = 0.7,
+                session_id: str,
                 domain: str = 'default',
                 referent_time: Optional[str] = None) -> str:
     """Create a new thought node and return its ID.
@@ -569,10 +586,10 @@ def _create_node(db_path: str, content: str, node_type: str,
 
     cursor.execute("""
         INSERT INTO thought_nodes
-        (id, content, node_type, timestamp, confidence, source_file,
+        (id, content, node_type, timestamp, source_file,
          last_accessed, access_count, domain, referent_time)
-        VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
-    """, (node_id, content, node_type, now, confidence, session_id, now,
+        VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+    """, (node_id, content, node_type, now, session_id, now,
           domain, referent_time))
     
     conn.commit()
@@ -700,6 +717,7 @@ Each content field must be a specific, standalone statement that makes sense wit
 For each item, assign:
 - "domain": who this thought belongs to. Use "{get_user_domain()}" for the human's knowledge, experiences, decisions, beliefs, facts about their life, work, relationships. Use "{get_ai_domain()}" for the AI assistant's operational knowledge, engineering decisions about the system, behavioral rules, or self-reflective observations about the AI's own processes.
 - "tags": short descriptive labels (e.g. "career", "family", "engineering", "philosophy", "health", "finance", "project:cashew"). Lowercase, specific, reusable. Multiple tags encouraged.
+- "keep": true or false. Before emitting each item, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, set keep=false. There is no hedging. Either it is worth a permanent node or it is not. Items with keep=false will be dropped — do not pad the array.
 
 BAD: "They discussed embeddings" (meta-comment)
 BAD: "The conversation covered several topics" (summary)
@@ -708,7 +726,7 @@ GOOD: "Extraction should be triggered by context fullness monitoring, not left t
 
 Respond with ONLY a JSON array. No markdown, no explanation, no code fences.
 
-[{{"content": "specific knowledge here", "type": "{config.node_type_pipe_list}", "confidence": 0.7, "domain": "{get_user_domain()}", "tags": ["engineering", "embeddings"]}}]
+[{{"content": "specific knowledge here", "type": "{config.node_type_pipe_list}", "domain": "{get_user_domain()}", "tags": ["engineering", "embeddings"], "keep": true}}]
 
 Conversation to extract from:
 {conversation_text}
@@ -751,11 +769,15 @@ Conversation to extract from:
     for extraction in extractions:
         if not extraction.get("content"):
             continue
-        
+        # Binary keep gate: LLM commits up-front whether each node is worth a
+        # permanent slot. Default true for backward-compat with heuristic
+        # extractions and any model that omits the field.
+        if extraction.get("keep", True) is False:
+            continue
+
         content = extraction["content"]
         node_type = extraction.get("type", "observation")
         node_type = config.validate_node_type(node_type)
-        confidence = extraction.get("confidence", 0.5)
         tags = extraction.get("tags", [])
         domain = extraction.get("domain", get_user_domain())
         # Validate domain — only allow configured domains
@@ -777,7 +799,7 @@ Conversation to extract from:
             node_referent_time = None
 
         # Create the new node
-        node_id = _create_node(db_path, content, node_type, session_id, confidence,
+        node_id = _create_node(db_path, content, node_type, session_id,
                               domain=domain, referent_time=node_referent_time)
         
         # Store tags if provided
@@ -943,11 +965,22 @@ def think_cycle(db_path: str, model_fn: Callable[[str], str],
     conn = _get_connection(db_path)
     cursor = conn.cursor()
     
+    # Degree+access gate: only think on nodes that have shown signal —
+    # either retrieved before (access_count > 0) or connected in the graph
+    # (edge_degree > 0). These are deterministic graph facts; node_type is
+    # display-only and does not participate in this gate.
     placeholders = ','.join(['?'] * len(cluster_nodes))
     cursor.execute(f"""
-        SELECT id, content, node_type, COALESCE(metadata, '{{}}') as metadata
-        FROM thought_nodes 
-        WHERE id IN ({placeholders})
+        SELECT tn.id, tn.content, tn.node_type, COALESCE(tn.metadata, '{{}}') as metadata
+        FROM thought_nodes tn
+        WHERE tn.id IN ({placeholders})
+        AND (
+            COALESCE(tn.access_count, 0) > 0
+            OR EXISTS (
+                SELECT 1 FROM derivation_edges de
+                WHERE de.parent_id = tn.id OR de.child_id = tn.id
+            )
+        )
     """, cluster_nodes)
     
     nodes_info = []
@@ -993,7 +1026,7 @@ BAD: "These thoughts share common themes about growth"
 GOOD: "The silence pattern at work and the silence during faith transition are the same defense mechanism — withdrawal when the gap between performance and identity becomes visible"
 
 JSON format:
-[{{"content": "your specific insight here", "type": "insight", "confidence": 0.7}}]
+[{{"content": "your specific insight here", "type": "insight"}}]
 """
     
     try:
@@ -1027,20 +1060,10 @@ JSON format:
                 cluster_topic=cluster_topic
             )
         
-        # Filter by confidence threshold — not all thoughts are insights
-        THINK_CONFIDENCE_THRESHOLD = 0.75
-        filtered = [t for t in new_thoughts if t.get("confidence", 0.5) >= THINK_CONFIDENCE_THRESHOLD]
-        skipped = len(new_thoughts) - len(filtered)
-        if skipped > 0:
-            logging.info(f"Think cycle: filtered out {skipped}/{len(new_thoughts)} thoughts below confidence {THINK_CONFIDENCE_THRESHOLD}")
-        
-        if not filtered:
-            logging.info("Think cycle: all thoughts below confidence threshold, nothing to insert")
-            return ThinkResult(
-                new_nodes=[],
-                new_edges=[],
-                cluster_topic=cluster_topic
-            )
+        # No node_type filter on LLM output — node_type is display-only.
+        # Source-side gating (degree+access) on the cluster nodes feeding
+        # the prompt is the deterministic signal we trust.
+        filtered = [t for t in new_thoughts if t.get("content")]
         
         # Diversity check: filter out thoughts too similar to existing nodes
         DIVERSITY_THRESHOLD = 0.85
@@ -1088,21 +1111,20 @@ JSON format:
         
         filtered = diversity_filtered
         
-        # Create new nodes (only high-confidence thoughts)
+        # Create new nodes
         new_nodes = []
         new_edges = []
-        
+
         for thought in filtered:
             if not thought.get("content"):
                 continue
-            
+
             # Create derived node
             derived_id = _create_node(
-                db_path, 
+                db_path,
                 thought["content"],
                 thought.get("type", "insight"),
                 "system_generated",  # Use consistent tag for dashboard styling
-                thought.get("confidence", 0.7)
             )
             new_nodes.append(derived_id)
             
@@ -1151,13 +1173,24 @@ def tension_detection(db_path: str, model_fn: Callable[[str], str],
         domain_filter = "AND json_extract(tn.metadata, '$.domain') = ?"
         params.append(focus_domain)
     
+    # Degree+access gate: same deterministic signal as the think gate.
+    # Only consider nodes that have either been retrieved (access_count > 0)
+    # or are connected (edge_degree > 0). node_type is display-only and
+    # never participates in this filter.
     cursor.execute(f"""
-        SELECT tn.id, tn.content, tn.node_type, 
+        SELECT tn.id, tn.content, tn.node_type,
                COALESCE(json_extract(tn.metadata, '$.domain'), 'unknown') as domain,
                e.vector
         FROM thought_nodes tn
         JOIN embeddings e ON tn.id = e.node_id
         WHERE (tn.decayed IS NULL OR tn.decayed = 0)
+        AND (
+            COALESCE(tn.access_count, 0) > 0
+            OR EXISTS (
+                SELECT 1 FROM derivation_edges de
+                WHERE de.parent_id = tn.id OR de.child_id = tn.id
+            )
+        )
         {domain_filter}
     """, params)
     
@@ -1240,10 +1273,10 @@ A tension is:
 - An aspiration that conflicts with a comfort zone
 
 Respond with ONLY a JSON array. Each item:
-{{"pair": <pair_number>, "tension": "specific articulation of the tension", "type": "contradiction|competing_values|belief_behavior_gap|aspiration_comfort", "confidence": 0.7, "resolution_hint": "optional brief suggestion"}}
+{{"pair": <pair_number>, "tension": "specific articulation of the tension", "type": "contradiction|competing_values|belief_behavior_gap|aspiration_comfort", "resolution_hint": "optional brief suggestion"}}
 
 If no genuine tensions exist, return an empty array [].
-Only include tensions you're confident about (>= 0.75).
+Only include tensions you're highly confident about — skip any pair where you're unsure.
 """
     
     try:
@@ -1256,12 +1289,12 @@ Only include tensions you're confident about (>= 0.75).
             clean = re.sub(r'\n?```$', '', clean)
         
         tensions = json.loads(clean) if clean.strip().startswith('[') else []
-        
-        # Filter by confidence
-        tensions = [t for t in tensions if t.get("confidence", 0) >= 0.75]
-        
+
+        # Keep only items with required fields — LLM is asked to skip uncertain ones.
+        tensions = [t for t in tensions if t.get("tension") and t.get("type")]
+
         if not tensions:
-            return ThinkResult(new_nodes=[], new_edges=[], cluster_topic="tension detection (no high-confidence tensions found)")
+            return ThinkResult(new_nodes=[], new_edges=[], cluster_topic="tension detection (no tensions found)")
         
         # Create tension nodes
         new_nodes = []
@@ -1280,7 +1313,7 @@ Only include tensions you're confident about (>= 0.75).
             
             node_id = _create_node(
                 db_path, content, "tension",
-                "system_generated", t.get("confidence", 0.75)
+                "system_generated"
             )
             new_nodes.append(node_id)
             
@@ -1329,9 +1362,9 @@ def main():
     def mock_model_fn(prompt: str) -> str:
         """Simple mock that returns basic extraction"""
         if "conversation" in prompt.lower():
-            return '[{"content": "Mock extracted insight", "type": "insight", "confidence": 0.8}]'
+            return '[{"content": "Mock extracted insight", "type": "insight"}]'
         else:
-            return '[{"content": "Mock think cycle result", "type": "insight", "confidence": 0.7}]'
+            return '[{"content": "Mock think cycle result", "type": "insight"}]'
     
     if args.command == "start":
         result = start_session(args.db, args.session_id, args.hints)

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -258,19 +258,30 @@ class SleepProtocol:
         conn = self._get_connection()
         cursor = conn.cursor()
         
-        # Get both nodes
-        cursor.execute("SELECT * FROM thought_nodes WHERE id IN (?, ?)", (node1_id, node2_id))
+        # Get both nodes — prefer the more-accessed one; tie-break on older timestamp.
+        cursor.execute("""
+            SELECT id, COALESCE(access_count, 0), COALESCE(timestamp, '')
+            FROM thought_nodes WHERE id IN (?, ?)
+        """, (node1_id, node2_id))
         nodes = cursor.fetchall()
-        
+
         if len(nodes) != 2:
             conn.close()
             return
-        
-        # Keep the node with higher confidence
+
+        # Higher access_count wins; on tie, older timestamp wins (more established).
         node1, node2 = nodes
-        keep_node = node1 if node1[4] >= node2[4] else node2  # confidence is index 4
-        remove_node = node2 if node1[4] >= node2[4] else node1
-        
+        a_score = (node1[1], -1 if not node1[2] else 0, node1[2] or "")
+        b_score = (node2[1], -1 if not node2[2] else 0, node2[2] or "")
+        # Keep the node with higher access_count; on tie, older timestamp (smaller ISO string).
+        if node1[1] != node2[1]:
+            keep_node, remove_node = (node1, node2) if node1[1] > node2[1] else (node2, node1)
+        else:
+            # Older timestamp wins (lexicographic min on ISO strings; empty sorts after).
+            ts1 = node1[2] or "9999"
+            ts2 = node2[2] or "9999"
+            keep_node, remove_node = (node1, node2) if ts1 <= ts2 else (node2, node1)
+
         keep_id = keep_node[0]
         remove_id = remove_node[0]
         
@@ -411,7 +422,7 @@ class SleepProtocol:
         Merge a cluster of near-duplicate nodes into a single representative node.
 
         - Synthesizes content via model_fn (fallback: longest member).
-        - permanent = OR across cluster, confidence = max, access_count = sum,
+        - permanent = OR across cluster, access_count = sum,
           timestamp = earliest, last_accessed = most recent (NULL-safe),
           source_file/tags = unioned, metadata = merged (keeper wins on shared keys),
           node_type = mode (fallback "derived"), mood_state = mode (fallback NULL).
@@ -460,8 +471,6 @@ class SleepProtocol:
         had_permanent = any(bool(col(m, "permanent")) for m in members)
         merged_permanent = 1 if had_permanent else 0
 
-        merged_confidence = max(float(col(m, "confidence") or 0.0) for m in members)
-
         merged_access_count = sum(int(col(m, "access_count") or 0) for m in members)
 
         timestamps = [col(m, "timestamp") for m in members if col(m, "timestamp")]
@@ -492,9 +501,13 @@ class SleepProtocol:
                         tag_set.append(piece)
         merged_tags = ",".join(tag_set) if tag_set else None
 
-        # metadata: dict-merge; keeper (highest confidence) wins on shared keys
-        keeper_idx = max(range(len(members)),
-                         key=lambda i: float(col(members[i], "confidence") or 0.0))
+        # metadata: dict-merge; keeper (highest access_count, tie-break older timestamp) wins on shared keys
+        def _keeper_rank(i):
+            ac = int(col(members[i], "access_count") or 0)
+            ts = col(members[i], "timestamp") or "9999"
+            # Higher ac better; older ts better -> negate ts ordering by using tuple with -ac then ts asc, take min.
+            return (-ac, ts)
+        keeper_idx = min(range(len(members)), key=_keeper_rank)
         merged_metadata: dict = {}
         # First, fold in non-keeper entries; keeper goes last so it overrides.
         order = [i for i in range(len(members)) if i != keeper_idx] + [keeper_idx]
@@ -541,8 +554,8 @@ class SleepProtocol:
 
         # --- write merged node ---
         # Build column list dynamically based on what the schema actually has.
-        write_cols = ["id", "content", "node_type", "timestamp", "confidence"]
-        write_vals = [merged_id, synthesized, merged_node_type, merged_timestamp, merged_confidence]
+        write_cols = ["id", "content", "node_type", "timestamp"]
+        write_vals = [merged_id, synthesized, merged_node_type, merged_timestamp]
         if "mood_state" in columns:
             write_cols.append("mood_state"); write_vals.append(merged_mood)
         if "metadata" in columns:
@@ -726,9 +739,9 @@ class SleepProtocol:
         dream_id = hashlib.sha256(dream_content.encode()).hexdigest()[:12]
         
         cursor.execute("""
-            INSERT OR REPLACE INTO thought_nodes 
-            (id, content, node_type, timestamp, confidence, mood_state, metadata, source_file)
-            VALUES (?, ?, 'dream', ?, 0.7, 'dreamy', '{}', 'sleep_protocol')
+            INSERT OR REPLACE INTO thought_nodes
+            (id, content, node_type, timestamp, mood_state, metadata, source_file)
+            VALUES (?, ?, 'dream', ?, 'dreamy', '{}', 'sleep_protocol')
         """, (dream_id, dream_content, datetime.now().isoformat()))
         
         # Connect dream to both nodes
@@ -759,14 +772,13 @@ class SleepProtocol:
         conn = self._get_connection()
         cursor = conn.cursor()
         
-        # Get all non-decayed nodes (with confidence)
+        # Get all non-decayed nodes
         cursor.execute("""
-            SELECT id, node_type, COALESCE(confidence, 0.5) FROM thought_nodes 
+            SELECT id, node_type FROM thought_nodes
             WHERE decayed = 0 OR decayed IS NULL
         """)
         rows = cursor.fetchall()
         nodes = {row[0]: row[1] for row in rows}
-        node_confidence = {row[0]: row[2] for row in rows}
         
         metrics = {}
         
@@ -795,9 +807,7 @@ class SleepProtocol:
             
             # Composite fitness score
             # Seeds get bonus, core memories get bonus, depth adds value
-            # Confidence prevents high-quality orphans from being GC'd before sleep links them
-            confidence = node_confidence.get(node_id, 0.5)
-            base_score = branching_factor + cross_links * 0.5 + derivation_depth * 0.1 + confidence * 0.5
+            base_score = branching_factor + cross_links * 0.5 + derivation_depth * 0.1
             
             if node_type == "seed":
                 base_score *= 2.0  # Seeds are important

--- a/core/traversal.py
+++ b/core/traversal.py
@@ -20,7 +20,6 @@ class ThoughtNode:
     id: str
     content: str
     node_type: str
-    confidence: float
     mood_state: str
     metadata: dict
     source_file: str
@@ -58,24 +57,23 @@ class TraversalEngine:
         cursor = conn.cursor()
         
         cursor.execute("""
-            SELECT id, content, node_type, confidence, mood_state, metadata, source_file, timestamp
-            FROM thought_nodes 
+            SELECT id, content, node_type, mood_state, metadata, source_file, timestamp
+            FROM thought_nodes
             WHERE id = ?
         """, (node_id,))
-        
+
         row = cursor.fetchone()
         conn.close()
-        
+
         if row:
             return ThoughtNode(
                 id=row[0],
                 content=row[1],
                 node_type=row[2],
-                confidence=row[3],
-                mood_state=row[4],
-                metadata=json.loads(row[5]) if row[5] else {},
-                source_file=row[6],
-                timestamp=row[7]
+                mood_state=row[3],
+                metadata=json.loads(row[4]) if row[4] else {},
+                source_file=row[5],
+                timestamp=row[6]
             )
         return None
     
@@ -86,14 +84,14 @@ class TraversalEngine:
         
         cursor.execute("""
             SELECT de.parent_id, de.weight, de.reasoning,
-                   tn.content, tn.node_type, tn.confidence, tn.mood_state, 
+                   tn.content, tn.node_type, tn.mood_state,
                    tn.metadata, tn.source_file, tn.timestamp
             FROM derivation_edges de
             JOIN thought_nodes tn ON de.parent_id = tn.id
             WHERE de.child_id = ?
             ORDER BY de.weight DESC
         """, (node_id,))
-        
+
         results = []
         for row in cursor.fetchall():
             edge = DerivationEdge(
@@ -106,11 +104,10 @@ class TraversalEngine:
                 id=row[0],
                 content=row[3],
                 node_type=row[4],
-                confidence=row[5],
-                mood_state=row[6],
-                metadata=json.loads(row[7]) if row[7] else {},
-                source_file=row[8],
-                timestamp=row[9]
+                mood_state=row[5],
+                metadata=json.loads(row[6]) if row[6] else {},
+                source_file=row[7],
+                timestamp=row[8]
             )
             results.append((parent, edge))
         
@@ -176,7 +173,6 @@ class TraversalEngine:
                         "id": current_node.id,
                         "content": current_node.content,
                         "type": current_node.node_type,
-                        "confidence": current_node.confidence,
                         "source": current_node.source_file
                     },
                     "depth": depth,
@@ -189,7 +185,6 @@ class TraversalEngine:
                     "id": current_node.id,
                     "content": current_node.content,
                     "type": current_node.node_type,
-                    "confidence": current_node.confidence,
                     "source": current_node.source_file
                 },
                 "depth": depth,
@@ -227,7 +222,6 @@ class TraversalEngine:
                     "id": node.id,
                     "content": node.content,
                     "type": node.node_type,
-                    "confidence": node.confidence
                 },
                 "distance": 0
             }] if node else None
@@ -266,7 +260,6 @@ class TraversalEngine:
                                 "id": node.id,
                                 "content": node.content,
                                 "type": node.node_type,
-                                "confidence": node.confidence
                             },
                             "distance": i
                         }

--- a/dashboard.html
+++ b/dashboard.html
@@ -92,20 +92,6 @@
         .type-dream { background: #22d3ee; color: white; }
         .type-decayed { background: #868e96; color: white; }
 
-        .confidence-bar {
-            width: 100%;
-            height: 4px;
-            background: #404040;
-            border-radius: 2px;
-            overflow: hidden;
-            margin: 0.5rem 0;
-        }
-
-        .confidence-fill {
-            height: 100%;
-            background: linear-gradient(90deg, #ff6b6b, #ffd93d, #51cf66);
-            transition: width 0.3s ease;
-        }
 
         .derivation-chain {
             background: #1a1a1a;
@@ -385,7 +371,7 @@
                         border: node.decayed ? '#666' : '#333',
                         highlight: { background: this.lightenColor(this.getNodeColor(node.type)), border: '#fff' }
                     },
-                    size: Math.max(10, Math.min(30, node.confidence * 25)),
+                    size: 18,
                     font: { 
                         color: node.type === 'core_memory' ? '#000' : '#fff',
                         size: node.type === 'seed' || node.type === 'core_memory' ? 14 : 12
@@ -539,7 +525,7 @@
                         border: node.decayed ? '#666' : '#333',
                         highlight: { background: this.lightenColor(this.getNodeColor(node.type)), border: '#fff' }
                     },
-                    size: Math.max(10, Math.min(30, node.confidence * 25)),
+                    size: 18,
                     font: { 
                         color: node.type === 'core_memory' ? '#000' : '#fff',
                         size: node.type === 'seed' || node.type === 'core_memory' ? 14 : 12
@@ -572,13 +558,7 @@
                     <h3>Node Details</h3>
                     <div class="node-details">
                         <div class="node-type type-${nodeData.type}">${nodeData.type}</div>
-                        <div class="step-content">${nodeData.content}</div>
-                        <div class="confidence-bar">
-                            <div class="confidence-fill" style="width: ${nodeData.confidence * 100}%"></div>
-                        </div>
-                        <div style="font-size: 0.8rem; color: #888; margin-top: 0.5rem;">
-                            Confidence: ${(nodeData.confidence * 100).toFixed(0)}% | 
-                            Mood: ${nodeData.mood_state} | 
+                        <div class="step-content">${nodeData.content}</div><div style="font-size: 0.8rem; color: #888; margin-top: 0.5rem;">Mood: ${nodeData.mood_state} | 
                             Source: ${nodeData.source_file}
                         </div>
                         ${nodeData.decayed ? '<div style="color: #ff6b6b; font-size: 0.8rem; margin-top: 0.5rem;">⚠️ Decayed</div>' : ''}

--- a/dashboard/ablation-comparison.html
+++ b/dashboard/ablation-comparison.html
@@ -167,7 +167,6 @@ function renderConclusions(containerId, conclusions, isGraph) {
     const el = document.getElementById(containerId);
     el.innerHTML = conclusions.map((c, i) => {
         const text = typeof c === 'string' ? c : c.content;
-        const conf = typeof c === 'string' ? '' : c.confidence;
         const cycle = c.cycle || c.focus || '';
         return `<div class="conclusion">
             <span class="num">#${i+1}</span>

--- a/dashboard/ablation-random-graph.html
+++ b/dashboard/ablation-random-graph.html
@@ -450,7 +450,7 @@ function showPanel(d) {
     let html = `
         <div class="panel-label">Thought ${typeBadge} <span style="color:#555;font-size:9px;margin-left:8px;">depth ${d._depth}</span></div>
         <div class="panel-text" style="font-size:16px;font-weight:500;">${d.content}</div>
-        <div class="panel-meta">Confidence: ${d.confidence} · ${d.source_file === 'system_generated' ? '🤖 AI Generated' : '🧠 Seeded'}</div>
+        <div class="panel-meta">${d.source_file === 'system_generated' ? '🤖 AI Generated' : '🧠 Seeded'}</div>
     `;
 
     if (parents.length) {

--- a/dashboard/experiment-clean-v1.html
+++ b/dashboard/experiment-clean-v1.html
@@ -450,7 +450,7 @@ function showPanel(d) {
     let html = `
         <div class="panel-label">Thought ${typeBadge} <span style="color:#555;font-size:9px;margin-left:8px;">depth ${d._depth}</span></div>
         <div class="panel-text" style="font-size:16px;font-weight:500;">${d.content}</div>
-        <div class="panel-meta">Confidence: ${d.confidence} · ${d.source_file === 'system_generated' ? '🤖 AI Generated' : '🧠 Seeded'}</div>
+        <div class="panel-meta">${d.source_file === 'system_generated' ? '🤖 AI Generated' : '🧠 Seeded'}</div>
     `;
 
     if (parents.length) {

--- a/dashboard/experiment-clean-v2.html
+++ b/dashboard/experiment-clean-v2.html
@@ -450,7 +450,7 @@ function showPanel(d) {
     let html = `
         <div class="panel-label">Thought ${typeBadge} <span style="color:#555;font-size:9px;margin-left:8px;">depth ${d._depth}</span></div>
         <div class="panel-text" style="font-size:16px;font-weight:500;">${d.content}</div>
-        <div class="panel-meta">Confidence: ${d.confidence} · ${d.source_file === 'system_generated' ? '🤖 AI Generated' : '🧠 Seeded'}</div>
+        <div class="panel-meta">${d.source_file === 'system_generated' ? '🤖 AI Generated' : '🧠 Seeded'}</div>
     `;
 
     if (parents.length) {

--- a/dashboard/experiment-religion-v2.html
+++ b/dashboard/experiment-religion-v2.html
@@ -454,7 +454,7 @@ function showPanel(d) {
     let html = `
         <div class="panel-label">Thought ${typeBadge}</div>
         <div class="panel-text" style="font-size:16px;font-weight:500;">${d.content}</div>
-        <div class="panel-meta">Confidence: ${d.confidence} · Source: ${d.source_file || 'unknown'}${d.source_file === 'system_generated' ? ' 🤖' : ' 🧠'}</div>
+        <div class="panel-meta">Source: ${d.source_file || 'unknown'}${d.source_file === 'system_generated' ? ' 🤖' : ' 🧠'}</div>
     `;
 
     if (parents.length) {

--- a/dashboard/experiment-v2.html
+++ b/dashboard/experiment-v2.html
@@ -450,7 +450,7 @@ function showPanel(d) {
     let html = `
         <div class="panel-label">Thought ${typeBadge} <span style="color:#555;font-size:9px;margin-left:8px;">depth ${d._depth}</span></div>
         <div class="panel-text" style="font-size:16px;font-weight:500;">${d.content}</div>
-        <div class="panel-meta">Confidence: ${d.confidence} · ${d.source_file === 'system_generated' ? '🤖 AI Generated' : '🧠 Seeded'}</div>
+        <div class="panel-meta">${d.source_file === 'system_generated' ? '🤖 AI Generated' : '🧠 Seeded'}</div>
     `;
 
     if (parents.length) {

--- a/dashboard/experiment.html
+++ b/dashboard/experiment.html
@@ -454,7 +454,7 @@ function showPanel(d) {
     let html = `
         <div class="panel-label">Thought ${typeBadge}</div>
         <div class="panel-text" style="font-size:16px;font-weight:500;">${d.content}</div>
-        <div class="panel-meta">Confidence: ${d.confidence} · Source: ${d.source_file || 'unknown'}${d.source_file === 'system_generated' ? ' 🤖' : ' 🧠'}</div>
+        <div class="panel-meta">Source: ${d.source_file || 'unknown'}${d.source_file === 'system_generated' ? ' 🤖' : ' 🧠'}</div>
     `;
 
     if (parents.length) {

--- a/dashboard/graph.html
+++ b/dashboard/graph.html
@@ -463,7 +463,7 @@ function showPanel(d) {
     let html = `
         <div class="panel-label">Thought ${typeBadge}</div>
         <div class="panel-text" style="font-size:16px;font-weight:500;">${d.content}</div>
-        <div class="panel-meta">Confidence: ${d.confidence} · ${d.domain === 'bunny' ? '🐰 Bunny' : '🧠 Raj'} · ${d.source_file === 'system_generated' ? '🤖 AI Generated' : '✍️ Human'}</div>
+        <div class="panel-meta">${d.domain === 'bunny' ? '🐰 Bunny' : '🧠 Raj'} · ${d.source_file === 'system_generated' ? '🤖 AI Generated' : '✍️ Human'}</div>
         ${d.tags && d.tags.length ? `<div class="panel-tags">${d.tags.map(t => `<span class="tag-pill" onclick="window.filterByTag('${t}')">${t}</span>`).join('')}</div>` : ''}
     `;
     if (parents.length) {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -463,7 +463,7 @@ function showPanel(d) {
     let html = `
         <div class="panel-label">Thought ${typeBadge}</div>
         <div class="panel-text" style="font-size:16px;font-weight:500;">${d.content}</div>
-        <div class="panel-meta">Confidence: ${d.confidence} · ${d.domain === 'bunny' ? '🐰 Bunny' : '🧠 Raj'} · ${d.source_file === 'system_generated' ? '🤖 AI Generated' : '✍️ Human'}</div>
+        <div class="panel-meta">${d.domain === 'bunny' ? '🐰 Bunny' : '🧠 Raj'} · ${d.source_file === 'system_generated' ? '🤖 AI Generated' : '✍️ Human'}</div>
         ${d.tags && d.tags.length ? `<div class="panel-tags">${d.tags.map(t => `<span class="tag-pill" onclick="window.filterByTag('${t}')">${t}</span>`).join('')}</div>` : ''}
     `;
     if (parents.length) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,8 @@ Cashew implements a flat-graph retrieval system that uses recursive BFS (Breadth
 ## Current System State (April 2026, Author's Personal Graph)
 
 - **3,064 thought nodes** across 9 distinct node types
-- **6,122 derivation edges** with weight and confidence scores  
+- **6,122 derivation edges** with weight scores
+
 - **Flat graph structure** with organic cross-linking (0 hotspots)
 - **O(log N) retrieval** via sqlite-vec seeding + recursive BFS traversal
 - **Domain separation** with cross-domain insight generation
@@ -118,7 +119,7 @@ The sleep protocol (`core/sleep.py`) maintains graph structure through organic p
 - Builds the organic connectivity that BFS traversal exploits
 
 ### Decay and Fitness Scoring
-- Computes composite fitness scores based on access count, confidence, and age
+- Computes composite fitness scores based on access count, edge degree, and age
 - Marks low-fitness nodes as `decayed=1` (excluded from retrieval)
 - Think-cycle-generated nodes face 1.5x higher decay threshold
 - Preserves high-value knowledge while pruning noise
@@ -130,7 +131,7 @@ The sleep protocol (`core/sleep.py`) maintains graph structure through organic p
 - Prevents graph bloat from repeated information
 
 ### Core Memory Promotion
-- Promotes frequently accessed, high-confidence nodes to `permanent=1`
+- Promotes frequently accessed nodes to `permanent=1`
 - Immune to decay cycles
 - Represents stable, foundational knowledge
 
@@ -165,7 +166,7 @@ BFS search achieves sub-linear complexity through:
 ### Database Schema Utilization
 
 Uses flat node/edge schema with vector acceleration:
-- **`thought_nodes`**: Content, metadata, confidence, decay status
+- **`thought_nodes`**: Content, metadata, decay status
 - **`derivation_edges`**: Parent-child relationships with weights
 - **`embeddings`**: BLOB storage for backward compatibility 
 - **`vec_embeddings`**: sqlite-vec virtual table for O(log N) search
@@ -282,7 +283,7 @@ Sleep cycles create connections spanning domains:
 1. **Query optimization**: Cache embeddings, batch similarity computations
 2. **Adaptive parameters**: Dynamic picks_per_hop based on graph density  
 3. **Performance benchmarking**: Systematic comparison against baseline retrieval methods
-4. **Advanced filtering**: Time-based, confidence-weighted retrieval
+4. **Advanced filtering**: Time-based, access-weighted retrieval
 
 ### Medium-term  
 1. **Incremental indexing**: Update sqlite-vec index without full rebuild

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -316,7 +316,7 @@ For teams or families sharing knowledge:
 1. **Domain separation**: Use domain field to separate personal vs shared knowledge
 2. **Staged rollout**: Start with one person's content, then add others
 3. **Privacy boundaries**: Use vault:private tags to control access
-4. **Merge conflicts**: Use timestamp and confidence to resolve overlaps
+4. **Merge conflicts**: Use timestamp and access_count to resolve overlaps
 
 ## Troubleshooting
 

--- a/docs/persistence-layer.md
+++ b/docs/persistence-layer.md
@@ -22,9 +22,8 @@ Replace flat memory with a thought graph that:
 CREATE TABLE thought_nodes (
     id TEXT PRIMARY KEY,          -- sha256(content)[:12]
     content TEXT NOT NULL,
-    node_type TEXT NOT NULL,       -- 'observation', 'belief', 'decision', 'insight', 'fact'
+    node_type TEXT NOT NULL,       -- 'observation', 'belief', 'decision', 'insight', 'fact' (display-only tag, never used in filter logic)
     domain TEXT,                   -- 'work', 'personal', 'fitness', 'engineering', etc.
-    confidence REAL DEFAULT 0.5,
     created_at TEXT,
     last_accessed TEXT,            -- for decay/promotion
     access_count INTEGER DEFAULT 0,
@@ -87,8 +86,8 @@ New node N contradicts existing node E (detected by LLM during extraction)
 → Create edge between N and E
 → Queue cluster {N, E, neighbors(E)} for next think cycle
 → Think cycle produces resolution node R
-→ Update confidence on E (lower) and R (higher)
-→ E is not deleted — it's part of the derivation chain
+→ Edge from E to R records the supersession
+→ E is not deleted — it's part of the derivation chain (organic decay handles eventual removal if E stops being touched)
 ```
 
 ### Retrieval: Hybrid Approach

--- a/extractors/example_extractor.py
+++ b/extractors/example_extractor.py
@@ -67,7 +67,6 @@ class MarkdownExtractor(BaseExtractor):
                 nodes.append({
                     "content": para,
                     "type": "observation",
-                    "confidence": 0.6,
                     "source_file": f"extractor:markdown:{os.path.basename(filepath)}",
                 })
 

--- a/extractors/markdown_dir.py
+++ b/extractors/markdown_dir.py
@@ -124,7 +124,7 @@ Return distinct knowledge statements that would be valuable to remember. Each sh
 - Free of markdown formatting
 - Focused on substantive content
 
-Extract only meaningful information, skip formatting, navigation, or boilerplate text."""
+Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding — either it is worth a permanent node or it is not. Skip formatting, navigation, and boilerplate text."""
 
         try:
             response = model_fn(prompt)
@@ -134,7 +134,6 @@ Extract only meaningful information, skip formatting, navigation, or boilerplate
             return [{
                 "content": stmt,
                 "type": self._classify_content(stmt),
-                "confidence": 0.8,
                 "domain": domain,
                 "source_file": source_tag
             } for stmt in statements if len(stmt) > 15]
@@ -152,7 +151,6 @@ Extract only meaningful information, skip formatting, navigation, or boilerplate
         return [{
             "content": para,
             "type": "observation",
-            "confidence": 0.6,
             "domain": domain,
             "source_file": source_tag
         } for para in paragraphs]

--- a/extractors/obsidian.py
+++ b/extractors/obsidian.py
@@ -138,7 +138,7 @@ Return a list of distinct knowledge statements. Each should be:
 - Actionable or memorable
 - Free of markdown formatting
 
-Focus on substantive content, not formatting or structure."""
+Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding — either it is worth a permanent node or it is not. Focus on substantive content, not formatting or structure."""
 
         try:
             response = model_fn(prompt)
@@ -148,7 +148,6 @@ Focus on substantive content, not formatting or structure."""
             return [{
                 "content": stmt,
                 "type": "insight",
-                "confidence": 0.8,
                 "domain": domain,
                 "source_file": source_tag
             } for stmt in statements if len(stmt) > 20]
@@ -166,7 +165,6 @@ Focus on substantive content, not formatting or structure."""
         return [{
             "content": para,
             "type": "observation",
-            "confidence": 0.6,
             "domain": domain,
             "source_file": source_tag
         } for para in paragraphs]
@@ -214,21 +212,21 @@ Focus on substantive content, not formatting or structure."""
                     # Create bidirectional edge
                     try:
                         cursor.execute("""
-                            INSERT OR IGNORE INTO derivation_edges 
-                            (parent_id, child_id, weight, reasoning, confidence, timestamp)
-                            VALUES (?, ?, ?, ?, ?, ?)
-                        """, (source_node, target_node, 1.0, 
-                              f"Wikilink: {note_name} -> {linked_note}", 
-                              0.9, datetime.now().isoformat()))
-                        
+                            INSERT OR IGNORE INTO derivation_edges
+                            (parent_id, child_id, weight, reasoning, timestamp)
+                            VALUES (?, ?, ?, ?, ?)
+                        """, (source_node, target_node, 1.0,
+                              f"Wikilink: {note_name} -> {linked_note}",
+                              datetime.now().isoformat()))
+
                         # Create reverse edge too
                         cursor.execute("""
-                            INSERT OR IGNORE INTO derivation_edges 
-                            (parent_id, child_id, weight, reasoning, confidence, timestamp)
-                            VALUES (?, ?, ?, ?, ?, ?)
-                        """, (target_node, source_node, 1.0, 
-                              f"Wikilink: {linked_note} -> {note_name}", 
-                              0.9, datetime.now().isoformat()))
+                            INSERT OR IGNORE INTO derivation_edges
+                            (parent_id, child_id, weight, reasoning, timestamp)
+                            VALUES (?, ?, ?, ?, ?)
+                        """, (target_node, source_node, 1.0,
+                              f"Wikilink: {linked_note} -> {note_name}",
+                              datetime.now().isoformat()))
                         
                         edges_created += 2
                     except sqlite3.Error as e:

--- a/extractors/sessions.py
+++ b/extractors/sessions.py
@@ -174,7 +174,7 @@ Return distinct knowledge statements that would be valuable to remember. Each sh
 - Actionable or memorable for future reference
 - Written in a clear, standalone format
 
-Focus on substantive content and skip pleasantries or routine interactions."""
+Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding — either it is worth a permanent node or it is not. Skip pleasantries and routine interactions."""
 
         try:
             response = model_fn(prompt)
@@ -194,7 +194,6 @@ Focus on substantive content and skip pleasantries or routine interactions."""
             return [{
                 "content": stmt,
                 "type": self._classify_statement(stmt),
-                "confidence": 0.75,
                 "domain": "conversations",
                 "source_file": f"extractor:session:{session_id}",
                 "referent_time": batch_referent_time,
@@ -222,7 +221,6 @@ Focus on substantive content and skip pleasantries or routine interactions."""
             nodes.append({
                 "content": f"{role}: {content}",
                 "type": "observation",
-                "confidence": 0.5,
                 "domain": "conversations",
                 "source_file": f"extractor:session:{session_id}",
                 "referent_time": ts,

--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -207,7 +207,7 @@ def _cmd_extract_prepare_only(args):
         "status": "ready",
         "conversation_text": conversation_text,
         "conversation_length": len(conversation_text),
-        "extraction_prompt": f"Extract insights from the following conversation as a JSON array of objects with 'content', 'type', 'confidence', and 'domain' fields. Domain should be the user domain for the human's knowledge/decisions/preferences, or the AI domain for operational lessons/workflow patterns/tool quirks:\n\n{conversation_text[:500]}",
+        "extraction_prompt": f"Extract insights from the following conversation as a JSON array of objects with 'content', 'type', and 'domain' fields. Domain should be the user domain for the human's knowledge/decisions/preferences, or the AI domain for operational lessons/workflow patterns/tool quirks:\n\n{conversation_text[:500]}",
         "session_id": getattr(args, 'session_id', None) or "prepare_only",
         "file_path": args.input,
         "input_length": len(conversation_text),
@@ -235,7 +235,6 @@ def _cmd_extract_ingest(args):
     for item in data.get("insights", []):
         content = item.get("content", "")
         node_type = item.get("type", "insight")
-        confidence = item.get("confidence", 0.7)
         domain = item.get("domain", None)
         # Infer domain if not specified: ai signals → ai domain, else user domain
         if not domain:
@@ -249,7 +248,7 @@ def _cmd_extract_ingest(args):
             domain = ai_domain if any(s in content_lower for s in ai_signals) else user_domain
         if content:
             node_id = _create_node(args.db, content, node_type, "openclaw_extraction",
-                        confidence=confidence, domain=domain)
+                        domain=domain)
             new_node_ids.append(node_id)
             new_nodes += 1
     
@@ -342,7 +341,6 @@ def _cmd_think_ingest(args):
     for item in data.get("insights", []):
         content = item.get("content", "")
         node_type = item.get("type", "insight")
-        confidence = item.get("confidence", 0.7)
         if not content:
             continue
         
@@ -357,7 +355,7 @@ def _cmd_think_ingest(args):
                 pass
         
         node_id = _create_node(args.db, content, node_type, "system_generated",
-                              confidence=confidence, domain="bunny")
+                              domain="bunny")
         new_nodes += 1
         
         # Link to source nodes
@@ -486,30 +484,24 @@ def cmd_stats(args):
 
 
 def cmd_prune(args):
-    """Prune old unused low-confidence nodes with cascading tree decay"""
+    """Prune old unaccessed observation nodes with cascading tree decay"""
     dry_run = getattr(args, 'dry_run', False)
     min_age_days = getattr(args, 'min_age_days', 14)
-    max_confidence = getattr(args, 'max_confidence', 0.85)
     disable_cascading = getattr(args, 'disable_cascading', False)
-    decay_factor = getattr(args, 'decay_factor', 0.7)
-    
-    print(f"🧹 Pruning nodes older than {min_age_days} days with confidence < {max_confidence}")
+
+    print(f"🧹 Pruning unaccessed observations older than {min_age_days} days")
     if not disable_cascading:
-        print(f"🌊 Cascading decay enabled (factor: {decay_factor})")
+        print(f"🌊 Cascading decay enabled (children must also be unaccessed observations >=30d)")
     print(f"🔍 Dry run: {dry_run}")
     print()
-    
+
     if dry_run:
         # Show candidates without actually pruning, including cascade preview
-        candidates = get_decay_candidates(args.db, min_age_days, max_confidence, 
-                                        show_cascade_preview=not disable_cascading, 
-                                        decay_factor=decay_factor)
+        candidates = get_decay_candidates(args.db, min_age_days,
+                                        show_cascade_preview=not disable_cascading)
         print(f"📊 Decay candidates:")
         print(f"  Direct candidates: {candidates['candidates']}")
-        print(f"  Avg confidence: {candidates['avg_confidence']}")
-        print(f"  Min confidence: {candidates['min_confidence']}")
-        print(f"  Max confidence: {candidates['max_confidence']}")
-        
+
         if not disable_cascading and 'cascade_preview' in candidates:
             print(f"  Would cascade: {candidates['cascade_preview']}")
             print(f"  Total affected: {candidates['total_preview']}")
@@ -520,9 +512,8 @@ def cmd_prune(args):
             print(f"✅ No nodes eligible for pruning")
     else:
         # Actually prune with cascading
-        result = auto_decay(args.db, min_age_days, max_confidence, 
-                           enable_cascading=not disable_cascading, 
-                           decay_factor=decay_factor)
+        result = auto_decay(args.db, min_age_days,
+                           enable_cascading=not disable_cascading)
         
         direct_pruned = result['pruned']
         cascaded = result.get('cascaded', 0)
@@ -571,8 +562,8 @@ def cmd_compact(args):
                 for merge in stats['merges']:
                     print(f"  {merge['discarded_node']} → {merge['kept_node']} "
                           f"(similarity: {merge['similarity']:.3f}, edges: {merge['edges_transferred']})")
-                    print(f"    Kept (conf: {merge['kept_confidence']:.2f}): {merge['kept_content']}")
-                    print(f"    Discarded (conf: {merge['discarded_confidence']:.2f}): {merge['discarded_content']}")
+                    print(f"    Kept: {merge['kept_content']}")
+                    print(f"    Discarded: {merge['discarded_content']}")
                     print()
             else:
                 print("✅ No near-duplicates found")
@@ -857,7 +848,6 @@ def cmd_init(args):
                 timestamp TEXT,
                 access_count INTEGER DEFAULT 0,
                 last_accessed TEXT,
-                confidence REAL,
                 source_file TEXT,
                 decayed INTEGER DEFAULT 0,
                 metadata TEXT,
@@ -873,7 +863,6 @@ def cmd_init(args):
                 child_id TEXT,
                 weight REAL,
                 reasoning TEXT,
-                confidence REAL,
                 timestamp TEXT,
                 PRIMARY KEY (parent_id, child_id),
                 FOREIGN KEY (parent_id) REFERENCES thought_nodes(id),
@@ -955,7 +944,6 @@ def _migrate_extract_file(db_path: str, content: str, filename: str, session_id:
 For each item, output a JSON object on its own line with fields:
 - "content": the knowledge statement (clear, self-contained, pattern-level — not raw quotes)
 - "type": one of "fact", "observation", "insight", "decision", "belief"
-- "confidence": 0.0-1.0 (how certain/important)
 
 Focus on:
 - Decisions and their reasoning
@@ -1007,16 +995,12 @@ Document ({filename}):
         if not node_content or len(node_content) < 20:
             continue
         node_type = item.get("type", "observation")
-        confidence = item.get("confidence", 0.7)
-        
+
         # Primary gate: semantic novelty check (uses sqlite-vec O(log N) fast path)
         try:
             is_novel, max_sim, nearest_id = check_novelty(db_path, node_content)
             if not is_novel:
                 print(f"   ⊘ Rejecting duplicate (sim={max_sim:.3f}): {node_content[:60]}")
-                continue
-            if max_sim > 0.72 and confidence < 0.7:
-                print(f"   ⊘ Rejecting borderline (sim={max_sim:.3f}, conf={confidence}): {node_content[:60]}")
                 continue
         except Exception as e:
             # Fail open — if novelty check breaks, fall through
@@ -1039,10 +1023,10 @@ Document ({filename}):
         
         try:
             cursor.execute("""
-                INSERT OR IGNORE INTO thought_nodes 
-                (id, content, node_type, timestamp, confidence, source_file, access_count, metadata, domain)
-                VALUES (?, ?, ?, ?, ?, ?, 0, '{}', ?)
-            """, (node_id, node_content, node_type, now, confidence, f"migration:{filename}", domain))
+                INSERT OR IGNORE INTO thought_nodes
+                (id, content, node_type, timestamp, source_file, access_count, metadata, domain)
+                VALUES (?, ?, ?, ?, ?, 0, '{}', ?)
+            """, (node_id, node_content, node_type, now, f"migration:{filename}", domain))
             new_nodes.append(node_id)
         except Exception:
             continue
@@ -1106,9 +1090,9 @@ def _migrate_extract_heuristic(db_path: str, content: str, filename: str, sessio
         
         try:
             cursor.execute("""
-                INSERT OR IGNORE INTO thought_nodes 
-                (id, content, node_type, timestamp, confidence, source_file, access_count, metadata, domain)
-                VALUES (?, ?, 'observation', ?, 0.5, ?, 0, '{}', ?)
+                INSERT OR IGNORE INTO thought_nodes
+                (id, content, node_type, timestamp, source_file, access_count, metadata, domain)
+                VALUES (?, ?, 'observation', ?, ?, 0, '{}', ?)
             """, (node_id, clean, now, f"migration:{filename}", domain))
             new_nodes.append(node_id)
         except Exception:
@@ -1568,12 +1552,10 @@ def main():
     stats_parser.set_defaults(func=cmd_stats)
     
     # Prune command
-    prune_parser = subparsers.add_parser("prune", help="Prune old unused low-confidence nodes with cascading decay")
+    prune_parser = subparsers.add_parser("prune", help="Prune old unaccessed observation nodes with cascading decay")
     prune_parser.add_argument("--dry-run", action="store_true", help="Show what would be pruned without making changes")
     prune_parser.add_argument("--min-age-days", type=int, default=14, help="Minimum age in days for pruning (default: 14)")
-    prune_parser.add_argument("--max-confidence", type=float, default=0.85, help="Maximum confidence for pruning (default: 0.85)")
     prune_parser.add_argument("--disable-cascading", action="store_true", help="Disable cascading tree decay")
-    prune_parser.add_argument("--decay-factor", type=float, default=0.7, help="Decay factor for cascading (default: 0.7)")
     prune_parser.set_defaults(func=cmd_prune)
     
     # Compact command

--- a/scripts/cashew_init.py
+++ b/scripts/cashew_init.py
@@ -115,7 +115,6 @@ def create_database_schema(db_path: str):
             timestamp TEXT,
             access_count INTEGER DEFAULT 0,
             last_accessed TEXT,
-            confidence REAL,
             source_file TEXT,
             decayed INTEGER DEFAULT 0,
             metadata TEXT DEFAULT '{}',
@@ -132,7 +131,6 @@ def create_database_schema(db_path: str):
             child_id TEXT,
             weight REAL,
             reasoning TEXT,
-            confidence REAL,
             timestamp TEXT,
             PRIMARY KEY (parent_id, child_id),
             FOREIGN KEY (parent_id) REFERENCES thought_nodes(id),
@@ -339,7 +337,6 @@ def build_config(interactive: bool = True, config_path: str = None, global_confi
             'think_cycle_nodes': 5,
             'clustering_eps': 0.35,
             'novelty_threshold': 0.82,
-            'confidence_threshold': 0.7,
             'max_think_iterations': 3
         },
         'integration': {},

--- a/scripts/dashboard_server.py
+++ b/scripts/dashboard_server.py
@@ -40,7 +40,7 @@ def load_graph_json(db_path: str) -> dict:
     conn = cdb.connect(db_path)
     c = conn.cursor()
     c.execute(
-        f"SELECT id, content, node_type, confidence, source_file, timestamp, "
+        f"SELECT id, content, node_type, source_file, timestamp, "
         f"mood_state, domain, tags FROM {cdb.NODES_TABLE} "
         f"WHERE decayed = 0 OR decayed IS NULL"
     )
@@ -48,10 +48,10 @@ def load_graph_json(db_path: str) -> dict:
     for row in c.fetchall():
         nodes.append({
             "id": row[0], "content": row[1], "node_type": row[2],
-            "confidence": row[3], "source_file": row[4] or "",
-            "timestamp": row[5] or "", "mood_state": row[6] or "",
-            "domain": row[7] or "",
-            "tags": (row[8] or "").split(",") if row[8] else [],
+            "source_file": row[3] or "",
+            "timestamp": row[4] or "", "mood_state": row[5] or "",
+            "domain": row[6] or "",
+            "tags": (row[7] or "").split(",") if row[7] else [],
         })
     node_ids = {n["id"] for n in nodes}
     c.execute(f"SELECT parent_id, child_id, weight, reasoning FROM {cdb.EDGES_TABLE}")

--- a/scripts/export_dashboard.py
+++ b/scripts/export_dashboard.py
@@ -27,7 +27,7 @@ def export(db_path: str, output_path: str, title: str = "cashew"):
 
     # Export nodes
     c.execute(f"""
-        SELECT id, content, node_type, confidence, source_file, timestamp, mood_state, domain, tags
+        SELECT id, content, node_type, source_file, timestamp, mood_state, domain, tags
         FROM {cdb.NODES_TABLE}
         WHERE decayed = 0 OR decayed IS NULL
     """)
@@ -41,17 +41,16 @@ def export(db_path: str, output_path: str, title: str = "cashew"):
         "default": "raj"
     }
     for row in c.fetchall():
-        db_domain = row[7] or "default"
+        db_domain = row[6] or "default"
         nodes.append({
             "id": row[0],
             "content": row[1],
             "node_type": row[2],
-            "confidence": row[3],
-            "source_file": row[4] or "",
-            "timestamp": row[5] or "",
-            "mood_state": row[6] or "",
+            "source_file": row[3] or "",
+            "timestamp": row[4] or "",
+            "mood_state": row[5] or "",
             "domain": DOMAIN_MAP.get(db_domain, "raj"),
-            "tags": (row[8] or "").split(",") if row[8] else []
+            "tags": (row[7] or "").split(",") if row[7] else []
         })
     
     # Export edges — use source/target format for dashboard compatibility

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,6 @@ def temp_db():
             timestamp TEXT,
             access_count INTEGER DEFAULT 0,
             last_accessed TEXT,
-            confidence REAL,
             source_file TEXT,
             decayed INTEGER DEFAULT 0,
             metadata TEXT DEFAULT '{}',
@@ -48,7 +47,6 @@ def temp_db():
             child_id TEXT,
             weight REAL,
             reasoning TEXT,
-            confidence REAL,
             timestamp TEXT,
             PRIMARY KEY (parent_id, child_id),
             FOREIGN KEY (parent_id) REFERENCES thought_nodes(id),
@@ -115,7 +113,6 @@ def temp_db_with_data():
             timestamp TEXT,
             access_count INTEGER DEFAULT 0,
             last_accessed TEXT,
-            confidence REAL,
             source_file TEXT,
             decayed INTEGER DEFAULT 0,
             metadata TEXT DEFAULT '{}',
@@ -132,7 +129,6 @@ def temp_db_with_data():
             child_id TEXT,
             weight REAL,
             reasoning TEXT,
-            confidence REAL,
             timestamp TEXT,
             PRIMARY KEY (parent_id, child_id),
             FOREIGN KEY (parent_id) REFERENCES thought_nodes(id),
@@ -153,32 +149,32 @@ def temp_db_with_data():
     # Add sample data
     now = datetime.now(timezone.utc).isoformat()
     sample_nodes = [
-        ("node1", "Machine learning algorithms improve with data", "fact", "tech", 0.8),
-        ("node2", "Python is good for data science", "observation", "tech", 0.7),
-        ("node3", "Exercise boosts cognitive function", "belief", "health", 0.9),
-        ("node4", "God exists and created the universe", "belief", "philosophy", 0.6),
-        ("node5", "Systems thinking reveals interconnections", "insight", "meta", 0.8)
+        ("node1", "Machine learning algorithms improve with data", "fact", "tech"),
+        ("node2", "Python is good for data science", "observation", "tech"),
+        ("node3", "Exercise boosts cognitive function", "belief", "health"),
+        ("node4", "God exists and created the universe", "belief", "philosophy"),
+        ("node5", "Systems thinking reveals interconnections", "insight", "meta")
     ]
-    
-    for node_id, content, node_type, domain, confidence in sample_nodes:
+
+    for node_id, content, node_type, domain in sample_nodes:
         cursor.execute("""
-            INSERT INTO thought_nodes 
-            (id, content, node_type, domain, timestamp, confidence, source_file, access_count, metadata)
-            VALUES (?, ?, ?, ?, ?, ?, 'test', 0, '{}')
-        """, (node_id, content, node_type, domain, now, confidence))
-    
+            INSERT INTO thought_nodes
+            (id, content, node_type, domain, timestamp, source_file, access_count, metadata)
+            VALUES (?, ?, ?, ?, ?, 'test', 0, '{}')
+        """, (node_id, content, node_type, domain, now))
+
     # Add sample edges
     sample_edges = [
         ("node1", "node2", 0.7, "supports - Both about tech/programming"),
         ("node3", "node5", 0.5, "related_to - Both about mental processes")
     ]
-    
+
     for parent_id, child_id, weight, reasoning in sample_edges:
         cursor.execute("""
-            INSERT INTO derivation_edges 
-            (parent_id, child_id, weight, reasoning, confidence, timestamp)
-            VALUES (?, ?, ?, ?, ?, ?)
-        """, (parent_id, child_id, weight, reasoning, 0.8, now))
+            INSERT INTO derivation_edges
+            (parent_id, child_id, weight, reasoning, timestamp)
+            VALUES (?, ?, ?, ?, ?)
+        """, (parent_id, child_id, weight, reasoning, now))
     
     conn.commit()
     conn.close()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -139,9 +139,6 @@ class TestContextRetrieval(unittest.TestCase):
             
             # Should contain the header
             self.assertIn("Existing reasoning", context)
-            
-            # Should contain confidence scores
-            self.assertIn("Confidence:", context)
     
     def test_search_by_content(self):
         """Test searching for specific content fragments"""

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 """
-Tests for decay functionality including cascading tree decay
+Tests for decay functionality including cascading tree decay.
+
+Post-confidence-removal, post-node_type-removal gate (both direct and cascade):
+  - access_count == 0
+  - age >= min_age_days (default 14 direct, 30 cascade)
+  - edge_degree == 0 (no edges to live neighbors)
+
+node_type plays no role in decay logic; it's purely a display tag.
 """
 
 import pytest
@@ -16,16 +23,36 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from core.decay import auto_decay, get_decay_candidates, cascade_decay, simulate_cascade_decay
 
 
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ago(days: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
 @pytest.fixture
 def decay_test_db():
-    """Create a test database with nodes in a tree structure for decay testing"""
+    """Create a test database structured for the degree+access gate.
+
+    Layout:
+        root (old, ac=0, edges to child1/child2)
+            child1 (old, ac=0)        — orphan once root decays → cascades
+                grandchild1 (old, ac=0, also has anchored_parent) — anchored, won't cascade
+            child2 (old, ac=0)        — orphan once root decays → cascades
+                grandchild2 (old, ac=0) — orphan once child2 decays → cascades
+        anchored_parent (recent, ac=0, permanent=1) — protected
+        isolated_old (old, ac=0, no edges) — direct decay
+        recent_obs (recent, ac=5)     — recent + accessed, won't decay
+        accessed_old (old, ac=3, no edges) — accessed, protected from direct decay
+        connected_old (old, ac=0, edge to recent_obs) — has live neighbor, protected
+    """
     fd, path = tempfile.mkstemp(suffix='.db')
     os.close(fd)
-    
+
     conn = sqlite3.connect(path)
     cursor = conn.cursor()
-    
-    # Create schema
+
     cursor.execute('''
         CREATE TABLE thought_nodes (
             id TEXT PRIMARY KEY,
@@ -35,7 +62,6 @@ def decay_test_db():
             timestamp TEXT,
             access_count INTEGER DEFAULT 0,
             last_accessed TEXT,
-            confidence REAL,
             source_file TEXT,
             decayed INTEGER DEFAULT 0,
             metadata TEXT DEFAULT '{}',
@@ -44,298 +70,227 @@ def decay_test_db():
             permanent INTEGER DEFAULT 0
         )
     ''')
-    
+
     cursor.execute('''
         CREATE TABLE derivation_edges (
             parent_id TEXT,
             child_id TEXT,
             weight REAL,
             reasoning TEXT,
-            confidence REAL,
             timestamp TEXT,
             PRIMARY KEY (parent_id, child_id),
             FOREIGN KEY (parent_id) REFERENCES thought_nodes(id),
             FOREIGN KEY (child_id) REFERENCES thought_nodes(id)
         )
     ''')
-    
-    # Create test nodes with tree structure
-    old_time = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
-    recent_time = datetime.now(timezone.utc).isoformat()
-    
-    # Tree structure:
-    # root (old, low conf, hotspot) -> child1 (medium conf) -> grandchild1 (low conf)
-    #                               -> child2 (high conf)   -> grandchild2 (medium conf)
-    # anchored_parent (high conf) -> grandchild1 (multi-parent anchoring)
-    # isolated_old (old, low conf, no children)
-    
+
+    old = _ago(60)
+    recent = _now()
+
+    # node_type values are arbitrary — they don't gate anything anymore.
     nodes = [
-        ("root", "Root node", "hotspot", old_time, 0.5, 0),  # Should decay
-        ("child1", "Child 1", "thought", old_time, 0.6, 0),
-        ("child2", "Child 2", "thought", old_time, 0.9, 0),  # High confidence, shouldn't cascade decay
-        ("grandchild1", "Grandchild 1", "thought", old_time, 0.4, 0),
-        ("grandchild2", "Grandchild 2", "thought", old_time, 0.7, 0),
-        ("anchored_parent", "Anchored parent", "thought", recent_time, 0.95, 1),  # Won't decay
-        ("isolated_old", "Isolated old", "thought", old_time, 0.3, 0),  # Should decay, no children
-        ("recent_node", "Recent node", "thought", recent_time, 0.4, 5)  # Recent, won't decay
+        # id,               type,           timestamp,  ac, perm
+        ("root",            "observation",  old,        0,  0),
+        ("child1",          "insight",      old,        0,  0),
+        ("child2",          "observation",  old,        0,  0),
+        ("grandchild1",     "observation",  old,        0,  0),
+        ("grandchild2",     "observation",  old,        0,  0),
+        ("anchored_parent", "observation",  recent,     0,  1),
+        ("isolated_old",    "observation",  old,        0,  0),
+        ("recent_obs",      "observation",  recent,     5,  0),
+        ("accessed_old",    "observation",  old,        3,  0),
+        ("connected_old",   "observation",  old,        0,  0),
     ]
-    
-    for node_id, content, node_type, timestamp, confidence, access_count in nodes:
+
+    for node_id, node_type, ts, ac, perm in nodes:
         cursor.execute("""
-            INSERT INTO thought_nodes 
-            (id, content, node_type, timestamp, confidence, access_count, source_file, metadata)
-            VALUES (?, ?, ?, ?, ?, ?, 'test', '{}')
-        """, (node_id, content, node_type, timestamp, confidence, access_count))
-    
-    # Create edges for tree structure
+            INSERT INTO thought_nodes
+            (id, content, node_type, timestamp, access_count, source_file, metadata, permanent)
+            VALUES (?, ?, ?, ?, ?, 'test', '{}', ?)
+        """, (node_id, f"content {node_id}", node_type, ts, ac, perm))
+
     edges = [
         ("root", "child1", "parent_of"),
         ("root", "child2", "parent_of"),
         ("child1", "grandchild1", "parent_of"),
         ("child2", "grandchild2", "parent_of"),
-        ("anchored_parent", "grandchild1", "supports")  # Multi-parent anchoring
+        ("anchored_parent", "grandchild1", "supports"),
+        ("connected_old", "recent_obs", "references"),
     ]
-    
     for parent_id, child_id, relation in edges:
         cursor.execute("""
-            INSERT INTO derivation_edges 
-            (parent_id, child_id, reasoning, confidence, timestamp)
-            VALUES (?, ?, ?, 0.8, ?)
-        """, (parent_id, child_id, relation, recent_time))
-    
+            INSERT INTO derivation_edges (parent_id, child_id, weight, reasoning, timestamp)
+            VALUES (?, ?, 1.0, ?, ?)
+        """, (parent_id, child_id, relation, _now()))
+
     conn.commit()
     conn.close()
-    
+
     yield path
     os.unlink(path)
 
 
 def test_cascade_propagation_basic(decay_test_db):
-    """Test that cascade propagates down the tree with confidence penalties"""
-    # First manually decay the root node
+    """After root decays, its now-orphaned children that match the gate cascade."""
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
     cursor.execute("UPDATE thought_nodes SET decayed = 1 WHERE id = 'root'")
     conn.commit()
     conn.close()
-    
-    # Run cascade decay from root with higher min_confidence to trigger cascading
-    cascade_result = cascade_decay(decay_test_db, "root", decay_factor=0.7, min_confidence=0.5)
-    
-    # Check that some nodes were cascaded (child1 confidence will be 0.6*0.7=0.42 < 0.5)
-    assert cascade_result['cascaded'] > 0
-    
-    # Check confidence changes and decay status
-    conn = sqlite3.connect(decay_test_db)
-    cursor = conn.cursor()
-    
-    # child1 should be decayed: 0.6 * 0.7 = 0.42 < 0.5
-    cursor.execute("SELECT confidence, decayed FROM thought_nodes WHERE id = 'child1'")
-    child1_conf, child1_decayed = cursor.fetchone()
-    assert child1_conf < 0.6  # Should be reduced
-    assert child1_conf < 0.5  # Below threshold, so decayed
-    assert child1_decayed == 1
-    
-    # child2 should have reduced confidence but not decayed: 0.9 * 0.7 = 0.63 > 0.5
-    cursor.execute("SELECT confidence, decayed FROM thought_nodes WHERE id = 'child2'")
-    child2_conf, child2_decayed = cursor.fetchone()
-    assert child2_conf < 0.9  # Should be reduced
-    assert child2_conf > 0.5  # Above threshold, not decayed
-    assert child2_decayed == 0
-    
-    conn.close()
 
+    result = cascade_decay(decay_test_db, "root")
 
-def test_depth_scaling(decay_test_db):
-    """Test that deeper nodes get hit with decay_factor^depth"""
-    # Manually decay root and trigger cascade
+    # child1 and child2 both had only root as a parent — both should cascade
+    # (regardless of node_type — 'insight' vs 'observation' is irrelevant).
+    assert result['cascaded'] >= 2
+
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
-    cursor.execute("UPDATE thought_nodes SET decayed = 1 WHERE id = 'root'")
-    conn.commit()
-    conn.close()
-    
-    cascade_result = cascade_decay(decay_test_db, "root", decay_factor=0.5)  # Use 0.5 for easier math
-    
-    conn = sqlite3.connect(decay_test_db)
-    cursor = conn.cursor()
-    
-    # child1: 0.6 * 0.5^1 = 0.3 (right at threshold)
-    cursor.execute("SELECT confidence FROM thought_nodes WHERE id = 'child1'")
-    child1_conf = cursor.fetchone()[0]
-    assert abs(child1_conf - 0.3) < 0.01
-    
-    # If child1 didn't decay, grandchild1 should get: original * 0.5^2 = 0.4 * 0.25 = 0.1
-    # But grandchild1 is anchored by anchored_parent, so it should be skipped
-    
+    cursor.execute("SELECT decayed FROM thought_nodes WHERE id = 'child1'")
+    assert cursor.fetchone()[0] == 1
+    cursor.execute("SELECT decayed FROM thought_nodes WHERE id = 'child2'")
+    assert cursor.fetchone()[0] == 1
     conn.close()
 
 
 def test_multi_parent_anchoring(decay_test_db):
-    """Test that nodes with multiple parents are not penalized if they have a live parent"""
-    # Manually decay root
+    """Nodes with another live parent are NOT cascaded even if they match the gate."""
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
     cursor.execute("UPDATE thought_nodes SET decayed = 1 WHERE id = 'root'")
     conn.commit()
-    
-    # Get grandchild1's original confidence
-    cursor.execute("SELECT confidence FROM thought_nodes WHERE id = 'grandchild1'")
-    original_conf = cursor.fetchone()[0]
     conn.close()
-    
-    # Run cascade from root
-    cascade_decay(decay_test_db, "root", decay_factor=0.7)
-    
-    # grandchild1 should NOT have been affected because it has anchored_parent as a live parent
+
+    cascade_decay(decay_test_db, "root")
+
+    # grandchild1 has anchored_parent (live, permanent) as a second parent — must stay alive.
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
-    cursor.execute("SELECT confidence, decayed FROM thought_nodes WHERE id = 'grandchild1'")
-    final_conf, is_decayed = cursor.fetchone()
+    cursor.execute("SELECT decayed FROM thought_nodes WHERE id = 'grandchild1'")
+    assert cursor.fetchone()[0] == 0
     conn.close()
-    
-    assert final_conf == original_conf  # Should be unchanged
-    assert is_decayed == 0  # Should not be decayed
 
 
-def test_full_subtree_collapse(decay_test_db):
-    """Test that a whole subtree can collapse when all nodes are low confidence"""
-    # Create a vulnerable subtree by updating confidence values
+def test_node_type_does_not_gate_decay(decay_test_db):
+    """node_type is informational — 'insight' nodes decay just like 'observation' nodes
+    when they fail the deterministic gate."""
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
-    
-    # Make child1 and grandchild1 very low confidence (but remove anchored_parent edge first)
-    cursor.execute("DELETE FROM derivation_edges WHERE parent_id = 'anchored_parent'")
-    cursor.execute("UPDATE thought_nodes SET confidence = 0.4 WHERE id = 'child1'")
-    cursor.execute("UPDATE thought_nodes SET confidence = 0.35 WHERE id = 'grandchild1'")
-    
-    # Decay root
     cursor.execute("UPDATE thought_nodes SET decayed = 1 WHERE id = 'root'")
     conn.commit()
     conn.close()
-    
-    # Run cascade with low decay factor and high min_confidence threshold
-    cascade_result = cascade_decay(decay_test_db, "root", decay_factor=0.8, min_confidence=0.35)
-    
-    # Should cascade at least child1
-    assert cascade_result['cascaded'] >= 1
-    
-    # Check that child1 got decayed (0.4 * 0.8 = 0.32 < 0.35)
+
+    cascade_decay(decay_test_db, "root")
+
+    # child1 is an 'insight' but it's old, never accessed, and orphaned — decays.
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
     cursor.execute("SELECT decayed FROM thought_nodes WHERE id = 'child1'")
-    child1_decayed = cursor.fetchone()[0]
-    assert child1_decayed == 1
+    assert cursor.fetchone()[0] == 1
+    conn.close()
+
+
+def test_access_count_gate_protects_node(decay_test_db):
+    """access_count > 0 protects a node from direct decay."""
+    auto_decay(decay_test_db, min_age_days=14)
+    conn = sqlite3.connect(decay_test_db)
+    cursor = conn.cursor()
+    cursor.execute("SELECT decayed FROM thought_nodes WHERE id = 'accessed_old'")
+    assert cursor.fetchone()[0] == 0
+    conn.close()
+
+
+def test_edge_degree_protects_node(decay_test_db):
+    """A node with a live neighbor is protected from direct decay even if old + unaccessed."""
+    auto_decay(decay_test_db, min_age_days=14, enable_cascading=False)
+    conn = sqlite3.connect(decay_test_db)
+    cursor = conn.cursor()
+    # connected_old has an edge to recent_obs (live, accessed) — must NOT direct-decay.
+    cursor.execute("SELECT decayed FROM thought_nodes WHERE id = 'connected_old'")
+    assert cursor.fetchone()[0] == 0
     conn.close()
 
 
 def test_auto_decay_with_cascading_integration(decay_test_db):
-    """Test the full auto_decay flow with cascading enabled"""
-    result = auto_decay(decay_test_db, min_age_days=10, max_confidence_for_decay=0.85, 
-                       enable_cascading=True, decay_factor=0.7)
-    
-    # Should have some direct and possibly some cascaded
-    assert result['pruned'] >= 2  # root hotspot + isolated_old at minimum
+    """Direct decay grabs the orphan; cascade picks up children orphaned by the prune."""
+    result = auto_decay(decay_test_db, min_age_days=14, enable_cascading=True)
+
+    # Direct: only isolated_old qualifies for direct decay (root has live edges).
+    assert result['pruned'] >= 1
     assert 'cascaded' in result
     assert 'total' in result
     assert result['total'] == result['pruned'] + result['cascaded']
 
 
 def test_auto_decay_without_cascading(decay_test_db):
-    """Test auto_decay with cascading disabled"""
-    result = auto_decay(decay_test_db, min_age_days=10, max_confidence_for_decay=0.85, 
-                       enable_cascading=False)
-    
-    # Should only have direct pruning
-    assert result['pruned'] >= 2
+    """Disabling cascading skips the DFS walk."""
+    result = auto_decay(decay_test_db, min_age_days=14, enable_cascading=False)
+
+    assert result['pruned'] >= 1
     assert result.get('cascaded', 0) == 0
     assert result['total'] == result['pruned']
 
 
 def test_dry_run_preview(decay_test_db):
-    """Test that dry run shows what would be cascaded without modifying"""
-    # Get original state
+    """get_decay_candidates with cascade preview reports counts without mutating."""
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
     cursor.execute("SELECT COUNT(*) FROM thought_nodes WHERE decayed = 1")
-    original_decayed_count = cursor.fetchone()[0]
-    cursor.execute("SELECT confidence FROM thought_nodes WHERE id = 'child1'")
-    original_child1_conf = cursor.fetchone()[0]
+    before = cursor.fetchone()[0]
     conn.close()
-    
-    # Run dry run with cascade preview
-    candidates = get_decay_candidates(decay_test_db, min_age_days=10, max_confidence_for_decay=0.85,
-                                    show_cascade_preview=True, decay_factor=0.7)
-    
-    # Should have preview data
+
+    candidates = get_decay_candidates(decay_test_db, min_age_days=14, show_cascade_preview=True)
+
     assert 'cascade_preview' in candidates
     assert 'total_preview' in candidates
     assert candidates['total_preview'] >= candidates['candidates']
-    
-    # Verify nothing was actually changed
+
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
     cursor.execute("SELECT COUNT(*) FROM thought_nodes WHERE decayed = 1")
-    final_decayed_count = cursor.fetchone()[0]
-    cursor.execute("SELECT confidence FROM thought_nodes WHERE id = 'child1'")
-    final_child1_conf = cursor.fetchone()[0]
+    after = cursor.fetchone()[0]
     conn.close()
-    
-    assert final_decayed_count == original_decayed_count
-    assert final_child1_conf == original_child1_conf
+
+    assert after == before
 
 
-def test_simulate_cascade_decay(decay_test_db):
-    """Test the simulation function works correctly"""
-    would_cascade = simulate_cascade_decay(decay_test_db, "root", decay_factor=0.7, min_confidence=0.3)
-    
-    # Should predict some cascading without modifying database
-    # (Exact number depends on tree structure and confidence values)
-    assert isinstance(would_cascade, int)
-    assert would_cascade >= 0
-    
-    # Verify no actual changes
+def test_simulate_cascade_decay_does_not_mutate(decay_test_db):
+    """simulate_cascade_decay returns a count and leaves the DB untouched."""
+    would = simulate_cascade_decay(decay_test_db, "root")
+    assert isinstance(would, int)
+    assert would >= 0
+
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
-    cursor.execute("SELECT confidence FROM thought_nodes WHERE id = 'child1'")
-    child1_conf = cursor.fetchone()[0]
     cursor.execute("SELECT COUNT(*) FROM thought_nodes WHERE decayed = 1")
-    decayed_count = cursor.fetchone()[0]
+    assert cursor.fetchone()[0] == 0
     conn.close()
-    
-    # Original values should be unchanged
-    assert child1_conf == 0.6  # Original value
-    assert decayed_count == 0  # No nodes should be decayed yet
 
 
 def test_empty_database_edge_cases(temp_db):
-    """Test decay functions handle empty database gracefully"""
-    # Test with empty database
+    """Decay functions handle empty databases gracefully."""
     result = auto_decay(temp_db)
     assert result['pruned'] == 0
     assert result.get('cascaded', 0) == 0
-    
+
     candidates = get_decay_candidates(temp_db)
     assert candidates['candidates'] == 0
-    
-    # Test cascade on non-existent node
+
     cascade_result = cascade_decay(temp_db, "nonexistent")
     assert cascade_result['cascaded'] == 0
 
 
 def test_circular_references_handling(decay_test_db):
-    """Test that circular references don't cause infinite loops"""
-    # Add circular reference
+    """Cascade visits each node at most once even with cycles."""
     conn = sqlite3.connect(decay_test_db)
     cursor = conn.cursor()
     cursor.execute("""
-        INSERT INTO derivation_edges (parent_id, child_id, weight, reasoning, confidence, timestamp)
-        VALUES ('child1', 'root', 0.8, 'circular reference', 0.8, ?)
-    """, (datetime.now(timezone.utc).isoformat(),))
+        INSERT INTO derivation_edges (parent_id, child_id, weight, reasoning, timestamp)
+        VALUES ('child1', 'root', 1.0, 'circular reference', ?)
+    """, (_now(),))
     conn.commit()
     conn.close()
-    
-    # This should not hang or crash
-    cascade_result = cascade_decay(decay_test_db, "root", decay_factor=0.7)
+
+    cascade_result = cascade_decay(decay_test_db, "root")
     assert isinstance(cascade_result['cascaded'], int)
     assert cascade_result['cascaded'] >= 0

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -184,7 +184,6 @@ Another paragraph with useful information.""")
         for node in nodes:
             self.assertIn('content', node)
             self.assertIn('type', node)
-            self.assertIn('confidence', node)
             self.assertIn('source_file', node)
             self.assertTrue(node['source_file'].startswith('extractor:obsidian:'))
 

--- a/tests/test_prepare_ingest.py
+++ b/tests/test_prepare_ingest.py
@@ -110,10 +110,10 @@ class TestThinkCyclePrepareIngest:
         _ensure_schema(temp_db)
         conn = _get_connection(temp_db)
         cursor = conn.cursor()
-        cursor.execute("INSERT OR IGNORE INTO thought_nodes (id, content, node_type, timestamp, confidence, source_file, domain) VALUES (?, ?, ?, datetime('now'), ?, ?, ?)",
-                      ("test_node_1", "Test source node 1", "observation", 0.7, "test", "bunny"))
-        cursor.execute("INSERT OR IGNORE INTO thought_nodes (id, content, node_type, timestamp, confidence, source_file, domain) VALUES (?, ?, ?, datetime('now'), ?, ?, ?)",
-                      ("test_node_2", "Test source node 2", "observation", 0.7, "test", "raj"))
+        cursor.execute("INSERT OR IGNORE INTO thought_nodes (id, content, node_type, timestamp, source_file, domain) VALUES (?, ?, ?, datetime('now'), ?, ?)",
+                      ("test_node_1", "Test source node 1", "observation", "test", "bunny"))
+        cursor.execute("INSERT OR IGNORE INTO thought_nodes (id, content, node_type, timestamp, source_file, domain) VALUES (?, ?, ?, datetime('now'), ?, ?)",
+                      ("test_node_2", "Test source node 2", "observation", "test", "raj"))
         conn.commit()
         conn.close()
         
@@ -154,7 +154,7 @@ class TestThinkCyclePrepareIngest:
         # Create a node with specific content
         _ensure_schema(temp_db)
         existing_content = "This is a very specific test insight about engineering patterns"
-        existing_id = _create_node(temp_db, existing_content, "insight", "system_generated", 0.8)
+        existing_id = _create_node(temp_db, existing_content, "insight", "system_generated")
         embed_nodes(temp_db)
         
         # Try to ingest very similar content

--- a/tests/test_referent_time.py
+++ b/tests/test_referent_time.py
@@ -69,7 +69,6 @@ class TestCreateNodeStoresReferentTime:
             "Event X happened in 2019",
             "observation",
             "sess",
-            confidence=0.7,
             domain="default",
             referent_time="2019-03-14T12:00:00+00:00",
         )
@@ -139,13 +138,13 @@ class TestSimilarityUsesCoalesce:
         conn = sqlite3.connect(temp_db)
         conn.execute(
             "INSERT INTO thought_nodes (id, content, node_type, timestamp, "
-            "confidence, source_file, referent_time) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            ("nA", "old event imported today", "observation", now_iso, 0.7, "t", old_iso),
+            "source_file, referent_time) VALUES (?, ?, ?, ?, ?, ?)",
+            ("nA", "old event imported today", "observation", now_iso, "t", old_iso),
         )
         conn.execute(
             "INSERT INTO thought_nodes (id, content, node_type, timestamp, "
-            "confidence, source_file, referent_time) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            ("nB", "fresh event", "observation", now_iso, 0.7, "t", None),
+            "source_file, referent_time) VALUES (?, ?, ?, ?, ?, ?)",
+            ("nB", "fresh event", "observation", now_iso, "t", None),
         )
         conn.commit()
         conn.close()
@@ -181,11 +180,11 @@ class TestDecayIgnoresReferentTime:
         conn = sqlite3.connect(temp_db)
         conn.execute(
             "INSERT INTO thought_nodes "
-            "(id, content, node_type, timestamp, confidence, source_file, "
+            "(id, content, node_type, timestamp, source_file, "
             "access_count, referent_time, decayed) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)",
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 0)",
             ("imp1", "old WA note imported fresh", "observation", fresh_ts,
-             0.3, "whatsapp:2019", 0, ancient_ref),
+             "whatsapp:2019", 0, ancient_ref),
         )
         conn.commit()
         conn.close()
@@ -193,7 +192,7 @@ class TestDecayIgnoresReferentTime:
         from core.decay import auto_decay
 
         result = auto_decay(
-            temp_db, min_age_days=30, max_confidence_for_decay=0.85,
+            temp_db, min_age_days=30,
             enable_cascading=False,
         )
         assert result["pruned"] == 0, (
@@ -210,10 +209,10 @@ class TestDecayIgnoresReferentTime:
         conn = sqlite3.connect(temp_db)
         conn.execute(
             "INSERT INTO thought_nodes "
-            "(id, content, node_type, timestamp, confidence, source_file, "
+            "(id, content, node_type, timestamp, source_file, "
             "access_count, referent_time, decayed) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)",
-            ("old1", "stale ingest", "observation", old_ts, 0.3, "x", 0, future_ref),
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 0)",
+            ("old1", "stale ingest", "observation", old_ts, "x", 0, future_ref),
         )
         conn.commit()
         conn.close()
@@ -221,7 +220,7 @@ class TestDecayIgnoresReferentTime:
         from core.decay import auto_decay
 
         result = auto_decay(
-            temp_db, min_age_days=14, max_confidence_for_decay=0.85,
+            temp_db, min_age_days=14,
             enable_cascading=False,
         )
         assert result["pruned"] == 1
@@ -239,9 +238,9 @@ class TestBackfill:
         for (nid, metadata, source_file) in rows:
             conn.execute(
                 "INSERT INTO thought_nodes (id, content, node_type, "
-                "timestamp, confidence, source_file, metadata, referent_time) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, NULL)",
-                (nid, f"content {nid}", "observation", now_iso, 0.7,
+                "timestamp, source_file, metadata, referent_time) "
+                "VALUES (?, ?, ?, ?, ?, ?, NULL)",
+                (nid, f"content {nid}", "observation", now_iso,
                  source_file, metadata),
             )
         conn.commit()

--- a/tests/test_schema_api.py
+++ b/tests/test_schema_api.py
@@ -29,7 +29,7 @@ OWNED_TABLES = {
 
 OWNED_NODE_COLUMNS = {
     "id", "content", "node_type", "domain", "timestamp",
-    "access_count", "last_accessed", "confidence", "source_file",
+    "access_count", "last_accessed", "source_file",
     "decayed", "metadata", "last_updated", "mood_state", "permanent",
     "tags", "referent_time",
 }

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -35,7 +35,6 @@ class TestSleepProtocol:
                 content TEXT NOT NULL,
                 node_type TEXT NOT NULL,
                 timestamp TEXT NOT NULL,
-                confidence REAL NOT NULL,
                 mood_state TEXT,
                 metadata TEXT,
                 source_file TEXT,
@@ -61,21 +60,21 @@ class TestSleepProtocol:
         
         # Insert test nodes with similar content for cross-linking tests
         nodes = [
-            ("seed1", "God exists and is all-powerful", "seed", "2023-01-01T00:00:00", 1.0, "certain", "{}", "test", 0),
-            ("similar1", "God exists and is all-powerful and omnipotent", "derived", "2023-01-02T00:00:00", 0.8, "confident", "{}", "test", 0),
-            ("similar2", "God exists and is all-powerful deity", "belief", "2023-01-03T00:00:00", 0.7, "hopeful", "{}", "test", 0),
-            ("different1", "Prayer works sometimes", "belief", "2023-01-04T00:00:00", 0.6, "hopeful", "{}", "test", 0),
-            ("hub1", "Core belief about reality", "core_memory", "2023-01-05T00:00:00", 0.9, "stable", "{}", "test", 0),
-            ("weak1", "Uncertain thought", "derived", "2023-01-06T00:00:00", 0.2, "doubtful", "{}", "test", 0),
-            ("weak2", "Another weak idea", "derived", "2023-01-07T00:00:00", 0.1, "confused", "{}", "test", 0),
-            ("isolated1", "Completely separate thought", "derived", "2023-01-08T00:00:00", 0.5, "neutral", "{}", "different_source", 0),
-            ("isolated2", "Another isolated idea", "belief", "2023-01-09T00:00:00", 0.4, "neutral", "{}", "different_source", 0),
+            ("seed1", "God exists and is all-powerful", "seed", "2023-01-01T00:00:00", "certain", "{}", "test", 0),
+            ("similar1", "God exists and is all-powerful and omnipotent", "derived", "2023-01-02T00:00:00", "confident", "{}", "test", 0),
+            ("similar2", "God exists and is all-powerful deity", "belief", "2023-01-03T00:00:00", "hopeful", "{}", "test", 0),
+            ("different1", "Prayer works sometimes", "belief", "2023-01-04T00:00:00", "hopeful", "{}", "test", 0),
+            ("hub1", "Core belief about reality", "core_memory", "2023-01-05T00:00:00", "stable", "{}", "test", 0),
+            ("weak1", "Uncertain thought", "derived", "2023-01-06T00:00:00", "doubtful", "{}", "test", 0),
+            ("weak2", "Another weak idea", "derived", "2023-01-07T00:00:00", "confused", "{}", "test", 0),
+            ("isolated1", "Completely separate thought", "derived", "2023-01-08T00:00:00", "neutral", "{}", "different_source", 0),
+            ("isolated2", "Another isolated idea", "belief", "2023-01-09T00:00:00", "neutral", "{}", "different_source", 0),
         ]
-        
+
         cursor.executemany("""
-            INSERT INTO thought_nodes 
-            (id, content, node_type, timestamp, confidence, mood_state, metadata, source_file, decayed)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO thought_nodes
+            (id, content, node_type, timestamp, mood_state, metadata, source_file, decayed)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         """, nodes)
         
         # Create edges to establish hierarchy and connectivity
@@ -502,7 +501,6 @@ class TestSleepProtocol:
                 content TEXT NOT NULL,
                 node_type TEXT NOT NULL,
                 timestamp TEXT NOT NULL,
-                confidence REAL NOT NULL,
                 mood_state TEXT,
                 metadata TEXT,
                 source_file TEXT,
@@ -1003,9 +1001,8 @@ class TestGCConfigModes:
         
         # Try to decay with very aggressive settings
         result = auto_decay(
-            permanence_db, 
+            permanence_db,
             min_age_days=0,  # No age restriction
-            max_confidence_for_decay=1.0,  # Even high confidence nodes
             enable_cascading=False
         )
         
@@ -1129,7 +1126,6 @@ class TestMergeCluster:
                 content TEXT NOT NULL,
                 node_type TEXT NOT NULL,
                 timestamp TEXT NOT NULL,
-                confidence REAL NOT NULL,
                 mood_state TEXT,
                 metadata TEXT,
                 source_file TEXT,
@@ -1171,7 +1167,7 @@ class TestMergeCluster:
             tags=None, last_updated=None,
         )
         defaults.update(kw)
-        cols = ["id", "content", "node_type", "timestamp", "confidence",
+        cols = ["id", "content", "node_type", "timestamp",
                 "mood_state", "metadata", "source_file", "decayed", "permanent",
                 "domain", "access_count", "last_accessed", "tags", "last_updated"]
         conn = sqlite3.connect(db)
@@ -1222,18 +1218,17 @@ class TestMergeCluster:
 
             conn = sqlite3.connect(db)
             row = conn.execute(
-                "SELECT id, content, node_type, timestamp, confidence, permanent, "
+                "SELECT id, content, node_type, timestamp, permanent, "
                 "access_count, last_accessed, source_file, tags, metadata "
                 "FROM thought_nodes WHERE id = ?",
                 (new_id,),
             ).fetchone()
             assert row is not None
-            (_, content, node_type, ts, conf, perm, acc, last_acc, src, tags, md) = row
+            (_, content, node_type, ts, perm, acc, last_acc, src, tags, md) = row
 
             # Fallback (model_fn=None) returns the longest member content
             assert content == "Build broken on main branch since Tuesday"
             assert perm == 1, "any-member-permanent => merged permanent"
-            assert conf == 0.9, "max confidence"
             assert acc == 10, "sum access_count"
             assert ts == "2024-01-01T00:00:00", "earliest timestamp"
             assert last_acc == "2024-02-15T00:00:00", "latest last_accessed"

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -27,22 +27,22 @@ def _cursor(db_path):
 
 
 def _add_node(cursor, node_id, content="test", node_type="fact",
-              domain="raj", confidence=0.8, decayed=0, source_file="test"):
+              domain="raj", decayed=0, source_file="test"):
     now = datetime.now(timezone.utc).isoformat()
     cursor.execute("""
         INSERT INTO thought_nodes
-        (id, content, node_type, domain, timestamp, confidence, source_file,
+        (id, content, node_type, domain, timestamp, source_file,
          decayed, access_count, metadata)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, '{}')
-    """, (node_id, content, node_type, domain, now, confidence, source_file, decayed))
+        VALUES (?, ?, ?, ?, ?, ?, ?, 0, '{}')
+    """, (node_id, content, node_type, domain, now, source_file, decayed))
 
 
 def _add_edge(cursor, parent_id, child_id, relation="supports", weight=0.7):
     now = datetime.now(timezone.utc).isoformat()
     cursor.execute("""
         INSERT INTO derivation_edges
-        (parent_id, child_id, weight, reasoning, confidence, timestamp)
-        VALUES (?, ?, ?, ?, 0.8, ?)
+        (parent_id, child_id, weight, reasoning, timestamp)
+        VALUES (?, ?, ?, ?, ?)
     """, (parent_id, child_id, weight, f"{relation} - test", now))
 
 

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -237,7 +237,6 @@ class TestTraversalEngine:
         assert node.id == "seed1"
         assert node.content == "God exists"
         assert node.node_type == "seed"
-        assert node.confidence == 1.0
         assert node.mood_state == "certain"
     
     def test_load_node_returns_none_for_missing_node(self, temp_db):


### PR DESCRIPTION
Confidence was an uncalibrated number — ~70% of nodes piled at 0.85+, no signal, no calibration, no reader actually weighting on it. This rip removes it end-to-end and replaces every gate with something deterministic or binary.

## Schema
- Drop `thought_nodes.confidence` column + `idx_nodes_confidence` index
- Drop `derivation_edges.confidence` (dead weight, no live readers)
- Idempotent v1 → v2 migration in `core/session.py`

## Read-side gates (replaces confidence thresholds)
- Think candidate selection: `access_count > 0 OR edge_degree > 0`
- Tension candidate selection: same deterministic signal
- Decay eligibility: `access_count == 0 AND age >= 14d AND edge_degree == 0`
- `node_type` is kept as display-only metadata; not routed for selection

## Write-side gate
Replaced the implicit "hedge with a confidence score" pattern with an explicit binary keep-or-drop forcing function on every LLM extraction prompt:
- `core/session.py` (JSON extractor): `keep: true/false` per candidate, filter non-keepers before insertion
- `extractors/sessions.py`, `extractors/obsidian.py`, `extractors/markdown_dir.py` (line-list extractors): prose-only "should this node exist forever? drop it if not" instruction

Either the extraction is worth a permanent slot or it isn't. No average to drift, no score to game.

## Side benefit
Stripping the confidence ask from prompts also trims tokens on every extraction call.

## Follow-up (separate PR)
Several pre-existing `node_type != 'seed' / != 'question'` filters in `core/context.py`, `core/session.py`, and `core/traversal.py` predate this work and still violate the display-only rule. Stripping them is a separate cleanup PR on the same branch base.

390 tests green.