### PR TITLE
fix(embedding): get_default_service should respect configured embedding model

### DIFF
--- a/core/embedding_service.py
+++ b/core/embedding_service.py
@@ -276,7 +276,8 @@ def get_default_service() -> EmbeddingService:
     rather than touching this."""
     global _default_service
     if _default_service is None:
-        _default_service = EmbeddingService()
+        from .config import get_embedding_model
+        _default_service = EmbeddingService(model=get_embedding_model())
     return _default_service
 
 


### PR DESCRIPTION
## Problem

`get_default_service()` constructs `EmbeddingService` without the `model` argument, so the service falls through to the hardcoded `DEFAULT_MODEL = \"all-MiniLM-L6-v2\"`. When the user has configured a different embedding model (e.g. `thenlper/gte-large`) via `CASHEW_EMBEDDING_MODEL` or the config file, the default singleton ignores it.

## Symptom

Every call to `retrieve_recursive_bfs` that hits a BFS neighbor node fails with:
```
ValueError: shapes (384,) and (1024,) not aligned: 384 (dim 0) != 1024 (dim 0)
```

The seed embedding search succeeds (sqlite-vec dimension matches), but the BFS neighbor cosine similarity step computes `np.dot(query_vec, neighbor_vec)` where `query_vec` is 384-dim (MiniLM) and `neighbor_vec` is 1024-dim (configured model).

## Fix

Import `get_embedding_model()` from `core.config` and pass it as the `model` argument when constructing the default singleton. This is the same resolution path used by the rest of cashew (env var → config file → built-in default).

## Notes

The more comprehensive fix (commit `ac7f468`) already exists in the dev branch — it changes `EmbeddingService.__init__` to accept `model: Optional[str]` with fallback to `_resolve_default_model()`. This PR is a minimal backport targeting v1.1.0's current constructor signature.