### PR TITLE
kill gc.protect_types: one signal for permanence, not two

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,9 +50,6 @@ gc:
   mode: soft
   threshold: 0.05
   grace_days: 7
-  protect_types:
-  - seed
-  - core_memory
   think_cycle_penalty: 1.5
 features:
   auto_extraction: true

--- a/core/config.py
+++ b/core/config.py
@@ -171,8 +171,6 @@ class CashewConfig:
                 'mode': 'soft',           # soft | hard | off
                 'threshold': 0.05,        # relevance score below which nodes are eligible
                 'grace_days': 7,          # days since last_accessed before eligible
-                
-                'protect_types': ['seed', 'core_memory'],
                 'think_cycle_penalty': 1.5,  # multiplier on threshold for think-cycle nodes
             },
             'sleep': {
@@ -257,7 +255,6 @@ class CashewConfig:
         self.gc_mode = gc.get('mode', 'soft')
         self.gc_threshold = float(gc.get('threshold', 0.05))
         self.gc_grace_days = int(gc.get('grace_days', 7))
-        self.gc_protect_types = list(gc.get('protect_types', ['seed', 'core_memory']))
         self.gc_think_cycle_penalty = float(gc.get('think_cycle_penalty', 1.5))
 
         # (node type taxonomy loaded above via _node_type_map)
@@ -466,7 +463,6 @@ def get_gc_config() -> dict:
         'mode': config.gc_mode,
         'threshold': config.gc_threshold,
         'grace_days': config.gc_grace_days,
-        'protect_types': config.gc_protect_types,
         'think_cycle_penalty': config.gc_think_cycle_penalty,
     }
 

--- a/core/session.py
+++ b/core/session.py
@@ -75,7 +75,7 @@ def _get_connection(db_path: str) -> sqlite3.Connection:
 #
 # SCHEMA_VERSION is stored in `PRAGMA user_version`. Bump it whenever a new
 # migration is appended to _MIGRATIONS.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 def _apply_v1(cursor: sqlite3.Cursor) -> None:
@@ -194,6 +194,23 @@ def _migrate_v1_to_v2(cursor: sqlite3.Cursor) -> None:
         cursor.execute("ALTER TABLE derivation_edges DROP COLUMN confidence")
 
 
