### PR TITLE
sleep: preserve temporal anchors during cluster merge synthesis

### DIFF
--- a/core/sleep.py
+++ b/core/sleep.py
@@ -4,6 +4,7 @@ Cashew Sleep Protocol
 Memory consolidation, cross-linking, garbage collection, and core memory promotion
 """
 
+import re
 import sqlite3
 import json
 import math
@@ -29,6 +30,58 @@ class SleepEvent:
     timestamp: str
     event_type: str  # "cross_link", "dedup", "dream", "gc_decay", "core_promotion", "core_demotion"
     details: dict
+
+# Temporal anchor detection — used to guard cluster merge against losing
+# date/weekday/relative-time information during LLM synthesis.
+_MONTHS = (
+    "january|february|march|april|may|june|july|august|"
+    "september|october|november|december|"
+    "jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec"
+)
+_WEEKDAYS = "monday|tuesday|wednesday|thursday|friday|saturday|sunday"
+_RELATIVE = (
+    r"yesterday|today|tonight|tomorrow|"
+    r"(?:last|next|this|past|coming)\s+(?:week|month|year|"
+    + _WEEKDAYS + r")|"
+    r"(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|"
+    r"eleven|twelve|few|several|couple\s+of)\s+"
+    r"(?:minute|hour|day|week|month|year)s?\s+ago|"
+    r"in\s+(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten)\s+"
+    r"(?:minute|hour|day|week|month|year)s?"
+)
+_TEMPORAL_PATTERNS = [
+    re.compile(r"\b\d{4}-\d{2}-\d{2}\b"),                      # ISO date
+    re.compile(r"\b\d{1,2}/\d{1,2}/\d{2,4}\b"),                # 3/5/2026
+    re.compile(rf"\b(?:{_MONTHS})\b\.?\s*\d{{1,2}}(?:,\s*\d{{4}})?", re.IGNORECASE),
+    re.compile(rf"\b\d{{1,2}}\s+(?:{_MONTHS})\b", re.IGNORECASE),
+    re.compile(rf"\b(?:{_MONTHS})\s+\d{{4}}\b", re.IGNORECASE),
+    re.compile(rf"\b(?:{_WEEKDAYS})\b", re.IGNORECASE),
+    re.compile(r"\b(?:19|20)\d{2}\b"),                         # bare year
+    re.compile(rf"\b(?:{_RELATIVE})\b", re.IGNORECASE),
+]
+
+
+def _collect_temporal_anchors(snippets: List[str]) -> List[str]:
+    """Return distinct lowercase temporal anchor strings found across snippets."""
+    seen: Set[str] = set()
+    for s in snippets or ():
+        if not s:
+            continue
+        for pat in _TEMPORAL_PATTERNS:
+            for m in pat.findall(s):
+                tok = m.lower().strip()
+                if tok:
+                    seen.add(tok)
+    return list(seen)
+
+
+def _has_any_anchor(text: str, anchors: List[str]) -> bool:
+    """True if `text` (case-insensitive) contains at least one anchor string."""
+    if not text or not anchors:
+        return False
+    low = text.lower()
+    return any(a in low for a in anchors)
+
 
 @dataclass
 class CrossLinkCandidate:
@@ -396,10 +449,18 @@ class SleepProtocol:
 
         With model_fn, asks the LLM for a single-line synthesis. Falls back to
         the longest member's content on None or failure (degraded but not blank).
+
+        Temporal-anchor preservation: any date, weekday, month, year, or relative
+        time phrase ("last Tuesday", "in March", "two weeks ago") that appears in
+        a source snippet must survive into the merged statement. If the LLM
+        synthesis drops every temporal anchor present in the inputs, fall back to
+        the longest source rather than emit a temporally bleached merge.
         """
         longest = max(cluster_contents, key=lambda s: len(s or "")) if cluster_contents else ""
         if model_fn is None:
             return longest
