### PR TITLE
fix: replace extraction prompt GOOD examples with personal knowledge templates

### DIFF
--- a/core/session.py
+++ b/core/session.py
@@ -589,8 +589,8 @@ For each item, assign:
 
 BAD: "They discussed embeddings" (meta-comment)
 BAD: "The conversation covered several topics" (summary)
-GOOD: "Otto is a schnauzer — prefers Teddy over Chucky/Piggy"
-GOOD: "Echeveria subsessilis self-propagated in an Erlenmeyer flask — low-demand plant matching AuDHD PDA rhythms"
+GOOD: "Alice prefers async standups over morning syncs — finds them less overwhelming than real-time meetings"
+GOOD: "Project Orion Q3 deadline pushed back by two months due to a late GraphQL migration dependency"
 
 Personal knowledge (preferences, projects, people, infrastructure, decisions)
 should be weighted above system-internal discussion. Architecture details

--- a/core/session.py
+++ b/core/session.py
@@ -589,8 +589,13 @@ For each item, assign:
 
 BAD: "They discussed embeddings" (meta-comment)
 BAD: "The conversation covered several topics" (summary)
-GOOD: "Local embedding models (all-MiniLM-L6-v2) are sufficient for graphs under 100K nodes — brute force cosine similarity stays under 50ms"
-GOOD: "Extraction should be triggered by context fullness monitoring, not left to manual memory — don't let compaction happen to you"
+GOOD: "Otto is a schnauzer — prefers Teddy over Chucky/Piggy"
+GOOD: "Echeveria subsessilis self-propagated in an Erlenmeyer flask — low-demand plant matching AuDHD PDA rhythms"
+
+Personal knowledge (preferences, projects, people, infrastructure, decisions)
+should be weighted above system-internal discussion. Architecture details
+belong in the '{get_ai_domain()}' domain when they describe the system itself,
+even if discussed collaboratively with the user.
 
 Respond with ONLY a JSON array. No markdown, no explanation, no code fences.
 


### PR DESCRIPTION
Closes #41

## Problem

The LLM extraction prompt has two GOOD examples about embeddings and memory management, biasing extracted knowledge toward system internals. In production, 98% of graph nodes are observations and only 1% are personal-domain facts.

## Changes

- **Replaced GOOD examples** with personal knowledge templates (dog preferences, plant care) that demonstrate the right granularity for personal domain extraction
- **Added domain priority instruction**: weight personal knowledge above system-internal discussion; classify architecture details as ai_domain even when discussed collaboratively
- Kept the BAD examples unchanged (still valid anti-patterns)