### PR TITLE
docs: replace em dashes in persistence-layer.md and build-plan.md

### DIFF
--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -1,4 +1,4 @@
-# Cashew Brain — Build Plan
+# Cashew Brain: Build Plan
 
 > **Status:** historical. This was the original Q1 2026 build plan. All six phases shipped between March and April 2026 (initial migration and core modules landed 2026-03-08, extractor plugin interface 2026-03-18, and Phase 6 integration via the OpenClaw skill plus later Claude Code skill packages). The doc is preserved as the design intent it was written under; for current behavior see DESIGN.md, PHILOSOPHY.md, and docs/architecture.md.
 
@@ -100,7 +100,7 @@ def test_retrieval_vs_memory_search():
   1. LLM call: "Extract key decisions, observations, beliefs, insights from this conversation"
   2. For each: create node with type, domain, content
   3. Embed new node (for later retrieval)
-  4. Nodes land ISOLATED — no edges created yet
+  4. Nodes land ISOLATED (no edges created yet)
   5. Flag contradictions for sleep cycle
 - Returns list of new node IDs
 - **Edge creation happens during sleep, not here** (original design: daytime = fragments, sleep = consolidation)
@@ -118,7 +118,7 @@ python3 -m pytest tests/test_extraction.py
 
 **Decision (from original design):**
 - Extract every N minutes if there's stuff to extract. Lightweight scan. Don't wait for compaction.
-- Edge creation happens during SLEEP, not extraction. New nodes land isolated during the day. Sleep rewires — finds nearest neighbors, creates edges, runs think cycles on new clusters, GCs noise. Biologically honest: daytime = fragments, sleep = consolidation.
+- Edge creation happens during SLEEP, not extraction. New nodes land isolated during the day. Sleep rewires: finds nearest neighbors, creates edges, runs think cycles on new clusters, GCs noise. Biologically honest: daytime = fragments, sleep = consolidation.
 
 **Files:** `core/extraction.py`, `tests/test_extraction.py`
 
@@ -166,8 +166,8 @@ python3 -m pytest tests/test_think_cycle.py
 5. Can I add a custom tool (like `memory_search` but `cashew_retrieve`)?
 
 **Two approaches:**
-- **A: Skill-based** — I explicitly call `cashew retrieve "query"` when I need context. Simple, testable, no OpenClaw core changes needed. I control when it's used.
-- **B: Hook-based** — Automatically runs on every session start/end. More powerful, but requires OpenClaw integration. Harder to test. Risk of breaking things.
+- **A: Skill-based**. I explicitly call `cashew retrieve "query"` when I need context. Simple, testable, no OpenClaw core changes needed. I control when it's used.
+- **B: Hook-based**. Automatically runs on every session start/end. More powerful, but requires OpenClaw integration. Harder to test. Risk of breaking things.
 
 **Decision (from original design):** Option A. Skill-based. Period. Don't get "comfortable" with A and then creep to B. A is the design. I call cashew explicitly when I need context.
 
@@ -190,9 +190,9 @@ python3 -m pytest tests/test_think_cycle.py
 - Graph growth over N conversations (does it stay healthy or explode?)
 
 ### Validation Tests (human eval, periodic)
-- "Does the retrieved context feel more relevant?" — User scores 1-5
-- "Did the think cycle produce genuine insights?" — User confirms/denies
-- "Am I responding better with cashew context?" — qualitative over 2 weeks
+- "Does the retrieved context feel more relevant?" (User scores 1-5)
+- "Did the think cycle produce genuine insights?" (User confirms/denies)
+- "Am I responding better with cashew context?" (qualitative over 2 weeks)
 
 ### Regression Tests
 - Response quality shouldn't degrade during transition
@@ -202,11 +202,11 @@ python3 -m pytest tests/test_think_cycle.py
 ---
 
 ## Dependencies
-- `sentence-transformers` — local embeddings (pip install)
-- `numpy` — vector operations (already installed?)
-- `anthropic` — LLM calls for extraction/think cycles (already installed)
-- `sqlite3` — graph storage (stdlib)
-- `pytest` — testing (pip install)
+- `sentence-transformers`: local embeddings (pip install)
+- `numpy`: vector operations (already installed?)
+- `anthropic`: LLM calls for extraction/think cycles (already installed)
+- `sqlite3`: graph storage (stdlib)
+- `pytest`: testing (pip install)
 
 ## Timeline Estimate
 - Phase 1 (migration): 1 session

