### PR TITLE
dev-docs: em-dash cleanup in DESIGN.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,19 @@
-# CLAUDE.md — Cashew Developer Guide
+# CLAUDE.md: Cashew Developer Guide
 
-Cashew is a thought-graph memory engine for AI agents. It stores knowledge as nodes in a SQLite graph, connects them with edges, and retrieves relevant context via recursive BFS over organic graph structure. Everything lives in one SQLite file — no external servers, no separate indexes.
+Cashew is a thought-graph memory engine for AI agents. It stores knowledge as nodes in a SQLite graph, connects them with edges, and retrieves relevant context via recursive BFS over organic graph structure. Everything lives in one SQLite file. No external servers, no separate indexes.
 
 **IMPORTANT**: Cashew does NOT call LLMs directly. It is purely the BRAIN (storage + retrieval + structure). The PROCESSOR (LLM) is external and provided by the orchestrator (OpenClaw) via `model_fn` parameters.
 
 ## Architecture
 
 ```
-scripts/cashew_context.py  — Main CLI entry point (context, extract, think, sleep, stats)
-cashew_cli.py              — Secondary CLI (init, install-crons, ingest)
-core/                      — Engine modules
-core/extractors.py         — Extractor plugin interface (BaseExtractor, ExtractorRegistry)
-extractors/                — Built-in source extractors (obsidian, sessions, markdown)
-extractors/utils.py        — Shared extractor utilities (frontmatter, wikilinks, ignore patterns)
-integration/               — OpenClaw bridges
+scripts/cashew_context.py  : Main CLI entry point (context, extract, think, sleep, stats)
+cashew_cli.py              : Secondary CLI (init, install-crons, ingest)
+core/                      : Engine modules
+core/extractors.py         : Extractor plugin interface (BaseExtractor, ExtractorRegistry)
+extractors/                : Built-in source extractors (obsidian, sessions, markdown)
+extractors/utils.py        : Shared extractor utilities (frontmatter, wikilinks, ignore patterns)
+integration/               : OpenClaw bridges
 ```
 
 ### Core Modules
@@ -22,7 +22,7 @@ integration/               — OpenClaw bridges
 |--------|---------|
 | `config.py` | YAML config loading with env var expansion. Global `config` singleton. |
 | `embeddings.py` | Sentence-transformer embeddings (all-MiniLM-L6-v2). sqlite-vec virtual table for O(log N) search. `search()`, `check_novelty()`, `embed_text()`. |
-| `retrieval.py` | `retrieve_recursive_bfs()` — seeds via sqlite-vec, BFS graph walk, per-hop scoring. The sole retrieval method. |
+| `retrieval.py` | `retrieve_recursive_bfs()`: seeds via sqlite-vec, BFS graph walk, per-hop scoring. The sole retrieval method. |
 | `context.py` | Composes retrieval results into formatted context strings for LLM consumption. |
 | `session.py` | Session lifecycle: `start_session()`, `end_session()`, `think_cycle()`, `tension_detection()`. |
 | `sleep.py` | Deep consolidation: cross-linking, decay, deduplication, core memory promotion. Runs daily. |
@@ -56,27 +56,27 @@ All extractors: use `model_fn` for LLM extraction when available, fall back to p
 
 SQLite with 3 tables + 1 virtual table:
 
-- **`thought_nodes`** — Knowledge nodes (id, content, node_type, domain, access_count, decayed, permanent, tags)
-- **`derivation_edges`** — Relationships (parent_id, child_id, weight)
-- **`embeddings`** — Vector embeddings per node (node_id, vector as BLOB, model name)
-- **`vec_embeddings`** — sqlite-vec virtual table for O(log N) nearest neighbor search (node_id, embedding float[384], cosine distance)
+- **`thought_nodes`**: Knowledge nodes (id, content, node_type, domain, access_count, decayed, permanent, tags)
+- **`derivation_edges`**: Relationships (parent_id, child_id, weight)
+- **`embeddings`**: Vector embeddings per node (node_id, vector as BLOB, model name)
+- **`vec_embeddings`**: sqlite-vec virtual table for O(log N) nearest neighbor search (node_id, embedding float[384], cosine distance)
 
 ### Key Columns
 
