### PR TITLE
docs/research-notes.md: clarify these are external research notes

### DIFF
--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -1,5 +1,7 @@
 # Research Notes - Session Integration Best Practices
 
+> **Scope note:** these are research notes from external papers and production-system writeups reviewed during cashew's design phase. They describe patterns from the literature (GraphRAG, ConversationKGMemory, hybrid retrieval), **not** what cashew actually implements. Specifically, things like learned ranking weights, temporal-decay coefficients in the score function, and TF-IDF fallbacks are paper concepts, not cashew behavior. For the implemented retrieval algorithm see [`docs/architecture.md`](architecture.md), and for the survival/decay model see PHILOSOPHY.md §9.
+
 ## 1. Knowledge Graph Retrieval Ranking
 
 ### Key Insights from Production Systems


### PR DESCRIPTION
## Summary

Audit finding: research-notes.md reads like a description of cashew's actual ranking, but it describes patterns from external papers (Microsoft GraphRAG, ConversationKGMemory, hybrid retrieval). Things like learned ranking weights and a `temporal_decay` term in the score function are paper concepts, not cashew behavior. A reader could easily assume cashew ranks by `alpha*embedding + beta*graph + gamma*temporal_decay`, which it does not.

## Options considered

- (a) Add a scope header at the top clarifying these are external research notes, pointing to architecture.md for the actual algorithm.
- (b) Delete the file entirely.

Went with (a) since the literature pointers still have design value and the framing fix is one paragraph. Easy to delete in a follow-up if you'd rather.

## Test plan

- [ ] Top-of-file note makes it clear this isn't a spec for cashew
- [ ] Pointers to architecture.md and PHILOSOPHY.md §9 land readers on the implemented behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)