+def _migrate_v2_to_v3(cursor: sqlite3.Cursor) -> None:
+    """Backfill permanent=1 on legacy seed and core_memory rows.
+
+    Replaces the gc.protect_types config knob (also removed in this version).
+    Going forward, the only GC protection signal is the `permanent` flag —
+    seed and core_memory nodes are created with permanent=1, and this
+    migration repairs any legacy rows that predate that guarantee.
+
+    Idempotent: rows already at permanent=1 are unaffected.
+    """
+    cursor.execute(
+        "UPDATE thought_nodes SET permanent = 1 "
+        "WHERE node_type IN ('seed', 'core_memory') "
+        "AND (permanent IS NULL OR permanent = 0)"
+    )
+
+
 def _ensure_schema(db_path: str):
     """Create or upgrade the cashew schema in place.
 
@@ -217,6 +234,10 @@ def _ensure_schema(db_path: str):
 
         # v2: drop confidence (uncalibrated noise, replaced by deterministic signals).
         _migrate_v1_to_v2(cursor)
+
+        # v3: backfill permanent=1 on legacy seed/core_memory rows
+        # (replaces the dropped gc.protect_types escape hatch).
+        _migrate_v2_to_v3(cursor)
 
         cursor.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         conn.commit()

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -62,7 +62,6 @@ class SleepProtocol:
         self.gc_mode = getattr(config, 'gc_mode', 'soft')
         self.gc_threshold = getattr(config, 'gc_threshold', 0.05)
         self.gc_grace_days = getattr(config, 'gc_grace_days', 7)
-        self.gc_protect_types = getattr(config, 'gc_protect_types', ['seed', 'core_memory'])
         self.gc_think_cycle_penalty = getattr(config, 'gc_think_cycle_penalty', 1.5)
         self.events: List[SleepEvent] = []
     
@@ -862,7 +861,6 @@ class SleepProtocol:
         gc_mode = config.gc_mode
         gc_threshold = config.gc_threshold
         gc_grace_days = config.gc_grace_days
-        gc_protect_types = set(config.gc_protect_types)
         gc_think_cycle_penalty = config.gc_think_cycle_penalty
 
         if gc_mode == "off":
@@ -884,22 +882,18 @@ class SleepProtocol:
             metric = metrics[node_id]
 
             cursor.execute(
-                "SELECT node_type, source_file, last_accessed, permanent FROM thought_nodes WHERE id = ?",
+                "SELECT source_file, last_accessed, permanent FROM thought_nodes WHERE id = ?",
                 (node_id,),
             )
             row = cursor.fetchone()
             if not row:
                 continue
-            node_type, source_file, last_accessed, is_permanent = row
+            source_file, last_accessed, is_permanent = row
 
-            # Permanent nodes are protected regardless of node_type.
-            # gc_protect_types only covers a hardcoded subset (seed, core_memory)
-            # and misses derived/fact/insight/etc. that sleep promoted to permanent.
+            # Permanent nodes are protected. Seed and core_memory nodes are
+            # always created with permanent=1; the v2→v3 migration backfills
+            # any legacy rows. There is no separate node_type escape hatch.
             if is_permanent:
-                continue
-
-            # Protect configured types
-            if node_type in gc_protect_types:
                 continue
 
             # Grace period — use last_accessed (NOT created_at)

--- a/scripts/cashew_init.py
+++ b/scripts/cashew_init.py
@@ -349,7 +349,6 @@ def build_config(interactive: bool = True, config_path: str = None, global_confi
             'mode': 'soft',
             'threshold': 0.05,
             'grace_days': 7,
-            'protect_types': ['seed', 'core_memory'],
             'think_cycle_penalty': 1.5
         },
         'features': {

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -833,8 +833,23 @@ class TestGCConfigModes:
         # Hotspot nodes are now treated like any other node
         assert "hot01" in result
 
-    def test_gc_protects_configured_types(self, gc_db):
-        """Nodes with types in protect_types should survive GC."""
+    def test_gc_protects_seed_and_core_memory_via_permanent(self, gc_db):
+        """Seed and core_memory nodes survive GC because they carry permanent=1.
+
+        The previous gc.protect_types config knob was removed; protection now
+        flows through a single signal — the permanent flag — and the v2→v3
+        schema migration backfills it on legacy seed/core_memory rows.
+        """
+        # Simulate the v3 migration backfill on the test fixture.
+        conn = sqlite3.connect(gc_db)
+        c = conn.cursor()
+        c.execute(
+            "UPDATE thought_nodes SET permanent = 1 "
+            "WHERE node_type IN ('seed', 'core_memory')"
+        )
+        conn.commit()
+        conn.close()
+
         protocol = SleepProtocol(gc_db, tempfile.mktemp(suffix=".json"))
         metrics = self._make_metrics(gc_db, fitness=0.0)
 
@@ -842,7 +857,6 @@ class TestGCConfigModes:
             mock_cfg.gc_mode = "soft"
             mock_cfg.gc_threshold = 10.0
             mock_cfg.gc_grace_days = 0
-            mock_cfg.gc_protect_types = ["seed", "core_memory"]
             mock_cfg.gc_protect_hotspots = False
             mock_cfg.gc_think_cycle_penalty = 1.0
 


### PR DESCRIPTION
PR 3 of 3 in the dumb-graph cleanup arc (after #25 confidence, #26 node_type semantic filters).

Removes the `gc.protect_types` config knob and the matching `if node_type in gc_protect_types: continue` branch in GC. Protection now flows through a single signal: the `permanent` flag.

## Why

Two protection signals (node_type-based + permanent-based) is one too many. The escape hatch was defensive scaffolding for a "what if some seed node sneaks through without permanent=1" scenario that doesn't exist in practice:

- No code path in cashew creates seed-type nodes (audited `core/`, `extractors/`, `scripts/`; live brain has 0/4254 seeds).
- `core_memory` creators (`sleep.py` `promote_core_memories`) already set `permanent=1` and carry a repair pass.

So the knob was protecting a population of size zero, at the cost of a second classifier the GC has to consult.

## What

- Drop `gc.protect_types` from config (yaml, defaults, init script, `cashew_init.py`, `get_gc_config`, `SleepProtocol` attr).
- Remove the `node_type in gc_protect_types` branch from `SleepProtocol.garbage_collect`.
- Add v2→v3 migration: backfill `permanent=1` on any legacy seed/core_memory row missing it. Idempotent. Bumps `SCHEMA_VERSION`.
- Update test to assert protection via `permanent=1`.

391/391 tests green. v2→v3 migration verified on a copy of the live brain: schema 2→3, 4254 nodes preserved, 60/60 core_memory permanent.

## Follow-up

`core/sleep.py promote_core_memories` has another `node_type` read on the demotion path. Same shape of violation; left for a separate PR since this one is scoped to GC.