### PR TITLE
strip node_type semantic filters: it's display-only, not load-bearing

### DIFF
--- a/core/context.py
+++ b/core/context.py
@@ -170,12 +170,13 @@ class ContextRetriever:
         conn = self._get_connection()
         cursor = conn.cursor()
         
-        # Get all non-decayed, non-question nodes
+        # Get all non-decayed nodes. node_type is display-only metadata
+        # and never participates in retrieval logic — let the LLM decide
+        # which shapes are useful context.
         cursor.execute("""
             SELECT id, content, node_type
             FROM thought_nodes
             WHERE (decayed = 0 OR decayed IS NULL)
-            AND node_type != 'question'
         """)
 
         candidates = []
@@ -274,7 +275,6 @@ class ContextRetriever:
             FROM thought_nodes
             WHERE content LIKE ?
             AND (decayed = 0 OR decayed IS NULL)
-            AND node_type != 'question'
             LIMIT ?
         """, (f"%{content_fragment}%", max_nodes))
 
@@ -308,7 +308,6 @@ class ContextRetriever:
                 (de.child_id = ? AND tn.id = de.parent_id)
             )
             WHERE (tn.decayed = 0 OR tn.decayed IS NULL)
-            AND tn.node_type != 'question'
             ORDER BY de.weight DESC
             LIMIT ?
         """, (node_id, node_id, max_nodes))

--- a/core/session.py
+++ b/core/session.py
@@ -848,13 +848,14 @@ def _find_cluster_for_thinking(db_path: str, focus_domain: Optional[str] = None)
         """, (focus_domain,))
         high_activation_candidates = cursor.fetchall()
         
-        # Also get some random walk candidates from other domains
+        # Also get some random walk candidates from other domains.
+        # node_type is display-only — think cycles run over whatever the
+        # graph happens to surface, including bootstrap-era nodes.
         cursor.execute("""
             SELECT id, last_accessed, access_count, node_type, COALESCE(domain, 'unknown') as domain
             FROM thought_nodes
             WHERE (decayed IS NULL OR decayed = 0)
             AND COALESCE(domain, 'unknown') != ?
-            AND node_type != 'seed'
             ORDER BY RANDOM()
             LIMIT 10
         """, (focus_domain,))
@@ -865,7 +866,6 @@ def _find_cluster_for_thinking(db_path: str, focus_domain: Optional[str] = None)
             SELECT id, last_accessed, access_count, node_type, COALESCE(domain, 'unknown') as domain
             FROM thought_nodes
             WHERE (decayed IS NULL OR decayed = 0)
-            AND node_type != 'seed'
             ORDER BY COALESCE(access_count, 0) ASC,
                      CASE WHEN COALESCE(access_count, 0) = 0
                           THEN RANDOM() ELSE last_accessed END ASC
@@ -873,31 +873,33 @@ def _find_cluster_for_thinking(db_path: str, focus_domain: Optional[str] = None)
         """)
         high_activation_candidates = cursor.fetchall()
         
-        # Find underrepresented domains/types for random walk
+        # Find underrepresented domains for random walk.
+        # node_type is display-only and not a partition signal — domain is
+        # the real semantic bucket cashew uses for organizing knowledge.
         cursor.execute("""
-            SELECT node_type, COALESCE(domain, 'unknown') as domain, COUNT(*) as cnt
-            FROM thought_nodes 
+            SELECT COALESCE(domain, 'unknown') as domain, COUNT(*) as cnt
+            FROM thought_nodes
             WHERE (decayed IS NULL OR decayed = 0)
             AND timestamp > datetime('now', '-30 days')
             AND (source_file LIKE '%system_generated%'
                  OR source_file LIKE 'extractor:%')
-            GROUP BY node_type, domain
+            GROUP BY domain
             ORDER BY cnt ASC
         """)
         underrep_stats = cursor.fetchall()
-        
-        # Get random walk candidates from underrepresented areas
+
+        # Get random walk candidates from underrepresented domains
         random_walk_candidates = []
