### PR TITLE
fix(extract): handle bare array in --ingest path

### DIFF
--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -226,10 +226,13 @@ def _cmd_extract_ingest(args):
     
     with open(ingest_path, 'r') as f:
         data = json.load(f)
-    
+
+    if isinstance(data, list):
+        data = {"insights": data}
+
     from core.session import _ensure_schema, _create_node, _get_connection
     _ensure_schema(args.db)
-    
+
     new_nodes = 0
     new_node_ids = []
     for item in data.get("insights", []):


### PR DESCRIPTION
## Summary

- `_cmd_extract_ingest` called `.get("insights", [])` on the parsed JSON, but the extraction prompt outputs a bare array `[...]` instead of `{"insights": [...]}`, causing `AttributeError: 'list' object has no attribute 'get'`
- Fix: after loading the JSON, check `isinstance(data, list)` and wrap it automatically — both formats now work

## Test plan

- [ ] `echo '[{"content": "test", "type": "fact", "domain": "bunny"}]' > /tmp/t.json && python3 scripts/cashew_context.py extract --ingest /tmp/t.json --session-id test` returns `{"success": true, "new_nodes": 1}`
- [ ] Wrapped format `{"insights": [...]}` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)