### PR TITLE
embedding service: honor CASHEW_EMBEDDING_MODEL, dynamic dim

### DIFF
--- a/core/daemon.py
+++ b/core/daemon.py
@@ -72,15 +72,15 @@ def _handle(req: dict) -> dict:
     if op == "embed":
         # Handled directly by the local backend so we don't recurse through
         # the service (which would try the daemon and loop forever).
-        from .embedding_service import EMBEDDING_DIM
+        backend = _local_backend()
         text = req.get("text", "")
         if not text or not text.strip():
-            return {"ok": True, "result": [0.0] * EMBEDDING_DIM}
-        vec = _local_backend().encode([text])[0]
+            return {"ok": True, "result": [0.0] * backend.dim}
+        vec = backend.encode([text])[0]
         return {"ok": True, "result": vec.tolist()}
 
     if op == "embed_batch":
-        from .embedding_service import EMBEDDING_DIM
+        backend = _local_backend()
         texts = req.get("texts") or []
         if not isinstance(texts, list):
             return {"ok": False, "error": "'texts' must be a list"}
@@ -88,9 +88,9 @@ def _handle(req: dict) -> dict:
             return {"ok": True, "result": []}
         nonempty_idx = [i for i, t in enumerate(texts) if t and t.strip()]
         nonempty_texts = [texts[i] for i in nonempty_idx]
-        out = [[0.0] * EMBEDDING_DIM for _ in texts]
+        out = [[0.0] * backend.dim for _ in texts]
         if nonempty_texts:
-            vecs = _local_backend().encode(nonempty_texts)
+            vecs = backend.encode(nonempty_texts)
             for i, vec in zip(nonempty_idx, vecs):
                 out[i] = vec.tolist()
         return {"ok": True, "result": out}

--- a/core/embedding_service.py
+++ b/core/embedding_service.py
@@ -13,6 +13,11 @@ plus the cache, and every consumer benefits transparently.
 
 The service is deliberately stateless at the module level — no hidden
 singletons. Inject a `Backend` protocol for tests.
+
+Model selection: the default service reads `CASHEW_EMBEDDING_MODEL` via
+`core.config.get_embedding_model()`. The dimension is derived from the loaded
+model on first encode, not hardcoded — swapping models from MiniLM (384) to
+gte-large (1024) just works.
 """
 
 from __future__ import annotations
@@ -23,8 +28,40 @@ import numpy as np
 
 from .embedding_cache import EmbeddingCache
 
-DEFAULT_MODEL = "all-MiniLM-L6-v2"
+# Legacy constant kept for back-compat with code that imports it directly
+# (daemon, tests, permanence). It reflects MiniLM-L6-v2's dimension. New code
+# should use the service's `dim` property instead.
 EMBEDDING_DIM = 384
+
+
+def _resolve_default_model() -> str:
+    """Resolve the configured embedding model name. Falls back to MiniLM if
+    config is unavailable (e.g. tests that import this module standalone)."""
+    try:
+        from .config import get_embedding_model
+        return get_embedding_model()
+    except Exception:
+        return "all-MiniLM-L6-v2"
+
+
+# Kept for back-compat with imports — but tests/daemon now read this lazily.
+DEFAULT_MODEL = "all-MiniLM-L6-v2"
+
+# Best-effort known dims so we can size zero vectors correctly even before
+# the model loads. If a model isn't listed, we lazily probe it at first use.
+_KNOWN_DIMS = {
+    "all-MiniLM-L6-v2": 384,
+    "sentence-transformers/all-MiniLM-L6-v2": 384,
+    "all-mpnet-base-v2": 768,
+    "sentence-transformers/all-mpnet-base-v2": 768,
+    "thenlper/gte-large": 1024,
+    "thenlper/gte-base": 768,
+    "thenlper/gte-small": 384,
+    "BAAI/bge-large-en-v1.5": 1024,
+    "BAAI/bge-base-en-v1.5": 768,
+    "BAAI/bge-small-en-v1.5": 384,
+}
+
 
 TextLike = Union[str, Sequence[str]]
 
@@ -38,40 +75,75 @@ class Backend(Protocol):
 class LocalBackend:
     """In-process sentence-transformer. Lazy-loads to keep import cheap."""
 
-    def __init__(self, model_name: str = DEFAULT_MODEL) -> None:
-        self.model_name = model_name
+    def __init__(self, model_name: Optional[str] = None) -> None:
+        self.model_name = model_name or _resolve_default_model()
         self._model = None
+        self._dim: Optional[int] = _KNOWN_DIMS.get(self.model_name)
 
-    def encode(self, texts: List[str]) -> np.ndarray:
-        if not texts:
-            return np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+    @property
+    def dim(self) -> int:
+        """Embedding dimension for this backend's model. Loads the model if
+        the dim isn't known a priori."""
+        if self._dim is None:
+            self._ensure_model()
+            self._dim = self._model.get_sentence_embedding_dimension()
+        return self._dim
+
+    def _ensure_model(self) -> None:
         if self._model is None:
             from sentence_transformers import SentenceTransformer
             self._model = SentenceTransformer(self.model_name)