+
+        source_anchors = _collect_temporal_anchors(cluster_contents)
 
         snippet_block = "\n\n".join(
             f"SNIPPET {i+1} ({t}):\n{c}"
@@ -412,6 +473,10 @@ class SleepProtocol:
             "express. Preserve the strongest, most specific phrasing. Do not "
             "average or hedge. If they disagree on detail, keep the version that "
             "is most concrete.\n\n"
+            "Critical: preserve every temporal anchor (specific dates, weekdays, "
+            "months, years, relative times like 'last Tuesday' or 'two weeks ago') "
+            "that appears in any snippet. Temporal context is load-bearing — "
+            "never drop it for brevity.\n\n"
             "Rules: no preamble, no headers, no markdown. Output only the "
             "consolidated statement, on a single line.\n\n"
             f"{snippet_block}\n"
@@ -421,6 +486,12 @@ class SleepProtocol:
             if response:
                 candidate = response.strip().splitlines()[0].strip()
                 if len(candidate) >= 10:
+                    if source_anchors and not _has_any_anchor(candidate, source_anchors):
+                        logger.warning(
+                            "Cluster synthesis dropped all temporal anchors; "
+                            "falling back to longest source to preserve them."
+                        )
+                        return longest
                     return candidate
         except Exception as e:
             logger.warning(f"Cluster LLM synthesis failed, falling back: {e}")

--- a/tests/test_sleep_temporal_anchors.py
+++ b/tests/test_sleep_temporal_anchors.py
@@ -1,0 +1,106 @@
+"""Tests for temporal-anchor preservation during sleep-cycle cluster merges.
+
+Regression: cluster merge synthesis was dropping date/weekday/relative-time
+phrases that appeared in source nodes, which crippled temporal-reasoning
+accuracy on downstream benchmarks (LoCoMo cat-2 specifically).
+"""
+import pytest
+
+from core.sleep import (
+    SleepProtocol,
+    _collect_temporal_anchors,
+    _has_any_anchor,
+)
+
+
+class TestTemporalAnchorDetection:
+    def test_iso_date(self):
+        anchors = _collect_temporal_anchors(["met on 2026-03-05 at noon"])
+        assert "2026-03-05" in anchors
+
+    def test_month_day_year(self):
+        anchors = _collect_temporal_anchors(["went on March 5, 2026"])
+        assert any("march" in a for a in anchors)
+
+    def test_weekday(self):
+        anchors = _collect_temporal_anchors(["call last Tuesday went well"])
+        assert any("tuesday" in a for a in anchors)
+        # the relative phrase "last tuesday" should also be captured
+        assert any("last tuesday" in a for a in anchors)
+
+    def test_relative_time(self):
+        anchors = _collect_temporal_anchors(["shipped two weeks ago"])
+        assert any("two weeks ago" in a for a in anchors)
+
+    def test_bare_year(self):
+        anchors = _collect_temporal_anchors(["graduated in 2018"])
+        assert "2018" in anchors
+
+    def test_no_temporal_content(self):
+        assert _collect_temporal_anchors(["raj likes ramen"]) == []
+
+    def test_dedup_across_snippets(self):
+        anchors = _collect_temporal_anchors([
+            "trip in March 2026",
+            "March 2026 was great",
+        ])
+        # "march 2026" should appear once, not twice
+        assert sum(1 for a in anchors if "march 2026" in a) == 1
+
+    def test_has_any_anchor_positive(self):
+        assert _has_any_anchor("we met March 5", ["march 5"])
+
+    def test_has_any_anchor_negative(self):
+        assert not _has_any_anchor("we met somewhere", ["march 5", "tuesday"])
+
+    def test_has_any_anchor_empty(self):
+        assert not _has_any_anchor("anything", [])
+        assert not _has_any_anchor("", ["march 5"])
+
+
+class TestSynthesisPreservesAnchors:
+    def _proto(self):
+        # SleepProtocol needs only its method; pass an empty path.
+        return SleepProtocol.__new__(SleepProtocol)
+
+    def test_no_model_returns_longest(self):
+        out = self._proto()._synthesize_cluster_content(
+            ["short", "a much longer snippet here"], ["fact", "fact"], model_fn=None
+        )
+        assert out == "a much longer snippet here"
+
+    def test_llm_keeps_anchor_passes_through(self):
+        snippets = ["raj traveled to sweden in march 2026", "sweden trip in march 2026 was great"]
+        def model_fn(_p):
+            return "raj traveled to sweden in march 2026 and enjoyed it"
+        out = self._proto()._synthesize_cluster_content(snippets, ["fact"]*2, model_fn=model_fn)
+        assert "march 2026" in out.lower()
+
+    def test_llm_drops_all_anchors_falls_back_to_longest(self):
+        snippets = [
+            "raj traveled to sweden in march 2026",
+            "sweden trip in march 2026 was great",
+        ]
+        def model_fn(_p):
+            # synthesis bleaches the date out
+            return "raj traveled to sweden and enjoyed it greatly overall"
+        out = self._proto()._synthesize_cluster_content(snippets, ["fact"]*2, model_fn=model_fn)
+        # Falls back to the longest source; both contain "march 2026"
+        assert "march 2026" in out.lower()
+
+    def test_no_anchors_in_sources_no_fallback(self):
+        # If sources have no temporal info, the LLM output should be accepted
+        # as-is even though it has no anchor.
+        snippets = ["raj likes ramen", "raj enjoys ramen a lot"]
+        def model_fn(_p):
+            return "raj enjoys ramen"
+        out = self._proto()._synthesize_cluster_content(snippets, ["fact"]*2, model_fn=model_fn)
+        assert out == "raj enjoys ramen"
+
+    def test_short_llm_response_falls_back(self):
+        # Existing behavior preserved: <10 char LLM responses fall through.
+        snippets = ["raj traveled to sweden in march 2026", "sweden trip in march"]
+        def model_fn(_p):
+            return "ok"
+        out = self._proto()._synthesize_cluster_content(snippets, ["fact"]*2, model_fn=model_fn)
+        assert "march" in out.lower()


### PR DESCRIPTION
## Summary

The sleep-cycle cluster-merge LLM synthesis was free to drop date, weekday, and relative-time phrases (e.g., "on March 5", "last Tuesday", "two weeks ago") when consolidating near-duplicate nodes. Critic diff on LoCoMo `conv-26` variant B traced 435 dropped-content cases to this path and matched them to a -9.6 F1 regression on temporal-reasoning questions (category 2).

This PR fixes the regression with two changes:

1. **Strengthens the synthesis prompt** — explicitly instructs the model that temporal anchors are load-bearing and must not be dropped for brevity.

2. **Adds a deterministic guard** — collects every temporal-anchor token from the source snippets, and if the model returns a synthesis containing none of them while the inputs had at least one, falls back to the longest source. Bleached-but-fluent merges never replace anchored facts.

Anchor regex covers: ISO dates, slash dates, month-day-year forms (`March 5, 2026`), weekdays (`Tuesday`), bare 19xx/20xx years, and relative phrases (`in 3 days`, `two weeks ago`, `last Tuesday`).

When the source snippets have no temporal content, behavior is unchanged (LLM output is accepted as-is).

## Test plan

- [x] 38 existing sleep tests still pass
- [x] 15 new tests cover anchor detection, LLM-keeps-anchor pass-through, LLM-drops-anchor fallback, and no-anchors-in-sources no-fallback
- [ ] Re-run LoCoMo `conv-26` variant B post-merge; expect cat-2 F1 to recover toward variant A levels

