### PR TITLE
fix: set PRAGMA busy_timeout = 5000 on all sqlite3 connections

### DIFF
--- a/cashew_cli.py
+++ b/cashew_cli.py
@@ -68,7 +68,8 @@ def cmd_init(args):
     
     try:
         conn = sqlite3.connect(str(db_path))
-        
+        conn.execute("PRAGMA busy_timeout = 5000")
+
         # Create schema
         conn.execute('''
             CREATE TABLE IF NOT EXISTS thought_nodes (
@@ -456,6 +457,7 @@ def cmd_audit(args):
     if sub == "gc":
         retention = args.retention_days
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         try:
             pruned = gc_decay_audit(conn, retention_days=retention)
             conn.commit()
@@ -466,6 +468,7 @@ def cmd_audit(args):
 
     if sub == "show":
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         try:
             rows = conn.execute(
                 "SELECT decay_timestamp, decay_reason, node_type, source_file, "

--- a/core/context.py
+++ b/core/context.py
@@ -44,7 +44,9 @@ class ContextRetriever:
     
     def _get_connection(self) -> sqlite3.Connection:
         """Get database connection"""
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
     
     def _extract_keywords(self, query: str) -> List[str]:
         """Extract meaningful keywords from query"""

--- a/core/decay.py
+++ b/core/decay.py
@@ -22,6 +22,13 @@ from typing import Dict, Set
 from .decay_audit import log_decay_event
 
 
+def _connect(db_path: str) -> sqlite3.Connection:
+    """Connection factory with busy_timeout to avoid lock contention."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
 CASCADE_MIN_AGE_DAYS = 30
 
 
@@ -101,7 +108,7 @@ def cascade_decay(db_path: str, decayed_node_id: str) -> Dict:
     Returns:
         Dict with cascading statistics
     """
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     _ensure_edges_table(cursor)
 
@@ -196,7 +203,7 @@ def auto_decay(db_path: str, min_age_days: int = 14,
     Returns:
         Dict with pruning statistics
     """
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     _ensure_edges_table(cursor)
 
@@ -261,7 +268,7 @@ def auto_decay(db_path: str, min_age_days: int = 14,
 def get_decay_candidates(db_path: str, min_age_days: int = 14,
                         show_cascade_preview: bool = False) -> Dict:
     """Get statistics on nodes eligible for decay without actually decaying them."""
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     _ensure_edges_table(cursor)
 
@@ -310,7 +317,7 @@ def get_decay_candidates(db_path: str, min_age_days: int = 14,
 
 def simulate_cascade_decay(db_path: str, decayed_node_id: str) -> int:
     """Simulate cascading decay without modifying the database."""
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     _ensure_edges_table(cursor)
 

--- a/core/embedding_cache.py
+++ b/core/embedding_cache.py
@@ -64,6 +64,7 @@ class EmbeddingCache:
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.path)
         conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout = 5000")
         return conn
 
     def _init_schema(self) -> None:

--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -39,6 +39,13 @@ def ensure_schema(db_path: str):
     _ensure_embeddings_table(db_path)
 
 
+def _connect(db_path: str) -> sqlite3.Connection:
+    """Connection factory with busy_timeout to avoid lock contention."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
 def _load_vec(conn: sqlite3.Connection):
     """Load sqlite-vec extension into a connection"""
     if _vec_available:
@@ -100,7 +107,7 @@ def _warn_on_dim_mismatch(db_path: str) -> None:
     if db_path in _WARNED_DIM_MISMATCH:
         return
     try:
-        conn = sqlite3.connect(db_path)
+        conn = _connect(db_path)
         row = conn.execute(
             "SELECT LENGTH(vector) FROM embeddings WHERE vector IS NOT NULL LIMIT 1"
         ).fetchone()
@@ -133,7 +140,7 @@ def _warn_on_dim_mismatch(db_path: str) -> None:
 
 def _ensure_embeddings_table(db_path: str):
     """Ensure the embeddings table exists with the correct schema"""
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     
     # Check if table exists
@@ -232,7 +239,7 @@ def embed_nodes(db_path: str, batch_size: int = 100) -> dict:
     _ensure_embeddings_table(db_path)
     _warn_on_dim_mismatch(db_path)
 
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     _load_vec(conn)
     cursor = conn.cursor()
     
@@ -355,7 +362,7 @@ def search(db_path: str, query: str, top_k: int = 10) -> List[Tuple[str, float]]
     # Embed the query
     query_embedding = np.array(embed_text(query), dtype=np.float32)
     
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     
     # Try sqlite-vec first (O(log N)). Skip when the vec table's dim doesn't
     # match the query embedding (legacy 384-dim table under a 1024-dim model,
@@ -437,7 +444,7 @@ NOVELTY_THRESHOLD = 0.82  # reject if nearest neighbor similarity > this
 
 def load_all_embeddings(db_path: str) -> Dict[str, np.ndarray]:
     """Load all non-decayed node embeddings from DB. Call once, pass to check_novelty."""
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     cursor.execute("""
         SELECT e.node_id, e.vector 
@@ -472,7 +479,7 @@ def check_novelty(db_path: str, content: str, threshold: float = NOVELTY_THRESHO
     
     # Fast path: sqlite-vec nearest neighbor
     if preloaded_embeddings is None:
-        conn = sqlite3.connect(db_path)
+        conn = _connect(db_path)
         if (
             _vec_available
             and _has_vec_table(conn)
@@ -524,7 +531,7 @@ def backfill_vec_index(db_path: str) -> dict:
     
     _ensure_embeddings_table(db_path)
     
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     _load_vec(conn)
     cursor = conn.cursor()
     
@@ -652,7 +659,7 @@ def main():
             return 0
         
         # Load node details for display
-        conn = sqlite3.connect(args.db)
+        conn = _connect(args.db)
         cursor = conn.cursor()
         
         print(f"\nTop {len(results)} results:")

--- a/core/export.py
+++ b/core/export.py
@@ -44,7 +44,9 @@ class GraphExporter:
     
     def _get_connection(self) -> sqlite3.Connection:
         """Get database connection"""
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
     
     def export_nodes(self) -> List[Dict]:
         """Export all nodes"""

--- a/core/extractors.py
+++ b/core/extractors.py
@@ -169,8 +169,9 @@ class ExtractorRegistry:
                       extractor_name: str) -> int:
         """Ingest extracted nodes into the graph database."""
         import sqlite3
-        
+
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         # Ensure referent_time column is present on older DBs.
         try:

--- a/core/graph_utils.py
+++ b/core/graph_utils.py
@@ -8,6 +8,13 @@ import sqlite3
 import logging
 from typing import List, Dict, Tuple
 
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    """Connection factory with busy_timeout to avoid lock contention."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
 import numpy as np
 
 logger = logging.getLogger("cashew.graph_utils")
@@ -32,7 +39,7 @@ def load_embeddings(db_path: str) -> Tuple[List[str], np.ndarray, Dict[str, Dict
         vectors: numpy array of shape (n_nodes, embedding_dim)
         node_meta: Dict of node_id -> {content, node_type, domain}
     """
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     
     cursor.execute("""

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -19,9 +19,16 @@ def is_metrics_enabled() -> bool:
     return os.getenv('CASHEW_METRICS', '0') == '1'
 
 
+def _connect(db_path: str) -> sqlite3.Connection:
+    """Connection factory with busy_timeout to avoid lock contention."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
 def ensure_metrics_table(db_path: str):
     """Ensure the metrics table exists in the database"""
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     
     cursor.execute("""
@@ -54,7 +61,7 @@ def record_metric(db_path: str, metric_type: str, duration_ms: float, **kwargs):
     try:
         ensure_metrics_table(db_path)
         
-        conn = sqlite3.connect(db_path)
+        conn = _connect(db_path)
         cursor = conn.cursor()
         
         cursor.execute("""
@@ -137,7 +144,7 @@ def get_metrics_summary(db_path: str, hours: int = 24) -> Dict[str, Any]:
     try:
         ensure_metrics_table(db_path)
         
-        conn = sqlite3.connect(db_path)
+        conn = _connect(db_path)
         cursor = conn.cursor()
         
         # Calculate time threshold
@@ -235,7 +242,7 @@ def get_metrics_timeseries(db_path: str, metric_type: str, hours: int = 24) -> L
     try:
         ensure_metrics_table(db_path)
         
-        conn = sqlite3.connect(db_path)
+        conn = _connect(db_path)
         cursor = conn.cursor()
         
         since = (datetime.now() - timedelta(hours=hours)).isoformat()
@@ -286,7 +293,7 @@ def get_retrieval_stats(db_path: str, hours: int = 24) -> Dict[str, Any]:
     try:
         ensure_metrics_table(db_path)
         
-        conn = sqlite3.connect(db_path)
+        conn = _connect(db_path)
         cursor = conn.cursor()
         
         since = (datetime.now() - timedelta(hours=hours)).isoformat()
@@ -367,7 +374,7 @@ def get_recent_metrics(db_path: str, limit: int = 20) -> List[Dict[str, Any]]:
     try:
         ensure_metrics_table(db_path)
         
-        conn = sqlite3.connect(db_path)
+        conn = _connect(db_path)
         cursor = conn.cursor()
         
         cursor.execute("""
@@ -408,7 +415,7 @@ def clear_metrics(db_path: str):
     try:
         ensure_metrics_table(db_path)
         
-        conn = sqlite3.connect(db_path)
+        conn = _connect(db_path)
         cursor = conn.cursor()
         
         cursor.execute("DELETE FROM metrics")

--- a/core/permanence.py
+++ b/core/permanence.py
@@ -15,6 +15,13 @@ from datetime import datetime, timezone
 from typing import Dict, List
 
 
+def _connect(db_path: str) -> sqlite3.Connection:
+    """Connection factory with busy_timeout to avoid lock contention."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
 def promote_permanent_nodes(db_path: str, access_threshold: int = 10) -> Dict:
     """
     Promote nodes to permanent status based on access count threshold.
@@ -29,7 +36,7 @@ def promote_permanent_nodes(db_path: str, access_threshold: int = 10) -> Dict:
     Returns:
         Dict with promotion statistics
     """
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     
     # Find nodes that should be permanent but aren't yet
@@ -73,7 +80,7 @@ def get_permanence_stats(db_path: str) -> Dict:
     Returns:
         Dict with permanence statistics
     """
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     
     # Count permanent vs non-permanent nodes
@@ -139,7 +146,7 @@ def calculate_recommended_threshold(db_path: str) -> int:
     Returns:
         Recommended access threshold
     """
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     
     # Get access counts of current permanent nodes
@@ -199,7 +206,7 @@ def validate_embeddings_integrity(db_path: str) -> Dict:
     """
     import numpy as np
 
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
 
     # Defensive: an embeddings table is optional in some DB layouts (older
@@ -283,7 +290,7 @@ def validate_permanence_integrity(db_path: str) -> Dict:
     Returns:
         Dict with validation results
     """
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     cursor = conn.cursor()
     
     # Check for permanent nodes that are marked as decayed (should never happen)

--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -38,7 +38,9 @@ class RetrievalResult:
 
 def _get_connection(db_path: str) -> sqlite3.Connection:
     """Get database connection"""
-    return sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
 
 def _load_node_details(db_path: str, node_ids: List[str], domain_filter: Optional[str] = None, tag_filter: Optional[List[str]] = None, exclude_tags: Optional[List[str]] = None) -> Dict[str, Dict]:
     """Load node details for multiple node IDs with optional domain, tag, and exclusion filtering"""

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -121,7 +121,9 @@ class SleepProtocol:
     
     def _get_connection(self) -> sqlite3.Connection:
         """Get database connection"""
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
     
     def _log_event(self, event_type: str, details: dict):
         """Log sleep event"""

--- a/core/stats.py
+++ b/core/stats.py
@@ -13,7 +13,9 @@ from typing import Dict, Tuple, Union
 
 def get_connection(db_path: str) -> sqlite3.Connection:
     """Single connection factory for the graph database."""
-    return sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
 
 
 def get_active_node_count(cursor: sqlite3.Cursor) -> int:

--- a/core/traversal.py
+++ b/core/traversal.py
@@ -49,7 +49,9 @@ class TraversalEngine:
     
     def _get_connection(self) -> sqlite3.Connection:
         """Get database connection"""
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
     
     def _load_node(self, node_id: str) -> Optional[ThoughtNode]:
         """Load a single node from database"""

--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -226,10 +226,13 @@ def _cmd_extract_ingest(args):
     
     with open(ingest_path, 'r') as f:
         data = json.load(f)
-    
+
+    if isinstance(data, list):
+        data = {"insights": data}
+
     from core.session import _ensure_schema, _create_node, _get_connection
     _ensure_schema(args.db)
-    
+
     new_nodes = 0
     new_node_ids = []
     for item in data.get("insights", []):


### PR DESCRIPTION
#56 fixed `session.py`. The same "database is locked" window exists in
every other module that opens its own connection: metrics, decay,
permanence, graph_utils, embeddings, embedding_cache, retrieval,
traversal, context, export, sleep, stats, extractors, and cashew_cli.

Each connection factory now sets `PRAGMA busy_timeout = 5000` before
returning. Modules that lacked a factory got a `_connect()` helper;
inline sites in cashew_cli got the PRAGMA added directly. The
embedding_cache already set `journal_mode=WAL`; busy_timeout is added
alongside it.