### PR TITLE
extractors: ask LLM to type each statement at extraction time

### DIFF
--- a/extractors/markdown_dir.py
+++ b/extractors/markdown_dir.py
@@ -20,8 +20,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.extractors import BaseExtractor
 from extractors.utils import (
+    TYPE_TAGGING_INSTRUCTION,
     load_ignore_patterns, should_ignore, split_into_paragraphs,
-    detect_domain_from_path, parse_extraction_lines
+    detect_domain_from_path, parse_extraction_lines, parse_typed_statement,
 )
 
 logger = logging.getLogger("cashew.extractors.markdown_dir")
@@ -124,19 +125,28 @@ Return distinct knowledge statements that would be valuable to remember. Each sh
 - Free of markdown formatting
 - Focused on substantive content
 
-Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding — either it is worth a permanent node or it is not. Skip formatting, navigation, and boilerplate text."""
+Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding, either it is worth a permanent node or it is not. Skip formatting, navigation, and boilerplate text.
+
+{TYPE_TAGGING_INSTRUCTION}"""
 
         try:
             response = model_fn(prompt)
             logger.debug(f"LLM raw ({source_tag}):\n{response}\n---")
             statements = parse_extraction_lines(response)
             
-            return [{
-                "content": stmt,
-                "type": self._classify_content(stmt),
-                "domain": domain,
-                "source_file": source_tag
-            } for stmt in statements if len(stmt) > 15]
+            nodes_out = []
+            for raw in statements:
+                node_type, content = parse_typed_statement(
+                    raw, fallback=self._classify_content)
+                if len(content) <= 15:
+                    continue
+                nodes_out.append({
+                    "content": content,
+                    "type": node_type,
+                    "domain": domain,
+                    "source_file": source_tag,
+                })
+            return nodes_out
             
         except Exception as e:
             logger.warning(f"LLM extraction failed: {e}")

--- a/extractors/obsidian.py
+++ b/extractors/obsidian.py
@@ -24,9 +24,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.extractors import BaseExtractor
 from extractors.utils import (
+    TYPE_TAGGING_INSTRUCTION,
     parse_frontmatter, extract_wikilinks, load_ignore_patterns,
     should_ignore, split_into_paragraphs, detect_domain_from_path,
-    parse_extraction_lines
+    parse_extraction_lines, parse_typed_statement,
 )
 
 logger = logging.getLogger("cashew.extractors.obsidian")
@@ -138,19 +139,31 @@ Return a list of distinct knowledge statements. Each should be:
 - Actionable or memorable
 - Free of markdown formatting
 
-Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding — either it is worth a permanent node or it is not. Focus on substantive content, not formatting or structure."""
+Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding, either it is worth a permanent node or it is not. Focus on substantive content, not formatting or structure.
+
+{TYPE_TAGGING_INSTRUCTION}"""
 
         try:
             response = model_fn(prompt)
             logger.debug(f"LLM raw ({source_tag}):\n{response}\n---")
             statements = parse_extraction_lines(response)
             
-            return [{
-                "content": stmt,
-                "type": "insight",
-                "domain": domain,
-                "source_file": source_tag
-            } for stmt in statements if len(stmt) > 20]
+            nodes_out = []
+            for raw in statements:
+                # Obsidian historically defaulted untagged notes to "insight"
+                # rather than "observation"; preserve that for back-compat
+                # when the LLM does not tag.
+                node_type, content = parse_typed_statement(
+                    raw, default_type="insight")
+                if len(content) <= 20:
+                    continue
+                nodes_out.append({
+                    "content": content,
+                    "type": node_type,
+                    "domain": domain,
+                    "source_file": source_tag,
+                })
+            return nodes_out
         except Exception as e:
             logger.warning(f"LLM extraction failed: {e}")
             # Fallback to paragraph extraction

--- a/extractors/sessions.py
+++ b/extractors/sessions.py
@@ -21,7 +21,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.extractors import BaseExtractor
-from extractors.utils import load_ignore_patterns, parse_extraction_lines, should_ignore
+from extractors.utils import (
+    TYPE_TAGGING_INSTRUCTION,
+    load_ignore_patterns,
+    parse_extraction_lines,
+    parse_typed_statement,
+    should_ignore,
+)
 
 logger = logging.getLogger("cashew.extractors.sessions")
 
