### PR TITLE
fix(session): set PRAGMA busy_timeout=5000 on all connections

### DIFF
--- a/core/session.py
+++ b/core/session.py
@@ -64,7 +64,9 @@ class ThinkResult:
 
 def _get_connection(db_path: str) -> sqlite3.Connection:
     """Get database connection"""
-    return sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
 
 # ----- Schema contract ----------------------------------------------------
 # Cashew owns these tables and the columns listed below. See DESIGN.md


### PR DESCRIPTION
## Problem

The connection factory `_get_connection()` in `core/session.py` creates SQLite connections without setting `PRAGMA busy_timeout`. SQLite's default (0) means `database is locked` is raised immediately on any write/write contention. For background AI agent workloads (turn persistence, sleep cycles), transient lock contention is normal — the caller almost always wants to wait briefly and retry.

## Symptom

Applications with concurrent writers (multiple Hermes Agent sessions, gateway + background workers) see frequent:

```
sqlite3.OperationalError: database is locked
```

in `end_session()`, `_create_node()`, and sleep cycle operations.

## Fix

Set `PRAGMA busy_timeout=5000` on the connection after opening it:

```python
def _get_connection(db_path: str) -> sqlite3.Connection:
    conn = sqlite3.connect(db_path)
    conn.execute("PRAGMA busy_timeout=5000")
    return conn
```

SQLite now waits up to 5 seconds for the lock to release before raising. One line, one place — all callers of `_get_connection` benefit transparently.

## Notes

- `busy_timeout` is purely a wait-and-retry mechanism. It does not change isolation semantics or transaction behavior.
- WAL mode is already in use (handles read/write concurrency). `busy_timeout` complements it by handling write/write contention.