+
+    def encode(self, texts: List[str]) -> np.ndarray:
+        if not texts:
+            return np.zeros((0, self.dim), dtype=np.float32)
+        self._ensure_model()
+        # Update dim from the actual loaded model (authoritative).
+        self._dim = self._model.get_sentence_embedding_dimension()
         return self._model.encode(texts, convert_to_numpy=True).astype(np.float32)
 
 
 class DaemonBackend:
     """Talks to the warm daemon over its unix socket. Returns empty array on
-    any transport failure so the service can fall back cleanly."""
+    any transport failure so the service can fall back cleanly.
 
-    def __init__(self, socket_path: Optional[str] = None) -> None:
+    Note: the daemon serves whatever model it was started with. Callers that
+    set CASHEW_EMBEDDING_MODEL to override should ensure the daemon is
+    restarted, otherwise the daemon's model wins for daemon-served requests.
+    """
+
+    def __init__(
+        self,
+        socket_path: Optional[str] = None,
+        model_name: Optional[str] = None,
+        dim: Optional[int] = None,
+    ) -> None:
         self.socket_path = socket_path
+        self.model_name = model_name or _resolve_default_model()
+        self._dim = dim if dim is not None else _KNOWN_DIMS.get(self.model_name, EMBEDDING_DIM)
+
+    @property
+    def dim(self) -> int:
+        return self._dim
 
     def encode(self, texts: List[str]) -> np.ndarray:
         if not texts:
-            return np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+            return np.zeros((0, self.dim), dtype=np.float32)
         from .daemon import client_request
         resp = client_request(
             {"op": "embed_batch", "texts": list(texts)},
             socket_path=self.socket_path,
         )
         if resp is None or not resp.get("ok"):
-            return np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+            return np.zeros((0, self.dim), dtype=np.float32)
         vectors = resp.get("result") or []
         if len(vectors) != len(texts):
-            return np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
-        return np.asarray(vectors, dtype=np.float32)
+            return np.zeros((0, self.dim), dtype=np.float32)
+        arr = np.asarray(vectors, dtype=np.float32)
+        # Authoritative: trust the daemon's actual output dim.
+        if arr.ndim == 2 and arr.shape[1] > 0:
+            self._dim = arr.shape[1]
+        return arr
 
 
 class EmbeddingService:
@@ -79,15 +151,25 @@ class EmbeddingService:
 
     def __init__(
         self,
-        model: str = DEFAULT_MODEL,
+        model: Optional[str] = None,
         cache: Optional[EmbeddingCache] = None,
         daemon: Optional[Backend] = None,
         local: Optional[Backend] = None,
     ) -> None:
-        self.model = model
+        self.model = model or _resolve_default_model()
         self.cache = cache if cache is not None else EmbeddingCache()
-        self.daemon = daemon if daemon is not None else DaemonBackend()
-        self.local = local if local is not None else LocalBackend(model)
+        self.daemon = daemon if daemon is not None else DaemonBackend(model_name=self.model)
+        self.local = local if local is not None else LocalBackend(self.model)
+
+    @property
+    def dim(self) -> int:
+        """Embedding dimension. Prefers the local backend's known/probed dim,
+        falls back to the daemon's, then to the legacy constant."""
+        for b in (self.local, self.daemon):
+            d = getattr(b, "dim", None)
+            if d:
+                return d
+        return _KNOWN_DIMS.get(self.model, EMBEDDING_DIM)
 
     def embed(self, text: TextLike) -> Union[List[float], List[List[float]]]:
         """Embed one string or a list of strings.
@@ -106,29 +188,34 @@ class EmbeddingService:
         """Same as embed() but returns an (N, D) ndarray for numeric callers."""
         vectors = self._embed_batch(list(texts))
         if not vectors:
-            return np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+            return np.zeros((0, self.dim), dtype=np.float32)
         return np.stack(vectors)
 
     def _embed_batch(self, texts: List[str]) -> List[np.ndarray]:
         if not texts:
             return []
-        # Empty strings -> zero vectors, never hit model/cache.
+        # Empty strings -> zero vectors (correct dim), never hit model/cache.
         results: List[Optional[np.ndarray]] = [None] * len(texts)
         nonempty_idx: List[int] = []
         nonempty_texts: List[str] = []
         for i, t in enumerate(texts):
             if not t or not t.strip():
-                results[i] = np.zeros(EMBEDDING_DIM, dtype=np.float32)
+                results[i] = np.zeros(self.dim, dtype=np.float32)
             else:
                 nonempty_idx.append(i)
                 nonempty_texts.append(t)
 
         if nonempty_texts:
             cached = self.cache.get_many(self.model, nonempty_texts)
+            # Defensive: prior versions of the bug could have cached a
+            # wrong-dim vector under this model's namespace (e.g. MiniLM 384
+            # stored under "thenlper/gte-large"). Treat dim-mismatched hits
+            # as misses so they get recomputed and overwritten on put_many.
+            expected_dim = self.dim
             miss_idx: List[int] = []
             miss_texts: List[str] = []
             for pos, vec in enumerate(cached):
-                if vec is not None:
+                if vec is not None and vec.shape[0] == expected_dim:
                     results[nonempty_idx[pos]] = vec
                 else:
                     miss_idx.append(pos)
@@ -142,7 +229,16 @@ class EmbeddingService:
                     to_store.append((nonempty_texts[pos], vec))
                 self.cache.put_many(self.model, to_store)
 
-        # mypy/humans: no Nones remain
+        # Fix up any zero-vector slots whose dim doesn't match the now-known
+        # model dim (rare: dim was unknown when we placed zeros, then a real
+        # encode revealed it).
+        actual_dim = self.dim
+        for i, r in enumerate(results):
+            if r is not None and r.shape[0] != actual_dim:
+                # Only zeros could have wrong dim here; resize them.
+                if not np.any(r):
+                    results[i] = np.zeros(actual_dim, dtype=np.float32)
+
         return [r for r in results if r is not None]
 
     def _compute(self, texts: List[str]) -> List[np.ndarray]:

--- a/core/embedding_service.py
+++ b/core/embedding_service.py
@@ -63,6 +63,23 @@ _KNOWN_DIMS = {
 }
 
 
+def resolve_embedding_dim(model_name: Optional[str] = None) -> int:
+    """Resolve the embedding dimension for ``model_name``.
+
+    Checks the known-dims table first (cheap, no model load). Falls back to
+    constructing a LocalBackend and probing the loaded SentenceTransformer.
+    Used by callers (e.g. sqlite-vec table creation in core/embeddings.py)
+    that need the dim before any embed call has happened. Single source of
+    truth: keep this in sync with _KNOWN_DIMS rather than duplicating the
+    table elsewhere.
+    """
+    name = model_name or _resolve_default_model()
+    if name in _KNOWN_DIMS:
+        return _KNOWN_DIMS[name]
+    # Unknown model — probe by loading it. LocalBackend.dim handles this.
+    return LocalBackend(name).dim
+
+
 TextLike = Union[str, Sequence[str]]
 
 

--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -184,10 +184,10 @@ def embed_nodes(db_path: str, batch_size: int = 100) -> dict:
                 vector_bytes = embeddings[j].astype(np.float32).tobytes()
                 
                 cursor.execute("""