-- `domain` — Classifies who the knowledge belongs to. Configurable via config.yaml.
-- `node_type` — One of: fact, observation, insight, decision, belief, derived, meta, core_memory, cross_link. Display/informational only — never used in filter or scoring logic.
-- `decayed` — 0 or 1. Decayed nodes are excluded from retrieval but kept in DB.
-- `permanent` — 0 or 1. Permanent nodes are immune to decay.
-- `access_count` — Integer. How many times this node has been retrieved. Deterministic signal for think/tension gates and decay.
-- `tags` — Comma-separated tags (e.g., `vault:private` for privacy classification).
+- `domain`: Classifies who the knowledge belongs to. Configurable via config.yaml.
+- `node_type`: One of: fact, observation, insight, decision, belief, derived, meta, core_memory, cross_link. Display/informational only, never used in filter or scoring logic.
+- `decayed`: 0 or 1. Decayed nodes are excluded from retrieval but kept in DB.
+- `permanent`: 0 or 1. Permanent nodes are immune to decay.
+- `access_count`: Integer. How many times this node has been retrieved. Deterministic signal for think/tension gates and decay.
+- `tags`: Comma-separated tags (e.g., `vault:private` for privacy classification).
 
 ## Retrieval: Recursive BFS
 
 The sole retrieval method. No hotspots, no hierarchy, no DFS.
 
-1. **Seed selection** — Embed query, find top-k nearest nodes via `vec_embeddings MATCH` (O(log N) with sqlite-vec, brute-force fallback)
-2. **BFS traversal** — From seeds, explore graph neighbors up to `max_depth` hops. At each hop, score neighbors by cosine similarity, keep top `picks_per_hop`.
-3. **Final ranking** — All candidates scored and sorted by similarity.
+1. **Seed selection**: Embed query, find top-k nearest nodes via `vec_embeddings MATCH` (O(log N) with sqlite-vec, brute-force fallback)
+2. **BFS traversal**: From seeds, explore graph neighbors up to `max_depth` hops. At each hop, score neighbors by cosine similarity, keep top `picks_per_hop`.
+3. **Final ranking**: All candidates scored and sorted by similarity.
 
 Parameters: `n_seeds=5`, `picks_per_hop=3`, `max_depth=3`.
 
@@ -107,47 +107,47 @@ Before any node is inserted, `check_novelty()` checks if content is too similar 
 - Threshold: 0.82 cosine similarity (calibrated for MiniLM-L6 where true dupes peak at 0.85-0.90)
 - Above threshold → reject (duplicate)
 - Below threshold → accept (novel)
-- Fails open — if embedding fails, the node gets through
+- Fails open: if embedding fails, the node gets through
 
 ## Sleep Cycle
 
 Periodic background consolidation (`core/sleep.py`):
-- **Decay** — Node fitness decays over time. Low-fitness nodes get `decayed=1`.
-- **Cross-linking** — Finds semantically similar nodes across domains, creates edges.
-- **Deduplication** — Merges near-identical nodes.
-- **Core memory promotion** — Frequently accessed nodes get promoted.
-- **Think cycle penalty** — Think-cycle-generated nodes face 1.5x higher decay threshold.
+- **Decay**: Node fitness decays over time. Low-fitness nodes get `decayed=1`.
+- **Cross-linking**: Finds semantically similar nodes across domains, creates edges.
+- **Deduplication**: Merges near-identical nodes.
+- **Core memory promotion**: Frequently accessed nodes get promoted.
+- **Think cycle penalty**: Think-cycle-generated nodes face 1.5x higher decay threshold.
 
 No hotspot creation, no clustering, no hierarchy maintenance. The graph self-organizes through cross-linking and decay.
 
 ## Configuration
 
 `config.yaml` at project root. Key settings:
