### PR TITLE
fix: add PRAGMA busy_timeout=5000 to remaining sqlite3.connect() sites (extractors/obsidian.py, scripts/migrate_embeddings.py)

### DIFF
--- a/extractors/obsidian.py
+++ b/extractors/obsidian.py
@@ -189,6 +189,7 @@ Before emitting each statement, ask yourself: should this node exist in the grap
 
         try:
             conn = sqlite3.connect(db_path)
+            conn.execute("PRAGMA busy_timeout = 5000")
             cursor = conn.cursor()
 
             # Get existing nodes with their source files

--- a/scripts/migrate_embeddings.py
+++ b/scripts/migrate_embeddings.py
@@ -55,6 +55,7 @@ def detect_mismatch(db_path: str) -> Optional[Dict]:
       - ``configured_model``: model name from current config
     """
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     try:
         stored = _stored_embedding_dim(conn)
     finally:
@@ -126,6 +127,7 @@ def migrate_embeddings(
 
     t0 = time.time()
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     _load_vec(conn)
     conn.execute("DELETE FROM embeddings")
     try:
@@ -142,6 +144,7 @@ def migrate_embeddings(
 
     # Confirm post-state
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     try:
         stored_after = _stored_embedding_dim(conn)
     finally:


### PR DESCRIPTION
## What

Complements #59 which covered 15 files but missed two modules with direct `sqlite3.connect()` calls.

### Remaining sites fixed

| File | Line | Context |
|---|---|---|
| `extractors/obsidian.py` | 191 | `_create_wikilink_edges` — writes edge data during vault extraction |
| `scripts/migrate_embeddings.py` | 57 | `detect_mismatch` — read during migration flows |
| `scripts/migrate_embeddings.py` | 128 | `migrate_embeddings` — DELETE + re-embed (heavy write path) |
| `scripts/migrate_embeddings.py` | 144 | `migrate_embeddings` — post-state confirmation query |

All follow the same pattern: `conn.execute("PRAGMA busy_timeout = 5000")` immediately after `sqlite3.connect()`.

## Rationale

PR #56 established `busy_timeout=5000` as the project convention for `core/session.py`. PR #59 applied it to every other core module. This closes the last two gaps uncovered by the full-scope audit.

## Related

- PR #56 — original session.py fix
- PR #59 — bulk coverage of core modules (should merge first; this PR rebases cleanly on top)
- Comment on #59 with full scope audit