-                    INSERT OR REPLACE INTO embeddings 
+                    INSERT OR REPLACE INTO embeddings
                     (node_id, vector, model, updated_at)
                     VALUES (?, ?, ?, ?)
-                """, (node_id, vector_bytes, "all-MiniLM-L6-v2", datetime.now().isoformat()))
+                """, (node_id, vector_bytes, service.model, datetime.now().isoformat()))
                 
                 # Dual-write to vec_embeddings for O(log N) search
                 if has_vec:

--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -59,6 +59,36 @@ def _has_vec_table(conn: sqlite3.Connection) -> bool:
         return False
 
 
+def _vec_table_dim(conn: sqlite3.Connection) -> Optional[int]:
+    """Parse the dim out of an existing vec_embeddings table's CREATE SQL.
+    Returns None if the table doesn't exist or the dim can't be parsed."""
+    try:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='vec_embeddings'"
+        ).fetchone()
+        if not row or not row[0]:
+            return None
+        import re
+        m = re.search(r"float\[(\d+)\]", row[0])
+        return int(m.group(1)) if m else None
+    except Exception:
+        return None
+
+
+def _vec_table_dim_matches(conn: sqlite3.Connection, expected_dim: int) -> bool:
+    """True iff vec_embeddings exists and its dim equals ``expected_dim``.
+    A False here is the signal to skip vec dual-write / vec search and fall
+    back to brute force (avoids cryptic sqlite-vec errors on dim mismatch)."""
+    actual = _vec_table_dim(conn)
+    return actual is not None and actual == expected_dim
+
+
+def _current_embedding_dim() -> int:
+    """Resolve the embedding dim for the currently configured model."""
+    from .embedding_service import resolve_embedding_dim
+    return resolve_embedding_dim()
+
+
 def _ensure_embeddings_table(db_path: str):
     """Ensure the embeddings table exists with the correct schema"""
     conn = sqlite3.connect(db_path)