-        for node_type, domain, _ in underrep_stats[:3]:  # Top 3 underrepresented
+        for domain, _ in underrep_stats[:3]:  # Top 3 underrepresented domains
             cursor.execute("""
                 SELECT id, last_accessed, access_count, node_type, COALESCE(domain, 'unknown') as domain
                 FROM thought_nodes
                 WHERE (decayed IS NULL OR decayed = 0)
-                AND node_type = ? AND COALESCE(domain, 'unknown') = ?
+                AND COALESCE(domain, 'unknown') = ?
                 AND source_file NOT LIKE '%system_generated%'  -- Prefer human-authored content (extractor:* counts as human-authored)
                 ORDER BY RANDOM()
                 LIMIT 2
-            """, (node_type, domain))
+            """, (domain,))
             random_walk_candidates.extend(cursor.fetchall())
     
     conn.close()

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -772,17 +772,20 @@ class SleepProtocol:
         conn = self._get_connection()
         cursor = conn.cursor()
         
-        # Get all non-decayed nodes
+        # Get all non-decayed nodes. node_type is display-only and never
+        # consulted in fitness scoring — fitness is a pure graph signal
+        # (branching, cross-links, depth). Seeds/core_memories that deserve
+        # protection get it via the `permanent` flag, not their label.
         cursor.execute("""
-            SELECT id, node_type FROM thought_nodes
+            SELECT id FROM thought_nodes
             WHERE decayed = 0 OR decayed IS NULL
         """)
         rows = cursor.fetchall()
-        nodes = {row[0]: row[1] for row in rows}
-        
+        nodes = {row[0]: None for row in rows}
+
         metrics = {}
-        
-        for node_id, node_type in nodes.items():
+
+        for node_id in nodes:
             # Branching factor (outgoing edges)
             cursor.execute("""
                 SELECT COUNT(*) FROM derivation_edges WHERE parent_id = ?
@@ -805,16 +808,12 @@ class SleepProtocol:
             # Derivation depth (max depth from seeds)
             derivation_depth = self._calculate_depth_from_seeds(node_id)
             
-            # Composite fitness score
-            # Seeds get bonus, core memories get bonus, depth adds value
-            base_score = branching_factor + cross_links * 0.5 + derivation_depth * 0.1
-            
-            if node_type == "seed":
-                base_score *= 2.0  # Seeds are important
-            elif node_type == "core_memory":
-                base_score *= 1.5  # Core memories are valuable
-            
-            composite_fitness = base_score
+            # Composite fitness score: pure graph signal.
+            # Important nodes (seeds, core memories) earn protection via the
+            # `permanent` flag (checked by GC), not by node_type bonuses here.
+            composite_fitness = (
+                branching_factor + cross_links * 0.5 + derivation_depth * 0.1
+            )
             
             metrics[node_id] = NodeMetrics(
                 node_id=node_id,

--- a/core/traversal.py
+++ b/core/traversal.py
@@ -166,8 +166,9 @@ class TraversalEngine:
             parents = self._get_parents(current_id)
             
             if not parents:
-                # This is a root node (check if it's actually a seed)
-                is_actual_seed = current_node.node_type == "seed"
+                # This is a root node — no incoming derivation edges.
+                # "Root" is a deterministic graph fact; node_type is
+                # display-only and never consulted here.
                 return [{
                     "node": {
                         "id": current_node.id,
@@ -176,7 +177,7 @@ class TraversalEngine:
                         "source": current_node.source_file
                     },
                     "depth": depth,
-                    "is_seed": is_actual_seed
+                    "is_root": True,
                 }]
             
             # Traverse parents
@@ -188,7 +189,7 @@ class TraversalEngine:
                     "source": current_node.source_file
                 },
                 "depth": depth,
-                "is_seed": False,
+                "is_root": False,
                 "derived_from": []
             }]
             
@@ -293,9 +294,10 @@ class TraversalEngine:
         conn = self._get_connection()
         cursor = conn.cursor()
         