@@ -174,7 +180,9 @@ Return distinct knowledge statements that would be valuable to remember. Each sh
 - Actionable or memorable for future reference
 - Written in a clear, standalone format
 
-Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding — either it is worth a permanent node or it is not. Skip pleasantries and routine interactions."""
+Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding, either it is worth a permanent node or it is not. Skip pleasantries and routine interactions.
+
+{TYPE_TAGGING_INSTRUCTION}"""
 
         try:
             response = model_fn(prompt)
@@ -191,13 +199,20 @@ Before emitting each statement, ask yourself: should this node exist in the grap
                 if ts:
                     batch_referent_time = ts  # last non-empty wins
 
-            return [{
-                "content": stmt,
-                "type": self._classify_statement(stmt),
-                "domain": "conversations",
-                "source_file": f"extractor:session:{session_id}",
-                "referent_time": batch_referent_time,
-            } for stmt in statements if len(stmt) > 20]
+            nodes_out = []
+            for raw in statements:
+                node_type, content = parse_typed_statement(
+                    raw, fallback=self._classify_statement)
+                if len(content) <= 20:
+                    continue
+                nodes_out.append({
+                    "content": content,
+                    "type": node_type,
+                    "domain": "conversations",
+                    "source_file": f"extractor:session:{session_id}",
+                    "referent_time": batch_referent_time,
+                })
+            return nodes_out
             
         except Exception as e:
             logger.warning(f"LLM extraction failed for {session_id}: {e}")

--- a/extractors/utils.py
+++ b/extractors/utils.py
@@ -7,7 +7,49 @@ import fnmatch
 import re
 import yaml
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+# Issue #12: LLMs tag statements at extraction time with one of these six
+# types. The parser strips the prefix and returns the type alongside the
+# statement text. Untagged lines fall back to a per-extractor classifier so
+# older prompts and odd LLM output still produce typed nodes.
+TYPED_STATEMENT_RE = re.compile(
+    r'^\[(fact|observation|insight|decision|commitment|belief)\]\s+(.+)$',
+    re.IGNORECASE,
+)
+
+TYPE_TAGGING_INSTRUCTION = (
+    "Output one statement per line. Prefix each with a type tag.\n"
+    "Types: [fact] concrete verifiable context-independent info | "
+    "[observation] something noticed in context, may be situational | "
+    "[insight] non-obvious connection requiring reasoning | "
+    "[decision] choice made between alternatives | "
+    "[commitment] stated intention or planned action | "
+    "[belief] held opinion, not objectively verifiable\n"
+    "When uncertain, use [observation].\n"
+    "Output typed statements only, one per line."
+)
+
+
+def parse_typed_statement(
+    line: str,
+    fallback: Optional[Callable[[str], str]] = None,
+    default_type: str = "observation",
+) -> Tuple[str, str]:
+    """Parse a possibly-typed statement line.
+
+    Tagged lines look like ``[insight] some text`` (case-insensitive). When
+    matched, the prefix is stripped and the lowercased type is returned. When
+    not matched, ``fallback(line)`` is consulted (if given) — otherwise
+    ``default_type`` is used and the line is returned unchanged.
+    """
+    m = TYPED_STATEMENT_RE.match(line)
+    if m:
+        return m.group(1).lower(), m.group(2).strip()
+    if fallback is not None:
+        return fallback(line), line
+    return default_type, line
 
 
 def parse_frontmatter(content: str) -> tuple[Dict[str, Any], str]:

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -17,7 +17,7 @@ from core.extractors import ExtractorRegistry
 from extractors import ObsidianExtractor, SessionExtractor, MarkdownDirExtractor
 from extractors.utils import (
     parse_frontmatter, extract_wikilinks, load_ignore_patterns,
-    should_ignore, split_into_paragraphs
+    should_ignore, split_into_paragraphs, parse_typed_statement,
 )
 
 