-- `database.path` — SQLite DB location
-- `domains.user` / `domains.ai` — Domain names
-- `models.embedding.name` — Embedding model
-- `performance.*` — Token budgets, thresholds, top-k
+- `database.path`: SQLite DB location
+- `domains.user` / `domains.ai`: Domain names
+- `models.embedding.name`: Embedding model
+- `performance.*`: Token budgets, thresholds, top-k
 
 Environment variables override config: `${VAR:-default}` syntax supported in YAML.
 
 ## Conventions
 
-- **Node IDs** — 12-char hex strings from content hash (`hashlib.sha256(content)[:12]`)
-- **Timestamps** — ISO 8601 strings
-- **Edges are untyped** — Topology carries the signal, not labels. In an early ablation (34 seed nodes, religion-debate test set, Claude Sonnet, 12 think cycles per method), structured graphs scored 9/10 on qualitative signatures vs 2/10 for random-edge graphs — topology matters. But an edge-label-swap variant (flipping supports↔contradicts, questions↔derived_from) produced 2.3x more conclusions than the correctly labeled version (84 vs 36), suggesting typed semantics act as constraints that narrow LLM exploration rather than guides that improve it. Edges are stored as pure topology; the LLM infers relationships from node content at read time. Ablation was small and single-domain — design-directional, not a benchmark.
-- **Embeddings** — 384-dimensional numpy arrays stored as BLOBs (and in vec_embeddings as float[384])
-- **Never delete nodes** — set `decayed=1` instead. The graph is append-mostly.
-- **Always embed new nodes** — every node must have rows in both `embeddings` and `vec_embeddings`.
-- **Domain assignment** — every node must have a domain. Use `config.get_user_domain()` and `config.get_ai_domain()`.
-- **No hardcoded paths** — use `config.get_db_path()` or accept `--db` CLI arg.
-- **No direct LLM calls** — Accept `model_fn` parameters, never create LLM clients internally.
+- **Node IDs**: 12-char hex strings from content hash (`hashlib.sha256(content)[:12]`)
+- **Timestamps**: ISO 8601 strings
+- **Edges are untyped**: Topology carries the signal, not labels. In an early ablation (34 seed nodes, religion-debate test set, Claude Sonnet, 12 think cycles per method), structured graphs scored 9/10 on qualitative signatures vs 2/10 for random-edge graphs (topology matters). But an edge-label-swap variant (flipping supports↔contradicts, questions↔derived_from) produced 2.3x more conclusions than the correctly labeled version (84 vs 36), suggesting typed semantics act as constraints that narrow LLM exploration rather than guides that improve it. Edges are stored as pure topology; the LLM infers relationships from node content at read time. Ablation was small and single-domain, design-directional rather than a benchmark.
+- **Embeddings**: 384-dimensional numpy arrays stored as BLOBs (and in vec_embeddings as float[384])
+- **Never delete nodes**: set `decayed=1` instead. The graph is append-mostly.
+- **Always embed new nodes**: every node must have rows in both `embeddings` and `vec_embeddings`.
+- **Domain assignment**: every node must have a domain. Use `config.get_user_domain()` and `config.get_ai_domain()`.
+- **No hardcoded paths**: use `config.get_db_path()` or accept `--db` CLI arg.
+- **No direct LLM calls**: Accept `model_fn` parameters, never create LLM clients internally.
 
 ## External LLM Pattern
 
 Functions that accept `model_fn`:
-- `extract_from_conversation(model_fn=None)` — Uses heuristic extraction if None
-- `run_think_cycle(model_fn=None)` — Skips think cycles if None
-- `run_sleep_cycle(model_fn=None)` — Uses fallback summaries if None
+- `extract_from_conversation(model_fn=None)`: Uses heuristic extraction if None
+- `run_think_cycle(model_fn=None)`: Skips think cycles if None
+- `run_sleep_cycle(model_fn=None)`: Uses fallback summaries if None
 
 The CLI auto-discovers a running OpenClaw gateway from `~/.openclaw/openclaw.json` and routes LLM calls through it via the `/v1/chat/completions` endpoint (OpenAI-compatible). No API keys or provider-specific code needed.
 