-        # Get all nodes and edges
-        cursor.execute("SELECT id, node_type FROM thought_nodes")
-        nodes = {row[0]: row[1] for row in cursor.fetchall()}
+        # Get all nodes and edges. We only need node ids — node_type is
+        # display-only and not consulted by audit logic.
+        cursor.execute("SELECT id FROM thought_nodes")
+        nodes = {row[0]: None for row in cursor.fetchall()}
         
         cursor.execute("SELECT parent_id, child_id, weight, reasoning FROM derivation_edges")
         edges = [(row[0], row[1], row[2], row[3]) for row in cursor.fetchall()]
@@ -348,25 +350,28 @@ class TraversalEngine:
                     f"Contradiction detected: {reasoning} (weight: {weight})"
                 ))
         
-        # 3. Find orphan nodes (no parents, not seeds)
+        # 3. Find orphan nodes — no edges in either direction.
+        # A node with downstream children is a legitimate root (was: "seed");
+        # a node with parents is reachable. Only fully isolated nodes are
+        # orphans. node_type is display-only and never consulted here.
         orphan_nodes = []
-        for node_id, node_type in nodes.items():
-            if node_id not in reverse_graph and node_type != "seed":
+        for node_id in nodes:
+            if node_id not in reverse_graph and node_id not in graph:
                 orphan_nodes.append(node_id)
         
-        # 4. Find weak chains (low average weight to roots)
+        # 4. Find weak chains (low average weight to roots).
+        # Root nodes naturally produce no weights and are skipped by the
+        # `if weights:` gate; we don't need to read node_type to filter them.
         weak_chains = []
         for node_id in nodes:
-            if nodes[node_id] != "seed":  # Skip seeds
-                # Calculate average weight to all seed nodes
-                chain = self.why(node_id)
-                if chain and not any("error" in step or "cycle_detected" in step for step in chain):
-                    weights = []
-                    self._collect_weights(chain[0], weights)
-                    if weights:
-                        avg_weight = sum(weights) / len(weights)
-                        if avg_weight < 0.5:  # Threshold for "weak"
-                            weak_chains.append((node_id, avg_weight))
+            chain = self.why(node_id)
+            if chain and not any("error" in step or "cycle_detected" in step for step in chain):
+                weights = []
+                self._collect_weights(chain[0], weights)
+                if weights:
+                    avg_weight = sum(weights) / len(weights)
+                    if avg_weight < 0.5:  # Threshold for "weak"
+                        weak_chains.append((node_id, avg_weight))
         
         # Sort weak chains by weight
         weak_chains.sort(key=lambda x: x[1])

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -65,7 +65,11 @@ class TestContextRetrieval(unittest.TestCase):
             ("christian_belief", "Christianity provides salvation through faith", "belief", "philosophy", 0.8),
             ("system_thinking", "Systems thinking reveals interconnected patterns", "insight", "meta", 0.7),
             ("religion_general", "Religion offers meaning and community", "observation", "philosophy", 0.6),
-            ("programming_fact", "Python is used for data analysis", "fact", "tech", 0.8)
+            ("programming_fact", "Python is used for data analysis", "fact", "tech", 0.8),
+            # node_type='question' nodes used to be filtered out of retrieval.
+            # Post node_type-strip, retrieval is type-blind and questions surface
+            # like any other content node.
+            ("python_question", "Why does Python prefer composition over inheritance?", "question", "tech", 0.5),
         ]
         
         for node_id, content, node_type, domain, confidence in test_nodes:
@@ -144,11 +148,23 @@ class TestContextRetrieval(unittest.TestCase):
         """Test searching for specific content fragments"""
         # Look for nodes containing "system"
         results = self.retriever.search_by_content("system", max_nodes=3)
-        
+
         if results:
             # All results should contain the search term
             for result in results:
                 self.assertIn("system", result.content.lower())