--- a/docs/persistence-layer.md
+++ b/docs/persistence-layer.md
@@ -1,19 +1,19 @@
-# Cashew Persistence Layer — Architecture
+# Cashew Persistence Layer: Architecture
 
 ## Problem
 Personal assistants have session amnesia. Current memory system:
-- `MEMORY.md` — flat prose, manually curated
-- `memory/YYYY-MM-DD.md` — daily logs, append-only
-- `memory_search` — keyword/embedding search over flat files
+- `MEMORY.md`: flat prose, manually curated
+- `memory/YYYY-MM-DD.md`: daily logs, append-only
+- `memory_search`: keyword/embedding search over flat files
 
 This is a filing cabinet. It stores WHAT was said but not WHY, has no derivation chains, can't update beliefs (only append), and can't discover cross-domain patterns.
 
 ## Solution
 Replace flat memory with a thought graph that:
-1. **Stores reasoning, not just facts** — every node traces back through edges to what produced it
-2. **Updates beliefs via contradiction** — new info creates edges to existing beliefs, think cycles resolve tensions
-3. **Surfaces relevant context** — hybrid retrieval (embeddings + graph walk) finds the right 5-10 nodes for any conversation
-4. **Generates insights autonomously** — think cycles on heartbeats discover patterns the agent hasn't articulated
+1. **Stores reasoning, not just facts**: every node traces back through edges to what produced it
+2. **Updates beliefs via contradiction**: new info creates edges to existing beliefs, think cycles resolve tensions
+3. **Surfaces relevant context**: hybrid retrieval (embeddings + graph walk) finds the right 5-10 nodes for any conversation
+4. **Generates insights autonomously**: think cycles on heartbeats discover patterns the agent hasn't articulated
 
 ## Architecture
 
@@ -42,15 +42,15 @@ CREATE TABLE edges (
 ```
 
 ### Node Types
-- **observation** — something that happened ("The user's manager gave performance feedback")
-- **belief** — an interpreted pattern ("User goes silent when struggling")
-- **decision** — a commitment made ("Will send manager update by Friday")
-- **insight** — a derived connection ("Silent periods correlate with avoidance of hard conversations")
-- **fact** — objective information ("User works in tech")
+- **observation**: something that happened ("The user's manager gave performance feedback")
+- **belief**: an interpreted pattern ("User goes silent when struggling")
+- **decision**: a commitment made ("Will send manager update by Friday")
+- **insight**: a derived connection ("Silent periods correlate with avoidance of hard conversations")
+- **fact**: objective information ("User works in tech")
 
 ### Integration Points
 
-#### 1. Session Start — Context Injection
+#### 1. Session Start: Context Injection
 ```
 User message arrives
 → Embed message
@@ -61,7 +61,7 @@ User message arrives
 → Update last_accessed on retrieved nodes
 ```
 
-#### 2. Session End — Knowledge Extraction
+#### 2. Session End: Knowledge Extraction
 ```
 Conversation ends (or compaction triggers)
 → Summarize key decisions, new info, emotional beats
@@ -70,7 +70,7 @@ Conversation ends (or compaction triggers)
 → If new info contradicts existing belief → flag for think cycle
 ```
 
-#### 3. Heartbeat — Generative Think Cycles
+#### 3. Heartbeat: Generative Think Cycles
 ```
 Heartbeat fires, nothing urgent
 → Pick underexplored cluster (low access_count, high edge density)
@@ -87,7 +87,7 @@ New node N contradicts existing node E (detected by LLM during extraction)
 → Queue cluster {N, E, neighbors(E)} for next think cycle
 → Think cycle produces resolution node R
 → Edge from E to R records the supersession
-→ E is not deleted — it's part of the derivation chain (organic decay handles eventual removal if E stops being touched)
+→ E is not deleted; it's part of the derivation chain (organic decay handles eventual removal if E stops being touched)
 ```
 
 ### Retrieval: Hybrid Approach


### PR DESCRIPTION
Replaces all em dashes in two docs that didn't get covered in the earlier dev-docs cleanup.

Was originally PR #37 stacked on PR #36 (build-plan-archive branch). When PR #36 squash-merged with branch deletion, GitHub auto-closed PR #37. This is the same content rebased onto main.

- persistence-layer.md: 17 em dashes replaced
- build-plan.md: 13 em dashes replaced

Same rules as PR #32 cleanup — colons, commas, periods, parens, or rephrasing depending on context.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>