@@ -169,7 +169,7 @@ Graph: 2160 nodes, 3499 edges. Types: 499 fact, 449 insight, 426 observation.
 === END CONTEXT ===
 ```
 
-Always use `cashew context --hints "..."` or `generate_session_context()` — never assemble prompts from raw node lists.
+Always use `cashew context --hints "..."` or `generate_session_context()`. Never assemble prompts from raw node lists.
 
 ## Privacy
 
@@ -188,8 +188,8 @@ cashew_context.py context --hints "bunny engineering principles best practices t
 
 ### Testing
 - **End-to-end tests over unit tests.** Don't write 5 tests for the same helper with varying inputs. Each test should exercise a REAL user flow from start to finish.
-- **Tests ship with the code — not optional, not afterthought.** No PR without tests.
-- **When fixing a bug, write the test that catches it FIRST.** The test is more important than the fix — it prevents regressions forever.
+- **Tests ship with the code, not optional, not an afterthought.** No PR without tests.
+- **When fixing a bug, write the test that catches it FIRST.** The test is more important than the fix, and it prevents regressions forever.
 - **Failures must be LOUD.** Silent failures (returning 0 results, empty arrays, swallowed exceptions) are worse than crashes. If something goes wrong, print why and exit non-zero.
 - **Test isolation is mandatory.** Use `tmp_path`, clean up after yourself, never touch production data from tests.
 
@@ -203,9 +203,9 @@ cashew_context.py context --hints "bunny engineering principles best practices t
 
 ### Architecture
 - **Dumb graph, smart reasoning layer.** The graph stores connections. The LLM reasons about meaning. Don't put intelligence in the graph structure.
-- **No edge semantics.** Typed edges were ablation-tested (topology scored 9/10 vs 2/10 random; label-swap produced 2.3x more conclusions, suggesting semantics constrain rather than guide) and dropped. No reintroductions under new names — topology stays, labels do not.
+- **No edge semantics.** Typed edges were ablation-tested (topology scored 9/10 vs 2/10 random; label-swap produced 2.3x more conclusions, suggesting semantics constrain rather than guide) and dropped. No reintroductions under new names: topology stays, labels do not.
 - **No temporal scaffolding.** Timestamps are node metadata, not graph structure.
-- **Fractal simplicity.** Simple rules, emergent behavior. If a feature adds structural complexity, the burden of proof is on the complexity.
+- **Fractal simplicity.** Favor simple rules that produce emergent behavior. If a feature adds structural complexity, the burden of proof is on the complexity.
 - **Organic decay is the forgetting mechanism.** Don't build structures that fight decay.
 - **The philosophy layer is load-bearing architecture, not optional.** Without it cashew is just a memory tool; with it each instance becomes distinct.
 - **Discovery tool, not prediction engine.** Surface connections you didn't know existed, then human decides what to do. One hop, human in loop immediately.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,12 +1,12 @@
-# cashew — Design Document
+# cashew Design Document
 
 ## 1. Problem Statement
 
 Current AI systems (and humans) produce conclusions but discard the derivation path. Chain-of-thought exists during inference but is ephemeral. Knowledge graphs store what is known but not how it was derived. No existing system combines:
 
-1. **Persistent derivation chains** — every thought linked to its parents
-2. **Emergent self-organization** — organic structure from cross-linking and decay  
-3. **Auditability as a first-class operation** — "why do I believe X?" is a query, not introspection
+1. **Persistent derivation chains**: every thought linked to its parents
+2. **Emergent self-organization**: organic structure from cross-linking and decay  
+3. **Auditability as a first-class operation**: "why do I believe X?" is a query, not introspection
 
 ### Core Question
 If you store reasoning with its full derivation path, can a system meaningfully audit and self-correct its own beliefs while exhibiting emergent insights?
@@ -15,7 +15,7 @@ If you store reasoning with its full derivation path, can a system meaningfully 
 | System | What it does | Gap |
 |--------|-------------|-----|
 | Knowledge Graphs | Stores entities + relationships | No derivation tracking |
-| Chain-of-thought (LLMs) | Step-by-step reasoning | Ephemeral — gone after response |
+| Chain-of-thought (LLMs) | Step-by-step reasoning | Ephemeral, gone after response |
 | RAG (LlamaIndex etc.) | Retrieves context for generation | Flat memory, no graph structure |
 | MemGPT | Persistent LLM memory | No derivation graph |
 | Argument mapping (Kialo) | Structured debate trees | Human-curated, not emergent |
@@ -113,7 +113,7 @@ CREATE VIRTUAL TABLE vec_embeddings USING vec0(
 
 Cashew is embeddable as a library: downstream consumers (e.g. `hermes-cashew`) layer their own tables on top of cashew's database. This section defines what cashew owns and what extension points consumers can rely on.
 
-**Cashew-owned tables** — schema is managed by `core.db.ensure_schema()`, may change across cashew versions under the rules below:
+**Cashew-owned tables**: schema is managed by `core.db.ensure_schema()`, may change across cashew versions under the rules below:
 
 - `thought_nodes`
 - `derivation_edges`
@@ -134,7 +134,7 @@ Cashew is embeddable as a library: downstream consumers (e.g. `hermes-cashew`) l
 
 **Extension points for downstream consumers**
 
-- Consumers may create their own tables (use a clear prefix, e.g. `hermes_*`) — cashew will not touch them.
+- Consumers may create their own tables (use a clear prefix, e.g. `hermes_*`). Cashew will not touch them.
 - Consumers may add columns prefixed `ext_` to cashew-owned tables. Cashew will never introduce an `ext_`-prefixed column.
 - Consumers should call `ensure_schema(db)` before running their own migrations, then branch on `get_schema_version(db)` to decide whether their own migration ladder needs to run.
 
@@ -149,15 +149,15 @@ if get_schema_version(db_path) >= 1:
 ```
 
 ### Node Types (Current Implementation)
