### PR TITLE
extraction: derive node-type taxonomy from config, kill drift

### DIFF
--- a/core/extractors.py
+++ b/core/extractors.py
@@ -41,7 +41,9 @@ class BaseExtractor(ABC):
         Returns:
             List of node dicts, each with keys:
                 - content (str, required): The knowledge statement
-                - type (str, required): Node type (belief, insight, decision, observation, fact)
+                - type (str, required): Node type. Must be one of the names
+                  defined in core.config (config.node_type_names). The full
+                  set is the canonical taxonomy, do not hand-roll it.
                 - domain (str, optional): Domain classification
                 - source_file (str, optional): Source identifier
         """

--- a/extractors/utils.py
+++ b/extractors/utils.py
@@ -10,23 +10,38 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 
-# Issue #12: LLMs tag statements at extraction time with one of these six
-# types. The parser strips the prefix and returns the type alongside the
-# statement text. Untagged lines fall back to a per-extractor classifier so
-# older prompts and odd LLM output still produce typed nodes.
+# LLMs tag statements at extraction time with one of the configured node
+# types. The regex is built from core.config so adding a type in config
+# automatically makes it valid here. Untagged lines fall back to a
+# per-extractor classifier so older prompts still produce typed nodes.
+from core.config import config as _cashew_config
+
+_extraction_types = list(_cashew_config._node_type_map.keys())
 TYPED_STATEMENT_RE = re.compile(
-    r'^\[(fact|observation|insight|decision|commitment|belief)\]\s+(.+)$',
+    r'^\[(' + '|'.join(re.escape(t) for t in _extraction_types) + r')\]\s+(.+)$',
     re.IGNORECASE,
 )
 
+# Description text is richer here than the one-liners in config because
+# extractors emit format-strict prompts. Keep this hand-tuned, but the
+# *set* of types is derived from config above. If config grows a new
+# type, add a one-line description here in the same order.
+_TYPE_DESCRIPTIONS = {
+    "fact": "concrete verifiable context-independent info",
+    "observation": "something noticed in context, may be situational",
+    "insight": "non-obvious connection requiring reasoning",
+    "decision": "choice made between alternatives",
+    "commitment": "stated intention or planned action",
+    "belief": "held opinion, not objectively verifiable",
+}
+
+_lines = [
+    f"[{t}] {_TYPE_DESCRIPTIONS.get(t, _cashew_config._node_type_map.get(t, ''))}"
+    for t in _extraction_types
+]
 TYPE_TAGGING_INSTRUCTION = (
     "Output one statement per line. Prefix each with a type tag.\n"
-    "Types: [fact] concrete verifiable context-independent info | "
-    "[observation] something noticed in context, may be situational | "
-    "[insight] non-obvious connection requiring reasoning | "
-    "[decision] choice made between alternatives | "
-    "[commitment] stated intention or planned action | "
-    "[belief] held opinion, not objectively verifiable\n"
+    "Types: " + " | ".join(_lines) + "\n"
     "When uncertain, use [observation].\n"
     "Output typed statements only, one per line."
 )

--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -927,7 +927,7 @@ def _migrate_extract_file(db_path: str, content: str, filename: str, session_id:
     import hashlib
     from datetime import datetime, timezone
     from core.embeddings import ensure_schema, embed_nodes
-    from core.config import get_ai_domain, get_user_domain
+    from core.config import get_ai_domain, get_user_domain, config
 
     ensure_schema(db_path)
 
@@ -935,22 +935,25 @@ def _migrate_extract_file(db_path: str, content: str, filename: str, session_id:
     if model_fn is None:
         print(f"   📝 CLI extraction - using heuristic method (LLM extraction available via claude_code backend)")
         return _migrate_extract_heuristic(db_path, content, filename, session_id)
-    
+
     print(f"   🤖 LLM extraction - using smart extraction via claude_code backend")
-    
-    # Use LLM to extract semantic knowledge
-    prompt = f"""Extract knowledge from this document into structured facts, insights, observations, and decisions.
+
+    # Type taxonomy comes from config so the prompt stays in sync with the
+    # canonical node_type list. Hand-rolling the list here previously caused
+    # the "commitment" type to be silently absent for months despite being
+    # defined in core.config defaults.
+    prompt = f"""Extract knowledge from this document.
 
 For each item, output a JSON object on its own line with fields:
-- "content": the knowledge statement (clear, self-contained, pattern-level — not raw quotes)
-- "type": one of "fact", "observation", "insight", "decision", "belief"
+- "content": the knowledge statement (clear, self-contained, pattern-level, not raw quotes)
+- "type": one of the types below
 
-Focus on:
-- Decisions and their reasoning
-- Patterns and behavioral observations  
-- Insights that connect multiple ideas
-- Facts about people, projects, relationships
-- Beliefs and preferences
+Valid types:
+{config.node_type_prompt_fragment}
+
+Be aggressive about capturing commitments. Anything anyone said they
+would do, including operational commitments by the assistant itself,
+must be tagged type=commitment.
 
 Skip: transient logistics, greetings, trivial statements.
 Output ONLY JSON lines, no other text.

--- a/tests/test_node_type_dry.py
+++ b/tests/test_node_type_dry.py
@@ -1,0 +1,66 @@
+"""Guard against drift between core.config node types and the extractor
+prompts/regex that consume them.
+
+Background: scripts/cashew_context.py once hand-rolled its extraction
+prompt with a hardcoded list ("fact, observation, insight, decision,
+belief") that omitted "commitment" even though the type was defined in
+config. Result: zero commitment-typed nodes for months. These tests fail
+loudly if anything reintroduces that drift.
+"""
+
+import re
+
+from core.config import config
+from extractors.utils import TYPED_STATEMENT_RE, TYPE_TAGGING_INSTRUCTION
+
+
+def test_typed_statement_re_matches_every_configured_type():
+    """The extractor regex must accept every type in core.config."""
+    for type_name in config._node_type_map.keys():
+        sample = f"[{type_name}] some statement text"
+        m = TYPED_STATEMENT_RE.match(sample)
+        assert m is not None, f"regex rejected configured type {type_name!r}"
+        assert m.group(1).lower() == type_name
+
+
+def test_type_tagging_instruction_mentions_every_configured_type():
+    """The prompt fragment must list every type so the LLM can use it."""
+    for type_name in config._node_type_map.keys():
+        token = f"[{type_name}]"
+        assert token in TYPE_TAGGING_INSTRUCTION, (
+            f"TYPE_TAGGING_INSTRUCTION omits {token}; "
+            f"add a description and rebuild the prompt fragment from config."
+        )
+
+
+def test_node_type_prompt_fragment_includes_commitment_when_configured():
+    """commitment is a first-class type. If config has it, the helper must
+    surface it. Guards against regressions in config.node_type_prompt_fragment."""
+    if "commitment" not in config._node_type_map:
+        return  # config genuinely doesn't define it, nothing to guard
+    fragment = config.node_type_prompt_fragment
+    assert '"commitment"' in fragment
+
+
+def test_validate_node_type_accepts_commitment_when_configured():
+    if "commitment" not in config._node_type_map:
+        return
+    assert config.validate_node_type("commitment") == "commitment"
+
+
+def test_migration_extraction_prompt_uses_config_helper():
+    """scripts/cashew_context.py's migration prompt should not hardcode the
+    type list. Specifically, the historical drift string must be gone."""
+    from pathlib import Path
+    src = Path(__file__).parent.parent / "scripts" / "cashew_context.py"
+    text = src.read_text()
+    # Old hand-rolled list that dropped commitment
+    assert 'one of "fact", "observation", "insight", "decision", "belief"' not in text, (
+        "scripts/cashew_context.py reintroduced the hand-rolled type list. "
+        "Use config.node_type_prompt_fragment instead."
+    )
+    # New helper must be referenced
+    assert "node_type_prompt_fragment" in text, (
+        "scripts/cashew_context.py extraction prompt should reference "
+        "config.node_type_prompt_fragment."
+    )


### PR DESCRIPTION
## Summary
- The migration extraction prompt in `scripts/cashew_context.py` hand-rolled its own type list and silently omitted `commitment`. Switch it to `config.node_type_prompt_fragment` so it stays in sync.
- `extractors/utils.py` now derives `TYPED_STATEMENT_RE` and `TYPE_TAGGING_INSTRUCTION` from `config._node_type_map`. New types in config are accepted and prompted for automatically.
- `core/extractors.py` docstring stops hand-rolling the type list, points at config.
- New `tests/test_node_type_dry.py` (5 tests) fails loudly on any future drift between config and the extractor surfaces.

## Why
A user-facing bug: documents extracted via the migration path produced zero `commitment`-typed nodes regardless of content, because the prompt didn't list "commitment" as a valid type even though config defined it. Same shape of bug could re-appear for any future type added to config but missed in a hand-rolled list.

## Test plan
- [x] `pytest tests/` — 406 passed (was 401, +5 new regression tests)
- [x] New tests verify: (a) `TYPED_STATEMENT_RE` matches every configured type, (b) `TYPE_TAGGING_INSTRUCTION` lists every configured type, (c) `node_type_prompt_fragment` includes commitment when configured, (d) `validate_node_type` accepts commitment, (e) the historical hand-rolled string in `cashew_context.py` is gone and the helper is referenced.