@@ -103,7 +133,13 @@ def _ensure_embeddings_table(db_path: str):
     if 'reasoning' not in de_columns:
         cursor.execute("ALTER TABLE derivation_edges ADD COLUMN reasoning TEXT")
     
-    # sqlite-vec virtual table for O(log N) nearest neighbor search
+    # sqlite-vec virtual table for O(log N) nearest neighbor search.
+    # Dim comes from the configured embedding model (CASHEW_EMBEDDING_MODEL).
+    # If an existing vec table was created at a different dim (e.g. legacy
+    # 384-dim table now opened under gte-large/1024), we leave it alone and
+    # let dual-write/vec-search detect the mismatch and fall back to brute
+    # force. Recreating would silently drop existing vectors. See module
+    # docstring on dim mismatch handling.
     if _vec_available:
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='vec_embeddings'")
         if cursor.fetchone() is None:
@@ -111,13 +147,29 @@ def _ensure_embeddings_table(db_path: str):
                 conn.enable_load_extension(True)
                 sqlite_vec.load(conn)
                 conn.enable_load_extension(False)
-                cursor.execute("""
-                    CREATE VIRTUAL TABLE IF NOT EXISTS vec_embeddings 
-                    USING vec0(node_id text primary key, embedding float[384] distance_metric=cosine)
+                dim = _current_embedding_dim()
+                cursor.execute(f"""
+                    CREATE VIRTUAL TABLE IF NOT EXISTS vec_embeddings
+                    USING vec0(node_id text primary key, embedding float[{dim}] distance_metric=cosine)
                 """)
-                logging.info("Created vec_embeddings virtual table")
+                logging.info(f"Created vec_embeddings virtual table (dim={dim})")
             except Exception as e:
                 logging.warning(f"Could not create vec_embeddings table: {e}")
+        else:
+            # Existing table — warn (once per call) on dim mismatch so the
+            # silent brute-force fallback isn't fully invisible.
+            existing_dim = _vec_table_dim(conn)
+            try:
+                expected_dim = _current_embedding_dim()
+            except Exception:
+                expected_dim = None
+            if existing_dim is not None and expected_dim is not None and existing_dim != expected_dim:
+                logging.warning(
+                    f"vec_embeddings dim mismatch: table is float[{existing_dim}], "
+                    f"current model produces dim {expected_dim}. Vector index will "
+                    f"be skipped; falling back to brute-force search. To rebuild, "
+                    f"drop vec_embeddings and re-run backfill_vec_index()."
+                )
     
     conn.commit()
     conn.close()
@@ -177,9 +229,15 @@ def embed_nodes(db_path: str, batch_size: int = 100) -> dict:
         # Embed the batch
         try:
             embeddings = service.embed_np(batch_texts)
-            
-            # Store embeddings
-            has_vec = _vec_available and _has_vec_table(conn)
+
+            # Store embeddings. Only dual-write when the vec table's dim
+            # matches what we're about to insert — otherwise sqlite-vec will
+            # reject the bytes and we'd just spam warnings.
+            has_vec = (
+                _vec_available
+                and _has_vec_table(conn)
+                and _vec_table_dim_matches(conn, service.dim)
+            )
             for j, (node_id, content) in enumerate(batch):
                 vector_bytes = embeddings[j].astype(np.float32).tobytes()
                 
@@ -256,8 +314,14 @@ def search(db_path: str, query: str, top_k: int = 10) -> List[Tuple[str, float]]
     
     conn = sqlite3.connect(db_path)
     
-    # Try sqlite-vec first (O(log N))
-    if _vec_available and _has_vec_table(conn):
+    # Try sqlite-vec first (O(log N)). Skip when the vec table's dim doesn't
+    # match the query embedding (legacy 384-dim table under a 1024-dim model,
+    # etc.) — that case falls through to brute force on the raw embeddings.
+    if (
+        _vec_available
+        and _has_vec_table(conn)
+        and _vec_table_dim_matches(conn, query_embedding.shape[0])
+    ):
         try:
             _load_vec(conn)
             cursor = conn.cursor()
@@ -366,7 +430,11 @@ def check_novelty(db_path: str, content: str, threshold: float = NOVELTY_THRESHO
     # Fast path: sqlite-vec nearest neighbor
     if preloaded_embeddings is None:
         conn = sqlite3.connect(db_path)
-        if _vec_available and _has_vec_table(conn):
+        if (
+            _vec_available
+            and _has_vec_table(conn)
+            and _vec_table_dim_matches(conn, candidate_embedding.shape[0])
+        ):
             try:
                 _load_vec(conn)
                 row = conn.execute(
@@ -420,7 +488,22 @@ def backfill_vec_index(db_path: str) -> dict:
     if not _has_vec_table(conn):
         conn.close()
         return {"error": "vec_embeddings table not found"}
-    
+
+    # Refuse to backfill into a dim-mismatched table — sqlite-vec would
+    # reject every insert and we'd report success-with-zero. Make the
+    # mismatch loud so the operator can drop+recreate intentionally.
+    expected_dim = _current_embedding_dim()
+    table_dim = _vec_table_dim(conn)
+    if table_dim is not None and table_dim != expected_dim:
+        conn.close()
+        return {
+            "error": (
+                f"vec_embeddings dim mismatch: table=float[{table_dim}], "
+                f"current model dim={expected_dim}. Drop vec_embeddings and "
+                f"re-run to recreate at the new dim."
+            )
+        }
+
     # Get all active embeddings
     cursor.execute("""
         SELECT e.node_id, e.vector FROM embeddings e

--- a/tests/test_embedding_model_env.py
+++ b/tests/test_embedding_model_env.py
@@ -1,0 +1,196 @@
+"""Tests for CASHEW_EMBEDDING_MODEL env override propagation.
+
+Bug history: `core/embedding_service.py` used to hardcode the model name and
+dimension, ignoring the `CASHEW_EMBEDDING_MODEL` env that `core/config.py`
+already honored. Result: gte-large benchmarks silently embedded with MiniLM.
+These tests pin the contract that the service reads the configured model and
+sizes vectors to match.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from typing import List
+
+import numpy as np
+import pytest
+
+from core.embedding_cache import EmbeddingCache
+from core.embedding_service import (
+    EmbeddingService,
+    LocalBackend,
+    _resolve_default_model,
+)
+
+
+class DimmedFakeBackend:
+    """Fake backend that emits vectors of a configured dim, identity-ish so
+    different models produce different vectors for the same text."""
+
+    def __init__(self, model_name: str, dim: int) -> None:
+        self.model_name = model_name
+        self.dim = dim
+        self.calls: List[List[str]] = []
+
+    def encode(self, texts: List[str]) -> np.ndarray:
+        self.calls.append(list(texts))
+        out = np.zeros((len(texts), self.dim), dtype=np.float32)
+        # Encode model identity into the vector so cross-model collisions are visible.
+        sig = float(sum(ord(c) for c in self.model_name) % 997)
+        for i, t in enumerate(texts):
+            out[i, 0] = float(len(t))
+            out[i, 1] = sig
+        return out
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("CASHEW_EMBEDDING_MODEL", raising=False)
+    yield
+
+
+class TestEnvOverridePropagation:
+    def test_resolve_default_model_picks_up_env(self, monkeypatch):
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "thenlper/gte-large")
+        # core.config caches a singleton; force a reload so it re-reads env.
+        import core.config as cfg
+        importlib.reload(cfg)
+        from core.embedding_service import _resolve_default_model as resolve
+        assert resolve() == "thenlper/gte-large"
+
+    def test_local_backend_default_follows_env(self, monkeypatch):
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "thenlper/gte-large")
+        import core.config as cfg
+        importlib.reload(cfg)
+        b = LocalBackend()
+        assert b.model_name == "thenlper/gte-large"
+        # Known-dim table should give us 1024 without loading the model.
+        assert b.dim == 1024
+
+    def test_service_default_follows_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "thenlper/gte-large")
+        import core.config as cfg
+        importlib.reload(cfg)
+        cache = EmbeddingCache(str(tmp_path / "cache.db"))
+        svc = EmbeddingService(
+            cache=cache,
+            daemon=DimmedFakeBackend("thenlper/gte-large", 1024),
+            local=DimmedFakeBackend("thenlper/gte-large", 1024),
+        )
+        assert svc.model == "thenlper/gte-large"
+        assert svc.dim == 1024
+        vec = svc.embed("hello")
+        assert len(vec) == 1024
+
+
+class TestZeroFillDimMatchesModel:
+    def test_empty_string_zero_vector_uses_model_dim(self, tmp_path):
+        cache = EmbeddingCache(str(tmp_path / "cache.db"))
+        backend = DimmedFakeBackend("thenlper/gte-large", 1024)
+        svc = EmbeddingService(
+            model="thenlper/gte-large",
+            cache=cache,
+            daemon=backend,
+            local=backend,
+        )
+        # Empty string never hits the backend, but the zero vector must still
+        # be 1024-dim, not 384.
+        out = svc.embed("")
+        assert len(out) == 1024
+        assert all(v == 0.0 for v in out)
+
+    def test_embed_np_empty_input_uses_model_dim(self, tmp_path):
+        cache = EmbeddingCache(str(tmp_path / "cache.db"))
+        backend = DimmedFakeBackend("thenlper/gte-large", 1024)
+        svc = EmbeddingService(
+            model="thenlper/gte-large",
+            cache=cache,
+            daemon=backend,
+            local=backend,
+        )
+        arr = svc.embed_np([])
+        assert arr.shape == (0, 1024)
+
+
+class TestCacheModelKeying:
+    def test_same_text_two_models_yields_two_cache_entries(self, tmp_path):
+        cache = EmbeddingCache(str(tmp_path / "cache.db"))
+        b_mini = DimmedFakeBackend("all-MiniLM-L6-v2", 384)
+        b_gte = DimmedFakeBackend("thenlper/gte-large", 1024)
+        svc_mini = EmbeddingService(
+            model="all-MiniLM-L6-v2", cache=cache, daemon=b_mini, local=b_mini
+        )
+        svc_gte = EmbeddingService(
+            model="thenlper/gte-large", cache=cache, daemon=b_gte, local=b_gte
+        )
+
+        v_mini = svc_mini.embed("hello world")
+        v_gte = svc_gte.embed("hello world")
+
+        # Different dims and different signatures → cache cannot have crossed
+        # over.
+        assert len(v_mini) == 384
+        assert len(v_gte) == 1024
+        assert v_mini[1] != v_gte[1]
+
+        # Cache holds one entry per (model, text).
+        assert cache.size("all-MiniLM-L6-v2") == 1
+        assert cache.size("thenlper/gte-large") == 1
+        assert cache.size() == 2
+
+    def test_warm_cache_for_one_model_does_not_serve_other(self, tmp_path):
+        cache = EmbeddingCache(str(tmp_path / "cache.db"))
+        b_mini = DimmedFakeBackend("all-MiniLM-L6-v2", 384)
+        b_gte = DimmedFakeBackend("thenlper/gte-large", 1024)
+        svc_mini = EmbeddingService(
+            model="all-MiniLM-L6-v2", cache=cache, daemon=b_mini, local=b_mini
+        )
+        svc_gte = EmbeddingService(
+            model="thenlper/gte-large", cache=cache, daemon=b_gte, local=b_gte
+        )
+
+        svc_mini.embed("the quick brown fox")
+        # gte must compute, not pull MiniLM's cached vector.
+        b_gte.calls.clear()
+        svc_gte.embed("the quick brown fox")
+        assert b_gte.calls == [["the quick brown fox"]]
+
+
+class TestPoisonedCacheRecovery:
+    def test_wrong_dim_cache_entry_is_treated_as_miss(self, tmp_path):
+        """Pre-fix bug: MiniLM (384) vectors got cached under the gte-large
+        namespace because the service ignored the env. Post-fix, those
+        poisoned entries should be silently recomputed instead of returned."""
+        cache = EmbeddingCache(str(tmp_path / "cache.db"))
+        # Plant a 384-dim vector under thenlper/gte-large for "hello".
+        bad = np.ones(384, dtype=np.float32) * 0.5
+        cache.put("thenlper/gte-large", "hello", bad)
+
+        backend = DimmedFakeBackend("thenlper/gte-large", 1024)
+        svc = EmbeddingService(
+            model="thenlper/gte-large",
+            cache=cache,
+            daemon=backend,
+            local=backend,
+        )
+        out = svc.embed("hello")
+        assert len(out) == 1024  # not 384
+        assert backend.calls == [["hello"]]  # forced a recompute
+        # Cache now has the correct entry (overwrite).
+        fresh = cache.get("thenlper/gte-large", "hello")
+        assert fresh is not None and fresh.shape[0] == 1024
+
+
+class TestEndToEndCrossModel:
+    def test_two_models_yield_different_vectors_for_same_text(self, tmp_path):
+        cache = EmbeddingCache(str(tmp_path / "cache.db"))
+        b_a = DimmedFakeBackend("model-a", 384)
+        b_b = DimmedFakeBackend("model-b", 384)
+        svc_a = EmbeddingService(model="model-a", cache=cache, daemon=b_a, local=b_a)
+        svc_b = EmbeddingService(model="model-b", cache=cache, daemon=b_b, local=b_b)
+
+        v_a = svc_a.embed("identical input")
+        v_b = svc_b.embed("identical input")
+
+        assert v_a != v_b, "different models must produce different vectors"

--- a/tests/test_vec_table_dim.py
+++ b/tests/test_vec_table_dim.py
@@ -1,0 +1,184 @@
+"""Tests for dynamic-dim sqlite-vec table creation.
+
+Bug history: `core/embeddings.py` hardcoded `embedding float[384]` in the
+sqlite-vec virtual table even after PR #40 made the rest of the embedding
+stack honor CASHEW_EMBEDDING_MODEL. Result: a fresh DB created under
+gte-large still got a 384-dim vec table, every dual-write rejected.
+These tests pin the contract that the vec table dim follows the configured
+model, and that legacy DBs at the wrong dim degrade to brute-force search
+without crashing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+
+import pytest
+
+
+def _reload_embedding_modules():
+    """Reload modules so they pick up a freshly-set CASHEW_EMBEDDING_MODEL."""
+    import core.config
+    importlib.reload(core.config)
+    import core.embedding_service
+    importlib.reload(core.embedding_service)
+    import core.embeddings
+    importlib.reload(core.embeddings)
+    return core.embeddings
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("CASHEW_EMBEDDING_MODEL", raising=False)
+    yield
+
+
+def _vec_table_sql(db_path: str) -> str:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='vec_embeddings'"
+        ).fetchone()
+        return row[0] if row else ""
+    finally:
+        conn.close()
+
+
+class TestVecTableCreatedAtModelDim:
+    def test_fresh_db_under_gte_large_gets_1024_dim_vec_table(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "thenlper/gte-large")
+        emb = _reload_embedding_modules()
+        db = str(tmp_path / "gte.db")
+        from core.session import _ensure_schema as ensure_session_schema
+        ensure_session_schema(db)
+        emb.ensure_schema(db)
+        sql = _vec_table_sql(db)
+        assert "float[1024]" in sql, f"expected float[1024] in {sql!r}"
+
+    def test_fresh_db_under_minilm_gets_384_dim_vec_table(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+        emb = _reload_embedding_modules()
+        db = str(tmp_path / "minilm.db")
+        from core.session import _ensure_schema as ensure_session_schema
+        ensure_session_schema(db)
+        emb.ensure_schema(db)
+        sql = _vec_table_sql(db)
+        assert "float[384]" in sql, f"expected float[384] in {sql!r}"
+
+
+class TestDualWriteAtNewDim:
+    def test_dual_write_succeeds_at_1024_dim(self, tmp_path, monkeypatch):
+        """A fresh gte-large DB should accept 1024-dim vectors into
+        vec_embeddings without sqlite-vec rejecting them."""
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "thenlper/gte-large")
+        emb = _reload_embedding_modules()
+        db = str(tmp_path / "gte_dual.db")
+
+        # Bootstrap the canonical schema so embed_nodes has thought_nodes.
+        from core.session import _ensure_schema as ensure_session_schema
+        ensure_session_schema(db)
+        emb.ensure_schema(db)
+
+        # Insert a node and synthesize a 1024-dim vector directly to avoid
+        # loading the actual SentenceTransformer in CI.
+        import numpy as np
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT INTO thought_nodes(id, content, node_type, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            ("n1", "hello world", "fact", "2026-05-08T00:00:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        # Open a vec-loaded conn and dual-write a fake 1024-dim vector.
+        conn = sqlite3.connect(db)
+        conn.enable_load_extension(True)
+        import sqlite_vec
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+
+        vec = np.zeros(1024, dtype=np.float32)
+        vec[0] = 1.0
+        # Should NOT raise.
+        conn.execute(
+            "INSERT INTO vec_embeddings(node_id, embedding) VALUES (?, ?)",
+            ("n1", vec.tobytes()),
+        )
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT node_id FROM vec_embeddings WHERE node_id = ?", ("n1",)
+        ).fetchone()
+        assert row == ("n1",)
+        conn.close()
+
+
+class TestLegacyDimMismatchFallsBackGracefully:
+    def test_search_on_384_dim_table_under_1024_model_does_not_crash(self, tmp_path, monkeypatch):
+        """Pre-existing 384-dim vec table opened under a 1024-dim model must
+        not crash — the code skips vec and falls back to brute force."""
+        # Build a legacy DB at 384 dim.
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+        emb = _reload_embedding_modules()
+        db = str(tmp_path / "legacy.db")
+
+        from core.session import _ensure_schema as ensure_session_schema
+        ensure_session_schema(db)
+        emb.ensure_schema(db)
+        assert "float[384]" in _vec_table_sql(db)
+
+        # Drop in a stored 384-dim embedding so brute-force has something.
+        import numpy as np
+        v384 = np.random.RandomState(0).randn(384).astype(np.float32)
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT INTO thought_nodes(id, content, node_type, timestamp, decayed) "
+            "VALUES (?, ?, ?, ?, 0)",
+            ("n1", "hello", "fact", "2026-05-08"),
+        )
+        conn.execute(
+            "INSERT INTO embeddings(node_id, vector, model, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("n1", v384.tobytes(), "all-MiniLM-L6-v2", "2026-05-08"),
+        )
+        conn.commit()
+        conn.close()
+
+        # Switch model to 1024-dim and re-import.
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "thenlper/gte-large")
+        emb = _reload_embedding_modules()
+
+        # Fake out embed_text so we don't load SentenceTransformer.
+        v1024 = np.random.RandomState(1).randn(1024).astype(np.float32).tolist()
+        emb.embed_text = lambda text: v1024  # type: ignore
+
+        # ensure_schema must not crash on dim mismatch.
+        emb.ensure_schema(db)
+        # Vec table dim is unchanged (we don't drop+recreate).
+        assert "float[384]" in _vec_table_sql(db)
+
+        # Search must not crash; falls back to brute force on the stored
+        # 384-dim vector. Cosine of mismatched-shape vectors would error in
+        # numpy, but since we skip the brute-force pair when shapes differ,
+        # we just expect no crash and a (possibly empty) list.
+        results = emb.search(db, "any query", top_k=5)
+        assert isinstance(results, list)
+
+    def test_backfill_refuses_dim_mismatch(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+        emb = _reload_embedding_modules()
+        db = str(tmp_path / "legacy_bf.db")
+
+        from core.session import _ensure_schema as ensure_session_schema
+        ensure_session_schema(db)
+        emb.ensure_schema(db)
+
+        monkeypatch.setenv("CASHEW_EMBEDDING_MODEL", "thenlper/gte-large")
+        emb = _reload_embedding_modules()
+
+        result = emb.backfill_vec_index(db)
+        assert "error" in result
+        assert "dim mismatch" in result["error"].lower()


### PR DESCRIPTION
## Summary

\`core/embedding_service.py\` hardcoded \`DEFAULT_MODEL = 'all-MiniLM-L6-v2'\` and \`EMBEDDING_DIM = 384\`, so \`CASHEW_EMBEDDING_MODEL\` (read correctly by \`core/config.py\`) never propagated. Every query embedded with MiniLM regardless of config, which made cross-model benchmarks meaningless.

- Default model resolves via \`core.config.get_embedding_model()\`; \`LocalBackend\` / \`DaemonBackend\` take \`model_name\`
- \`LocalBackend.dim\` is dynamic: known-dims table for common models, falls back to probing \`SentenceTransformer.get_sentence_embedding_dimension()\`
- All zero-fill paths (empty input, empty string, daemon failure) size from the actual model dim, not 384
- Daemon \`embed\` / \`embed_batch\` size zero vectors from the backend's live dim
- \`embeddings.py\` stores the configured model name on rows, not a hardcoded MiniLM string
- Cache treats dim-mismatched hits as misses and recomputes — recovers from any cache poisoned by the prior bug (e.g. 384-dim vectors stored under a gte-large namespace)

Cache keying by \`(model, hash)\` was already correct, so MiniLM users keep their warm cache.

## Verification

- \`pytest tests/\` — 415 passed
- \`python3 -c \"from core.embeddings import embed_text; print(len(embed_text('hello')))\"\` → 384
- \`CASHEW_EMBEDDING_MODEL=thenlper/gte-large python3 -c \"from core.embeddings import embed_text; print(len(embed_text('hello')))\"\` → 1024

## Caveats

- The warm daemon serves whatever model it was started with. If you change \`CASHEW_EMBEDDING_MODEL\`, restart the daemon, otherwise daemon-served requests still use the old model.
- The sqlite-vec virtual table in per-DB \`vec_embeddings\` is declared \`float[384]\`. Switching to a non-384 model breaks vec-table inserts on existing DBs; brute-force search still works. A separate change is needed if we want vec-search at non-MiniLM dims (re-create the virtual table per-dim, or namespace it).
- The graph stores model name on each row, so a graph can have mixed-model embeddings if the env changed mid-run. Search/novelty-check today don't filter by model — they will compute a similarity across dims and crash. Recommend backfilling or invalidating after a model swap.

## Test plan

- [x] Full pytest suite green
- [x] Manual: default env returns 384-dim
- [x] Manual: \`CASHEW_EMBEDDING_MODEL=thenlper/gte-large\` returns 1024-dim
- [x] Manual: poisoned-cache (legacy 384 stored under gte-large) recovers and overwrites