### PR TITLE
release v1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cashew-brain"
-version = "1.0.1"
+version = "1.1.0"
 description = "Persistent thought-graph memory for AI agents. Provides context generation, knowledge extraction, and autonomous think cycles."
 authors = [{name = "rajkripal"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Bumps version 1.0.1 → 1.1.0.

Minor bump captures the schema migration (v1 → v3) and behavior changes shipped in #21–#27:

- #21 protect permanent nodes from GC and dedup decay paths
- #22 LLM-backed dream synthesis with template fallback
- #23 sleep: n-plicate cluster merge replaces pair-wise dedup
- #24 permanence: add embeddings-integrity health check
- #25 kill confidence: replace with deterministic gates
- #26 strip node_type semantic filters: it's display-only
- #27 kill gc.protect_types: one signal for permanence, not two

The "dumb graph, smart reasoning" invariant is now enforced end-to-end. Schema migrates v1 → v3 idempotently on next session start.