+
+    def test_retrieval_is_node_type_blind(self):
+        """Retrieval no longer filters by node_type. Questions surface like
+        any other content node — node_type is display-only metadata."""
+        # Keyword-based retrieve()
+        nodes = self.retriever.retrieve("Python composition inheritance", max_nodes=10)
+        ids = {n.id for n in nodes}
+        self.assertIn("python_question", ids)
+
+        # Substring search
+        results = self.retriever.search_by_content("composition over inheritance", max_nodes=5)
+        self.assertTrue(any(r.id == "python_question" for r in results))
 
 
 if __name__ == "__main__":

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -110,19 +110,20 @@ class TestTraversalEngine:
         assert "derived_from" in chain[0]
         assert len(chain[0]["derived_from"]) == 2  # Two parents: question1 and belief1 (contradiction)
         
-        # Check that it traces back to seed
-        found_seed = False
-        def check_for_seed(step):
-            nonlocal found_seed
-            if step.get("is_seed", False):
-                found_seed = True
+        # Check that it traces back to a graph root (no parents).
+        # node_type is display-only; "is_root" is a deterministic graph fact.
+        found_root = False
+        def check_for_root(step):
+            nonlocal found_root
+            if step.get("is_root", False):
+                found_root = True
                 return
             for derivation in step.get("derived_from", []):
                 for parent_step in derivation.get("parent_chain", []):
-                    check_for_seed(parent_step)
-        
-        check_for_seed(chain[0])
-        assert found_seed, "Should trace back to seed node"
+                    check_for_root(parent_step)
+
+        check_for_root(chain[0])
+        assert found_root, "Should trace back to a root node"
     
     def test_why_handles_orphan_nodes(self, temp_db):
         """Test that why() handles orphan nodes correctly"""
@@ -132,7 +133,10 @@ class TestTraversalEngine:
         
         assert len(chain) == 1
         assert chain[0]["node"]["id"] == "orphan1"
-        assert chain[0]["is_seed"] == False  # Not a seed, just has no parents
+        # orphan1 has no parents → it's a graph root in the why() output.
+        # Per strict display-only invariant for node_type, the flag we surface
+        # is is_root (deterministic), not is_seed (semantic).
+        assert chain[0]["is_root"] == True
         assert "derived_from" not in chain[0] or len(chain[0].get("derived_from", [])) == 0
     
     def test_how_finds_shortest_path(self, temp_db):


### PR DESCRIPTION
PR 2 of 2 cleanup pair, after #25 (kill confidence). The schema/docs already declared node_type "display/informational only — never used in filter or scoring logic," but the engine still cheated and read it in retrieval, think selection, audit, and fitness. This PR enforces the invariant.

## Filters removed (semantic node_type reads in WHERE clauses)

- `core/context.py` — `retrieve()`, `search_by_content()`, `get_related_nodes()` no longer drop `node_type='question'` rows. Questions surface like any other content node; the LLM decides if a question-shaped node is useful context.
- `core/session.py` — think-cycle candidate pools no longer skip `node_type='seed'`. Random-walk diversity sampling now buckets by domain alone, not `(node_type, domain)`.
- `core/traversal.py` — orphan detection redefined from "no parents AND not a seed" to "no edges in either direction" (deterministic `edge_degree==0`). Weak-chain skip dropped; root nodes naturally contribute no weights.

## Scoring removed

- `core/sleep.py` `calculate_node_metrics` no longer multiplies fitness by 2.0 for seeds or 1.5 for core_memories. Fitness is now a pure graph signal (branching + cross_links + depth). Protection is expressed via the `permanent` flag, which GC short-circuits on before evaluating fitness.

## API surface change

- `traversal.why()` returns `is_root` (deterministic graph fact) instead of `is_seed` (semantic label).

## Not touched (escalation)

- `core/sleep.py:903` `if node_type in gc_protect_types` is a user-configurable escape hatch (`config.yaml: gc.protect_types`). Real protection happens via the `permanent` flag at line 899. To remove this knob we'd need to guarantee all seeds get `permanent=1` at creation, which has no canonical creator in current code. Filed as follow-up.

## Why this matters

`node_type` is taxonomy for humans reading the graph; it's not a typed edge. Routing it through SQL filters or score multipliers turns it into load-bearing semantics, violating "dumb graph, smart reasoning" — the same principle that killed typed edges and the confidence field.

391 tests green (390 + 1 new test asserting question-type nodes surface in retrieval).