-- **fact** — Data points and factual observations
-- **observation** — Personal experiences and direct observations
-- **insight** — Derived understanding from think cycles and analysis
-- **decision** — Specific choices and their reasoning
-- **belief** — Core principles and values
-- **derived** — LLM-generated hypotheses and conclusions
-- **meta** — Self-analysis and system reflection
-- **core_memory** — High-importance, frequently accessed knowledge
-- **cross_link** — Connections between disparate knowledge domains
+- **fact**: Data points and factual observations
+- **observation**: Personal experiences and direct observations
+- **insight**: Derived understanding from think cycles and analysis
+- **decision**: Specific choices and their reasoning
+- **belief**: Core principles and values
+- **derived**: LLM-generated hypotheses and conclusions
+- **meta**: Self-analysis and system reflection
+- **core_memory**: High-importance, frequently accessed knowledge
+- **cross_link**: Connections between disparate knowledge domains
 
 ---
 
@@ -295,10 +295,10 @@ def run_sleep_cycle():
 
 ### Power Law Properties
 The graph exhibits natural power law behavior:
-- **Preferential attachment** — New thoughts connect to high-connectivity hubs
-- **Self-organized criticality** — Sleep cycles restructure accumulated knowledge
-- **Fractal structure** — Same patterns at all scales
-- **Emergent hierarchy** — Organization from simple connection rules
+- **Preferential attachment**: New thoughts connect to high-connectivity hubs
+- **Self-organized criticality**: Sleep cycles restructure accumulated knowledge
+- **Fractal structure**: Same patterns at all scales
+- **Emergent hierarchy**: Organization from simple connection rules
 
 ### Organic Retrieval Scaling
 Traditional RAG systems use flat vector search (O(N) comparisons). cashew uses sqlite-vec for O(log N) seed selection followed by recursive BFS graph traversal, achieving efficient retrieval while preserving semantic relationships through organic connectivity.
@@ -311,12 +311,12 @@ Cross-domain context synthesis produces insights that connect disparate knowledg
 ## 8. Success Criteria
 
 ### Phase 1: Personal Thought Graph ✅ ACHIEVED
