### PR TITLE
docs/build-plan.md: mark as historical, annotate phases as shipped

### DIFF
--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -1,8 +1,10 @@
 # Cashew Brain — Build Plan
 
+> **Status:** historical. This was the original Q1 2026 build plan. All six phases shipped between March and April 2026 (initial migration and core modules landed 2026-03-08, extractor plugin interface 2026-03-18, and Phase 6 integration via the OpenClaw skill plus later Claude Code skill packages). The doc is preserved as the design intent it was written under; for current behavior see DESIGN.md, PHILOSOPHY.md, and docs/architecture.md.
+
 ## Build Order (each phase is testable before moving to next)
 
-### Phase 1: Migration + Schema
+### Phase 1: Migration + Schema  ✅ Shipped 2026-03
 **Build:** Migration script for brain graph → new architecture
 **What it does:**
 - Copy current graph.db → brain.db (backup original)
@@ -26,7 +28,7 @@ python3 -m pytest tests/test_migration.py
 
 ---
 
-### Phase 2: Embedding Layer
+### Phase 2: Embedding Layer  ✅ Shipped 2026-03-08 (`core/embeddings.py`)
 **Build:** Embed all nodes, store embeddings, similarity search
 **What it does:**
 - Embed every node's content using sentence-transformers (local, free)
@@ -54,7 +56,7 @@ python3 -m pytest tests/test_embeddings.py
 
 ---
 
-### Phase 3: Hybrid Retrieval
+### Phase 3: Hybrid Retrieval  ✅ Shipped 2026-03-08 (`core/retrieval.py`; later replaced by recursive BFS, see docs/architecture.md)
 **Build:** Graph-walk expansion on top of embedding search
 **What it does:**
 - `cashew.retrieve(query, k=10)` =
@@ -91,7 +93,7 @@ def test_retrieval_vs_memory_search():
 
 ---
 
-### Phase 4: Knowledge Extraction
+### Phase 4: Knowledge Extraction  ✅ Shipped 2026-03 (`core/extractors.py` + plugin interface in 5c94ca7, 2026-03-18)
 **Build:** Extract nodes from conversations as ISOLATED fragments
 **What it does:**
 - `cashew.extract(conversation_text)` →
@@ -122,7 +124,7 @@ python3 -m pytest tests/test_extraction.py
 
 ---
 
-### Phase 5: Think Cycle Integration
+### Phase 5: Think Cycle Integration  ✅ Shipped 2026-03 (`core/sleep.py`, `core/session.py` think cycles)
 **Build:** Autonomous think cycles on heartbeat
 **What it does:**
 - `cashew.think()` →
@@ -148,7 +150,7 @@ python3 -m pytest tests/test_think_cycle.py
 
 ---
 
-### Phase 6: Integration Hooks (THE HARD PART)
+### Phase 6: Integration Hooks (THE HARD PART)  ✅ Shipped 2026-04 (skill-based path, packaged as the OpenClaw and Claude Code skills)
 **Build:** Wire cashew into OpenClaw's session lifecycle
 **What it does:**
 - On session start: retrieve relevant context, inject into system prompt


### PR DESCRIPTION
## Summary

Audit finding: build-plan.md describes a Phase-1 migration that already shipped, but reads in present tense as if it were the active roadmap.

Went with option (b) from the brief: annotate in place rather than move. Less destructive, preserves git history and any inbound links.

Changes:
- Top-of-file note: this was the original Q1 2026 plan, all six phases shipped, pointers to DESIGN.md / PHILOSOPHY.md / docs/architecture.md for current state.
- Each phase header gets a `✅ Shipped <date>` marker tied to the core/ module where the code lives.
- Phase 3 note flags that the original hybrid-retrieval design was later replaced by recursive-BFS retrieval.

## Date verification

From `git log` on the relevant files:
- 2026-03-08: initial migration + core modules (embeddings, retrieval, session)
- 2026-03-18: extractor plugin interface + configurable GC policy (5c94ca7)
- 2026-04: skill-based integration packages

## Test plan

- [ ] Top-of-file note makes the historical scope clear
- [ ] Phase markers are accurate against git log

🤖 Generated with [Claude Code](https://claude.com/claude-code)