@@ -107,6 +107,70 @@ This is a longer paragraph that should be included."""
         self.assertTrue(any("paragraph two" in p for p in paragraphs))
         self.assertTrue(any("longer paragraph" in p for p in paragraphs))
         self.assertFalse(any("Short." in p for p in paragraphs))
+
+
+class TestParseTypedStatement(unittest.TestCase):
+    """Issue #12 — LLM-side type tagging on extracted statements."""
+
+    def test_tagged_basic(self):
+        t, c = parse_typed_statement("[insight] connection between X and Y")
+        self.assertEqual(t, "insight")
+        self.assertEqual(c, "connection between X and Y")
+
+    def test_tagged_all_six_types(self):
+        for tag in ["fact", "observation", "insight",
+                    "decision", "commitment", "belief"]:
+            t, c = parse_typed_statement(f"[{tag}] body text here")
+            self.assertEqual(t, tag)
+            self.assertEqual(c, "body text here")
+
+    def test_tagged_case_insensitive(self):
+        t, c = parse_typed_statement("[INSIGHT] uppercase tag")
+        self.assertEqual(t, "insight")
+        self.assertEqual(c, "uppercase tag")
+
+        t, c = parse_typed_statement("[Decision] mixed case")
+        self.assertEqual(t, "decision")
+        self.assertEqual(c, "mixed case")
+
+    def test_untagged_fallback_callable(self):
+        fallback = lambda line: "decision"
+        t, c = parse_typed_statement("we will ship this", fallback=fallback)
+        self.assertEqual(t, "decision")
+        self.assertEqual(c, "we will ship this")
+
+    def test_untagged_default_type(self):
+        t, c = parse_typed_statement("naked statement")
+        self.assertEqual(t, "observation")
+        self.assertEqual(c, "naked statement")
+
+    def test_untagged_custom_default(self):
+        t, c = parse_typed_statement("naked", default_type="insight")
+        self.assertEqual(t, "insight")
+        self.assertEqual(c, "naked")
+
+    def test_unknown_type_falls_back(self):
+        # Unknown bracketed prefix is not a recognized type — must fall back.
+        t, c = parse_typed_statement("[random] some text",
+                                     fallback=lambda _: "fact")
+        self.assertEqual(t, "fact")
+        self.assertEqual(c, "[random] some text")
+
+    def test_no_space_after_bracket_falls_back(self):
+        # Prefix without separating whitespace does not match.
+        t, c = parse_typed_statement("[insight]nospace")
+        self.assertEqual(t, "observation")
+        self.assertEqual(c, "[insight]nospace")
+
+    def test_malformed_unclosed_bracket(self):
+        t, c = parse_typed_statement("[insight some text")
+        self.assertEqual(t, "observation")
+        self.assertEqual(c, "[insight some text")
+
+    def test_tagged_strips_inner_whitespace(self):
+        t, c = parse_typed_statement("[fact]   padded body   ")
+        self.assertEqual(t, "fact")
+        self.assertEqual(c, "padded body")
 
 
 class TestObsidianExtractor(unittest.TestCase):


### PR DESCRIPTION
Closes #12.

Credit to @fauxreigner-mb for the proposal and the parser sketch.

Today the line-list extractors (sessions, markdown, obsidian) ask the LLM for a flat list of statements, then run a keyword classifier to pick a `node_type` post hoc. Keyword matching is brittle: "we will ship X" is a commitment, not just a future-tense fact, and "I think" can mean belief or speculation depending on context the classifier can't see.

Move typing into the LLM call. Each prompt now ends with the six-type menu (`fact` / `observation` / `insight` / `decision` / `commitment` / `belief`) and tells the model to prefix every line with `[type]`. A small parser in `extractors/utils.py` strips the prefix; if the model omits the tag, we fall back to the existing keyword classifier (or `"insight"` for obsidian, which was its prior hardcoded default), so older prompts and odd LLM output still produce typed nodes.

## Scope notes
- JSON path in `core/session.py` already gets `type` from a structured field, no change needed there.
- `node_type` is display-only after #26/#27 — this PR doesn't touch any gating, just improves the quality of the displayed type.

Tests: 10 new parser cases (case-insensitive match, all six tags, fallback paths, malformed prefixes). Full suite 401 green.