-1. ✅ **why(node) produces non-obvious derivation chains** — tracing reveals unplanned connections
-2. ✅ **audit() catches real circular reasoning** — cycle detection works
-3. ✅ **Organic connectivity emerges** — cross-linking creates natural pathways without synthetic structure  
-4. ✅ **Think cycles produce cross-domain synthesis** — connections across knowledge areas
-5. ✅ **Graph exhibits preferential attachment** — high-connectivity nodes via cross-linking  
-6. ✅ **sqlite-vec retrieval scales** — O(log N) seed selection + BFS traversal
+1. ✅ **why(node) produces non-obvious derivation chains**: tracing reveals unplanned connections
+2. ✅ **audit() catches real circular reasoning**: cycle detection works
+3. ✅ **Organic connectivity emerges**: cross-linking creates natural pathways without synthetic structure  
+4. ✅ **Think cycles produce cross-domain synthesis**: connections across knowledge areas
+5. ✅ **Graph exhibits preferential attachment**: high-connectivity nodes via cross-linking  
+6. ✅ **sqlite-vec retrieval scales**: O(log N) seed selection + BFS traversal
 
 ### Phase 2: Multi-Domain Knowledge ✅ ACHIEVED  
 1. ✅ Multiple domains (user/ai) co-exist in single graph
@@ -383,7 +383,7 @@ cashew/
 ## 10. Sleep Protocol Details
 
 ### Purpose
-Connect isolated thought chains, deduplicate, garbage collect, and consolidate — mirrors neural sleep consolidation.
+Connect isolated thought chains, deduplicate, garbage collect, and consolidate. Mirrors neural sleep consolidation.
 
 ### Operations (run periodically or daily):
 
@@ -405,26 +405,26 @@ Connect isolated thought chains, deduplicate, garbage collect, and consolidate �
 ## 11. Engineering Principles
 
 ### Testing Philosophy
-"I don't want an unfalsifiable system." — Every behavior gets a test.
+"I don't want an unfalsifiable system." Every behavior gets a test.
 
 **Test categories:**
-1. **Unit tests** — Every function, every edge case
+1. **Unit tests**: Every function, every edge case
    - Graph store: CRUD, dedup, edge creation, integrity
    - Traversal: why() correctness, audit() cycle detection
    - Sleep: fitness scoring, decay behavior, promotion logic
 
-2. **Behavioral tests** — Does the system do what we claim?
+2. **Behavioral tests**: Does the system do what we claim?
    - Derivation: why(A) includes correct parent chain
    - Contradiction detection: audit() flags conflicts
    - Sleep preservation: high-value nodes survive GC
    - Cross-linking: independent clusters connect
 
-3. **Emergence tests** — Can we measure emergent properties?  
+3. **Emergence tests**: Can we measure emergent properties?  
    - Power laws: degree distribution vs random graphs
    - Clustering: modularity scores vs random networks
    - Insight generation: think cycle novelty assessment
 
-4. **Regression tests** — Don't break what works
+4. **Regression tests**: Don't break what works
    - Every bug gets test before fix
    - Reproducible experiments (seeded randomness)
 
@@ -433,7 +433,7 @@ Connect isolated thought chains, deduplicate, garbage collect, and consolidate �
 ### Code Standards
 - Type hints everywhere
 - Docstrings on public functions  
-- No magic numbers — constants named and documented
+- No magic numbers, constants named and documented
 - Git hygiene: specific `git add`, one feature per PR
 
 ---
@@ -443,18 +443,18 @@ Connect isolated thought chains, deduplicate, garbage collect, and consolidate �
 ### Graph Statistics (Author's Personal Graph)
 - **3,064 thought nodes** across 9 distinct types (fact, insight, observation, etc.)
 - **6,122 derivation edges** with weight and confidence
-- **Domain separation** — user/ai domains in single graph
-- **288/288 tests passing** — comprehensive coverage
-- **sqlite-vec integration** — O(log N) vector search
+- **Domain separation**: user/ai domains in single graph
+- **288/288 tests passing**: comprehensive coverage
+- **sqlite-vec integration**: O(log N) vector search
 
 *Note: These statistics reflect the author's personal knowledge graph as of April 2026. New users start with an empty graph.*
 
 ### Proven Capabilities  
-1. **BFS retrieval at scale** — 2000+ nodes with sub-second response
-2. **Organic graph evolution** — cross-linking creates natural structure
-3. **Sleep cycles maintain quality** — decay prevents bloat, dedup prevents redundancy
-4. **Zero infrastructure** — single SQLite file, no external servers
-5. **Dashboard visualization** — real-time graph rendering
+1. **BFS retrieval at scale**: 2000+ nodes with sub-second response
+2. **Organic graph evolution**: cross-linking creates natural structure
+3. **Sleep cycles maintain quality**: decay prevents bloat, dedup prevents redundancy
+4. **Zero infrastructure**: single SQLite file, no external servers
+5. **Dashboard visualization**: real-time graph rendering
 
 ### In Production Use
 - Daily context retrieval for agent sessions
@@ -469,17 +469,17 @@ Connect isolated thought chains, deduplicate, garbage collect, and consolidate �
 **Done = You look at the graph and it surprises you.**
 
 Concrete achievements (April 2026):
-1. ✅ Graph scaled — 3,064 nodes, 6,122 edges from organic growth (author's personal graph)
-2. ✅ sqlite-vec integration — O(log N) vector search with cosine distance
-3. ✅ BFS retrieval — recursive traversal replaces hierarchical hotspots  
-4. ✅ Sleep cycle evolution — cross-linking, decay, dedup without clustering
-5. ✅ Think cycles via session.py — function-based, not class-based
-6. ✅ Test coverage — 288/288 tests passing after major refactor
+1. ✅ Graph scaled to 3,064 nodes, 6,122 edges from organic growth (author's personal graph)
+2. ✅ sqlite-vec integration: O(log N) vector search with cosine distance
+3. ✅ BFS retrieval: recursive traversal replaces hierarchical hotspots  
+4. ✅ Sleep cycle evolution: cross-linking, decay, dedup without clustering
+5. ✅ Think cycles via session.py, function-based not class-based
+6. ✅ Test coverage: 288/288 tests passing after major refactor
 
 ### Key Learning: Foundation Model AS Reasoning Engine
-Don't build Python reasoning modules — the LLM reasoning over structured graph context IS the think cycle. Only tooling needed is graph plumbing (retrieve nodes, insert results).
+Don't build Python reasoning modules. The LLM reasoning over structured graph context IS the think cycle. Only tooling needed is graph plumbing (retrieve nodes, insert results).
 
 ### Philosophy Confirmed  
-- **Orphans are unsolved problems, not bugs** — Don't force connections
-- **Honest attempts > curve fitting** — Genuine relationships matter more than graph density
-- **Emergent structure validates the architecture** — Power laws and organic connectivity prove self-organization
+- **Orphans are unsolved problems, not bugs**: Don't force connections
+- **Honest attempts > curve fitting**: Genuine relationships matter more than graph density
+- **Emergent structure validates the architecture**: Power laws and organic connectivity prove self-organization


### PR DESCRIPTION
## Summary
- Replace all em dashes in DESIGN.md (51) and CLAUDE.md (49) per the no-em-dash rule.
- Bullet patterns like `**Foo** — Desc` become `**Foo**: Desc`. Sentence-internal dashes rephrased with comma, colon, period, or parens.
- Fold the "Simple rules, emergent behavior." fragment in CLAUDE.md into the Fractal simplicity bullet so it reads as a directive rather than a standalone aphorism.

Operating principle: reads honestly, not maximalist scrub. X.Y. dev-doc shorthand and ablation-result phrasing left intact where they were already doing real work.

## Test plan
- [ ] Skim both files rendered, confirm meaning unchanged
- [ ] `grep '—' DESIGN.md CLAUDE.md` returns nothing

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>