### PR TITLE
feat: ClaudeArchiveExtractor — ingest claude.ai conversation archives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Built-in source extractors in `extractors/`:
 | `obsidian.py` | Obsidian vault extraction. Frontmatter, `[[wikilink]]` edges, `.obsidianignore`, domain from folder structure. |
 | `sessions.py` | OpenClaw session JSONL extraction. Incremental line tracking, filters tool calls/system messages. |
 | `markdown_dir.py` | General markdown directory extraction. `.cashewignore` support. |
+| `claude_archive.py` | Claude.ai conversation archive extraction. Walks content blocks to strip tool calls/results, tracks processed conversations by UUID + updated_at, referent_time from message timestamps. |
 | `utils.py` | Shared: `parse_frontmatter()`, `extract_wikilinks()`, `load_ignore_patterns()`, `should_ignore()`, `split_into_paragraphs()`, `detect_domain_from_path()`. |
 
 All extractors: use `model_fn` for LLM extraction when available, fall back to paragraph splitting when not. Checkpointing via `get_state()`/`set_state()` persisted automatically by the registry.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ cashew ingest markdown /path/to/notes/
 
 General purpose extractor for any directory of `.md` files. Respects `.cashewignore` for excluding files.
 
+**Claude.ai conversation archive:**
+
+```bash
+cashew ingest claude_archive /path/to/claude/export/
+```
+
+Extracts knowledge from `conversations.json` — the Claude.ai data export format. Walks content blocks to strip tool calls and results, keeping only human/assistant text. Supports incremental processing via conversation UUIDs, so re-running on the same directory only processes new or updated conversations. Also accepts a direct path to `conversations.json` for convenience.
+
 **Options:**
 
 ```bash
@@ -141,6 +149,7 @@ context = retriever.generate_context(hints=["work", "projects"])
 | `cashew ingest obsidian /path` | Ingest an Obsidian vault |
 | `cashew ingest sessions /path` | Ingest OpenClaw session logs |
 | `cashew ingest markdown /path` | Ingest a directory of markdown files |
+| `cashew ingest claude_archive /path` | Ingest a claude.ai conversation archive |
 | `cashew think` | Run a think cycle |
 | `cashew sleep` | Full sleep cycle (consolidation) |
 | `cashew stats` | Graph statistics |

--- a/cashew_cli.py
+++ b/cashew_cli.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from core.config import config, reload_config, get_db_path
 from core.embeddings import embed_text
 from core.extractors import ExtractorRegistry
-from extractors import ObsidianExtractor, SessionExtractor, MarkdownDirExtractor
+from extractors import ObsidianExtractor, SessionExtractor, MarkdownDirExtractor, ClaudeArchiveExtractor
 
 logger = logging.getLogger("cashew")
 
@@ -392,6 +392,7 @@ def cmd_ingest(args):
     registry.register(ObsidianExtractor())
     registry.register(SessionExtractor())
     registry.register(MarkdownDirExtractor())
+    registry.register(ClaudeArchiveExtractor())
     
     if args.list:
         # List available extractors
@@ -560,6 +561,7 @@ Examples:
   cashew ingest obsidian /path/to/vault # Extract from Obsidian vault
   cashew ingest sessions /path/to/logs  # Extract from session logs
   cashew ingest markdown /path/to/notes # Extract from markdown directory
+  cashew ingest claude_archive /path/to/claude/export/ # Extract from claude.ai archive
   cashew ingest --list                  # Show available extractors
   cashew think                          # Run think cycle
   cashew sleep                          # Run sleep cycle
@@ -608,7 +610,7 @@ Examples:
     
     # ingest command
     ingest_parser = subparsers.add_parser('ingest', help='Ingest knowledge using extractor plugins')
-    ingest_parser.add_argument('extractor', nargs='?', choices=['obsidian', 'sessions', 'markdown'],
+    ingest_parser.add_argument('extractor', nargs='?', choices=['obsidian', 'sessions', 'markdown', 'claude_archive'],
                                help='Extractor type to use')
     ingest_parser.add_argument('path', nargs='?', help='Source path to extract from')
     ingest_parser.add_argument('--list', action='store_true', help='List available extractors')

--- a/extractors/__init__.py
+++ b/extractors/__init__.py
@@ -6,10 +6,12 @@ Available extractors:
 - ObsidianExtractor: Extract knowledge from Obsidian vault markdown files
 - SessionExtractor: Extract knowledge from OpenClaw session JSONL files  
 - MarkdownDirExtractor: Extract knowledge from markdown directory structures
+- ClaudeArchiveExtractor: Extract knowledge from claude.ai conversation archives
 """
 
 from .obsidian import ObsidianExtractor
 from .sessions import SessionExtractor
 from .markdown_dir import MarkdownDirExtractor
+from .claude_archive import ClaudeArchiveExtractor
 
-__all__ = ['ObsidianExtractor', 'SessionExtractor', 'MarkdownDirExtractor']
+__all__ = ['ObsidianExtractor', 'SessionExtractor', 'MarkdownDirExtractor', 'ClaudeArchiveExtractor']

--- a/extractors/claude_archive.py
+++ b/extractors/claude_archive.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+ClaudeArchiveExtractor - Extract knowledge from claude.ai conversation archives.
+
+Usage:
+    cashew ingest claude_archive /path/to/claude/export/
+    cashew ingest claude_archive /path/to/claude/export/conversations.json
+
+Input format:
+    Claude.ai data export produces a `conversations.json` file — a JSON array of
+    conversation objects. Each conversation has:
+        - uuid: unique conversation ID
+        - name: conversation title (user-given or auto-generated)
+        - chat_messages: list of message objects, each with:
+            - sender: "human" or "assistant"
+            - text: the message text (may contain tool output blocks)
+            - content: list of content blocks (text, tool_use, tool_result)
+            - created_at: ISO-8601 timestamp
+            - parent_message_uuid: threading/parent reference
+
+    Tool-use and tool-result blocks are filtered out. Only substantive human and
+    assistant messages are passed to the LLM extraction pipeline.
+
+Features:
+    - Incremental processing (tracks processed conversation UUIDs)
+    - LLM-based extraction via model_fn (with typed node tagging)
+    - Simple fallback extraction when no LLM is available
+    - referent_time preservation from conversation timestamps
+    - .cashewignore support
+    - Handles both the full export directory or a single conversations.json
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.extractors import BaseExtractor
+from extractors.utils import (
+    TYPE_TAGGING_INSTRUCTION,
+    load_ignore_patterns,
+    parse_extraction_lines,
+    parse_typed_statement,
+    should_ignore,
+)
+
+logger = logging.getLogger("cashew.extractors.claude_archive")
+
+
+class ClaudeArchiveExtractor(BaseExtractor):
+    """Extract knowledge from claude.ai conversation archives."""
+
+    @property
+    def name(self) -> str:
+        return "claude_archive"
+
+    def __init__(self):
+        # Track processed conversation UUIDs
+        self._processed: Dict[str, str] = {}  # uuid -> updated_at timestamp
+
+    def extract(self, source_path: str, model_fn: Optional[Callable],
+                db_path: str) -> List[Dict[str, Any]]:
+        """Extract knowledge from claude.ai export directory or file."""
+        source = Path(source_path)
+
+        if not source.exists():
+            logger.error(f"Source path does not exist: {source_path}")
+            return []
+
+        # Locate conversations.json
+        if source.is_file() and source.name == "conversations.json":
+            conv_file = source
+            base_dir = source.parent
+        elif source.is_dir():
+            conv_file = source / "conversations.json"
+            base_dir = source
+        else:
+            logger.error(f"Expected a claude.ai export directory or conversations.json, got: {source_path}")
+            return []
+
+        if not conv_file.exists():
+            logger.error(f"conversations.json not found at {conv_file}")
+            return []
+
+        # Load conversations
+        try:
+            with open(conv_file, 'r', encoding='utf-8') as f:
+                conversations = json.load(f)
+        except (IOError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to load {conv_file}: {e}")
+            return []
+
+        if not isinstance(conversations, list):
+            logger.error(f"Expected JSON array in conversations.json, got {type(conversations).__name__}")
+            return []
+
+        # Load ignore patterns
+        ignore_patterns = load_ignore_patterns(base_dir / ".cashewignore")
+
+        nodes = []
+
+        for conv in conversations:
+            conv_uuid = conv.get("uuid", "")
+            if not conv_uuid:
+                continue
+
+            # Check ignore patterns
+            if should_ignore(Path(conv_uuid), base_dir, ignore_patterns):
+                continue
+
+            # Check if already processed (by updated_at to catch re-exports)
+            updated_at = conv.get("updated_at", "")
+            already_processed = self._processed.get(conv_uuid, "")
+            if already_processed and updated_at and updated_at <= already_processed:
+                continue
+
+            # Extract messages
+            messages = conv.get("chat_messages", [])
+            if not messages:
+                continue
+
+            # Filter and prepare conversation turns
+            turns = self._extract_turns(messages)
+            if not turns:
+                continue
+
+            # Assign conversation-level metadata
+            conv_name = conv.get("name", conv_uuid[:12])
+
+            # Extract knowledge
+            if model_fn:
+                extracted_nodes = self._extract_with_llm(turns, model_fn, conv_uuid, conv_name)
+            else:
+                extracted_nodes = self._extract_simple(turns, conv_uuid, conv_name)
+
+            nodes.extend(extracted_nodes)
+            self._processed[conv_uuid] = updated_at or conv.get("created_at", "")
+
+        return nodes
+
+    def _extract_turns(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Extract human/assistant turns, filtering out tool use and system content.
+
+        Claude.ai messages have a `content` field which is a list of content blocks.
+        Each block has a `type`: "text" (human text), "tool_use", "tool_result", etc.
+        The top-level `text` field is a concatenation of all text blocks, which often
+        includes tool output interspersed.
+
+        Strategy: walk the content blocks, keep only type="text" blocks for both
+        human and assistant messages. This strips tool calls and results cleanly.
+        """
+        turns = []
+
+        for msg in messages:
+            sender = msg.get("sender", "")
+            if sender not in ("human", "assistant"):
+                continue
+
+            created_at = msg.get("created_at", "")
+
+            # Extract only text content blocks (skip tool_use, tool_result, etc.)
+            content_blocks = msg.get("content", [])
+            text_parts = []
+            for block in content_blocks:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "").strip()
+                    if text:
+                        text_parts.append(text)
+
+            if not text_parts:
+                # Fall back to the top-level `text` field if content blocks are empty
+                full_text = (msg.get("text") or "").strip()
+                if not full_text:
+                    continue
+                text_parts = [full_text]
+
+            # Join the text parts
+            combined = "\n\n".join(text_parts)
+
+            # Filter out very short or empty messages
+            if len(combined) < 50:
+                continue
+
+            # Filter out messages that are entirely tool output artifacts
+            # (Claude.ai sometimes renders tool output as text blocks on unsupported devices)
+            tool_artifact_indicators = [
+                "This block is not supported on your current device yet.",
+                "[Tool output truncated]",
+            ]
+            if any(indicator in combined for indicator in tool_artifact_indicators):
+                # Only keep this message if it has substantial non-tool content
+                clean_text = combined
+                for indicator in tool_artifact_indicators:
+                    clean_text = clean_text.replace(indicator, "")
+                if len(clean_text.strip()) < 50:
+                    continue
+                combined = clean_text.strip()
+
+            turns.append({
+                "sender": sender,
+                "text": combined,
+                "created_at": created_at,
+            })
+
+        return turns
+
+    def _extract_with_llm(self, turns: List[Dict[str, Any]],
+                          model_fn: Callable, conv_uuid: str,
+                          conv_name: str) -> List[Dict[str, Any]]:
+        """Extract knowledge using LLM."""
+        if not turns:
+            return []
+
+        # Build conversation transcript
+        conversation_lines = []
+        batch_referent_time = None
+        for turn in turns:
+            role_label = "HUMAN" if turn["sender"] == "human" else "CLAUDE"
+            conversation_lines.append(f"{role_label}: {turn['text']}")
+            ts = (turn.get("created_at") or "").strip()
+            if ts:
+                batch_referent_time = ts  # last non-empty wins
+
+        conv_text = "\n\n".join(conversation_lines)
+
+        prompt = f"""Extract key insights, decisions, commitments, and important information from this conversation.
+
+Conversation: {conv_name}
+
+{conv_text}
+
+Return distinct knowledge statements that would be valuable to remember. Each should be:
+- A specific insight, decision, commitment, or important fact
+- Actionable or memorable for future reference
+- Written in a clear, standalone format
+
+Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding, either it is worth a permanent node or it is not. Skip pleasantries and routine interactions.
+
+{TYPE_TAGGING_INSTRUCTION}"""
+
+        try:
+            response = model_fn(prompt)
+            logger.debug(f"LLM raw ({conv_uuid[:12]}):\n{response}\n---")
+            statements = parse_extraction_lines(response)
+
+            nodes_out = []
+            for raw in statements:
+                node_type, content = parse_typed_statement(
+                    raw, fallback=self._classify_statement)
+                if len(content) <= 20:
+                    continue
+                nodes_out.append({
+                    "content": content,
+                    "type": node_type,
+                    "domain": "claude_conversations",
+                    "source_file": f"extractor:claude_archive:{conv_uuid}",
+                    "referent_time": batch_referent_time,
+                })
+            return nodes_out
+
+        except Exception as e:
+            logger.warning(f"LLM extraction failed for {conv_uuid[:12]}: {e}")
+            return self._extract_simple(turns, conv_uuid, conv_name)
+
+    def _extract_simple(self, turns: List[Dict[str, Any]],
+                        conv_uuid: str, conv_name: str) -> List[Dict[str, Any]]:
+        """Simple extraction without LLM."""
+        nodes = []
+
+        for turn in turns:
+            text = turn.get("text", "").strip()
+            if len(text) < 50:  # Skip short messages (turns filter already handles this)
+                continue
+
+            role = turn.get("sender", "unknown")
+            ts = (turn.get("created_at") or "").strip() or None
+
+            nodes.append({
+                "content": f"{conv_name} ({role}): {text[:500]}",
+                "type": "observation",
+                "domain": "claude_conversations",
+                "source_file": f"extractor:claude_archive:{conv_uuid}",
+                "referent_time": ts,
+            })
+
+        return nodes
+
+    def _classify_statement(self, statement: str) -> str:
+        """Classify extracted statement type."""
+        statement_lower = statement.lower()
+
+        decision_keywords = ['decided', 'will', 'going to', 'plan to', 'agreed']
+        if any(keyword in statement_lower for keyword in decision_keywords):
+            return "decision"
+
+        insight_keywords = ['learned', 'realized', 'discovered', 'found that']
+        if any(keyword in statement_lower for keyword in insight_keywords):
+            return "insight"
+
+        commit_keywords = ['commit', 'promise', 'deadline', 'due', 'by']
+        if any(keyword in statement_lower for keyword in commit_keywords):
+            return "commitment"
+
+        return "observation"
+
+    def get_state(self) -> Dict[str, Any]:
+        return {"processed": self._processed}
+
+    def set_state(self, state: Dict[str, Any]):
+        self._processed = state.get("processed", {})

--- a/tests/test_claude_archive_extractor.py
+++ b/tests/test_claude_archive_extractor.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Tests for ClaudeArchiveExtractor."""
+
+import copy
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.extractors import ExtractorRegistry
+from extractors.claude_archive import ClaudeArchiveExtractor
+
+
+def _make_conversations_json(path, conversations):
+    """Write a synthetic conversations.json to path."""
+    with open(path, 'w') as f:
+        json.dump(conversations, f, indent=2)
+
+
+def _make_db(path):
+    """Create a minimal cashew DB at path and return the path."""
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS thought_nodes (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            node_type TEXT NOT NULL,
+            domain TEXT,
+            timestamp TEXT,
+            access_count INTEGER DEFAULT 0,
+            last_accessed TEXT,
+            confidence REAL,
+            source_file TEXT,
+            decayed INTEGER DEFAULT 0,
+            metadata TEXT,
+            last_updated TEXT,
+            mood_state TEXT,
+            tags TEXT DEFAULT ""
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS derivation_edges (
+            parent_id TEXT,
+            child_id TEXT,
+            weight REAL,
+            reasoning TEXT,
+            confidence REAL,
+            timestamp TEXT,
+            PRIMARY KEY (parent_id, child_id)
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _count_nodes(db_path):
+    """Return count of rows in thought_nodes."""
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM thought_nodes").fetchone()[0]
+    conn.close()
+    return count
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+SIMPLE_CONV = {
+    "uuid": "conv-001",
+    "name": "Refactoring Discussion",
+    "created_at": "2025-06-01T10:00:00Z",
+    "updated_at": "2025-06-01T11:00:00Z",
+    "chat_messages": [
+        {
+            "uuid": "msg-001",
+            "sender": "human",
+            "text": "I need to refactor the database layer to use async connections.",
+            "content": [{"type": "text", "text": "I need to refactor the database layer to use async connections."}],
+            "created_at": "2025-06-01T10:00:00Z",
+            "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        },
+        {
+            "uuid": "msg-002",
+            "sender": "assistant",
+            "text": "Let's use async SQLAlchemy with connection pooling.",
+            "content": [{"type": "text", "text": "Let's use async SQLAlchemy with connection pooling."}],
+            "created_at": "2025-06-01T10:05:00Z",
+            "parent_message_uuid": "msg-001",
+        },
+    ],
+}
+
+CONV_WITH_TOOL_CALLS = {
+    "uuid": "conv-002",
+    "name": "Weather Check and Analysis",
+    "created_at": "2025-06-02T14:00:00Z",
+    "updated_at": "2025-06-02T14:30:00Z",
+    "chat_messages": [
+        {
+            "uuid": "msg-101",
+            "sender": "human",
+            "text": "Can you check the current weather in Raleigh and tell me if it's good for an afternoon bike ride on the greenway trails?",
+            "content": [{"type": "text", "text": "Can you check the current weather in Raleigh and tell me if it's good for an afternoon bike ride on the greenway trails?"}],
+            "created_at": "2025-06-02T14:00:00Z",
+            "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        },
+        {
+            "uuid": "msg-102",
+            "sender": "assistant",
+            "text": "I checked the weather. Currently 84°F and partly cloudy in Raleigh. Good conditions for a bike ride — low chance of rain, moderate temperature. I'd recommend the Neuse River Trail since it has good tree coverage.",
+            "content": [
+                {"type": "text", "text": "Let me look up the current weather data for Raleigh, NC."},
+                {"type": "tool_use", "text": "{}", "name": "get_weather"},
+                {"type": "tool_result", "text": "{\"temp\":84,\"conditions\":\"partly cloudy\"}"},
+                {"type": "text", "text": "Currently 84°F and partly cloudy in Raleigh. Good conditions for a bike ride — low chance of rain, moderate temperature. I'd recommend the Neuse River Trail since it has good tree coverage."},
+            ],
+            "created_at": "2025-06-02T14:02:00Z",
+            "parent_message_uuid": "msg-101",
+        },
+    ],
+}
+
+SHORT_CONV = {
+    "uuid": "conv-003",
+    "name": "Greeting",
+    "created_at": "2025-06-03T09:00:00Z",
+    "updated_at": "2025-06-03T09:01:00Z",
+    "chat_messages": [
+        {
+            "uuid": "msg-201",
+            "sender": "human",
+            "text": "hi",
+            "content": [{"type": "text", "text": "hi"}],
+            "created_at": "2025-06-03T09:00:00Z",
+            "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        },
+    ],
+}
+
+ALL_CONVERSATIONS = [SIMPLE_CONV, CONV_WITH_TOOL_CALLS, SHORT_CONV]
+
+
+class TestClaudeArchiveExtractor(unittest.TestCase):
+    """Test ClaudeArchiveExtractor."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.fixture_dir = Path(self.temp_dir.name)
+        self.db_path = str(self.fixture_dir / "test.db")
+        _make_db(self.db_path)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _run_extractor(self, source_path=None, model_fn=None):
+        """Helper: run the claude_archive extractor and return result."""
+        if source_path is None:
+            source_path = str(self.fixture_dir)
+        ext = ClaudeArchiveExtractor()
+        return ext.extract(source_path, model_fn=model_fn, db_path=self.db_path)
+
+    # ── Basic extraction ──────────────────────────────────────────────
+
+    def test_extracts_substantive_conversations(self):
+        """Should extract nodes from substantive conversations."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SIMPLE_CONV])
+        nodes = self._run_extractor()
+        # Two substantive messages -> 2 nodes (50+ chars each)
+        self.assertEqual(len(nodes), 2)
+
+    def test_strips_tool_calls(self):
+        """Should filter out tool_use and tool_result content blocks."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [CONV_WITH_TOOL_CALLS])
+        nodes = self._run_extractor()
+        # Human message + assistant message (only text blocks kept)
+        self.assertEqual(len(nodes), 2)
+        # Neither node should contain tool output
+        for node in nodes:
+            self.assertNotIn("tool_use", node["content"].lower())
+            self.assertNotIn("tool_result", node["content"].lower())
+
+    def test_skips_short_conversations(self):
+        """Should skip messages under 50 characters."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SHORT_CONV])
+        nodes = self._run_extractor()
+        self.assertEqual(len(nodes), 0)
+
+    def test_skips_conversations_entirely_of_tool_artifacts(self):
+        """Should skip conversations where all substantive content is tool artifacts."""
+        artifact_conv = {
+            "uuid": "conv-artifact",
+            "name": "Tool Only",
+            "created_at": "2025-06-04T12:00:00Z",
+            "updated_at": "2025-06-04T12:00:00Z",
+            "chat_messages": [
+                {
+                    "uuid": "msg-art-1",
+                    "sender": "assistant",
+                    "text": "This block is not supported on your current device yet.",
+                    "content": [{"type": "text", "text": "This block is not supported on your current device yet."}],
+                    "created_at": "2025-06-04T12:00:00Z",
+                    "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+                },
+            ],
+        }
+        _make_conversations_json(self.fixture_dir / "conversations.json", [artifact_conv])
+        nodes = self._run_extractor()
+        self.assertEqual(len(nodes), 0)
+
+    # ── Domain and source_file ────────────────────────────────────────
+
+    def test_domain_is_claude_conversations(self):
+        """All extracted nodes should have domain='claude_conversations'."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SIMPLE_CONV])
+        nodes = self._run_extractor()
+        for node in nodes:
+            self.assertEqual(node.get("domain"), "claude_conversations")
+
+    def test_source_file_contains_extractor_prefix(self):
+        """Source file should follow extractor:claude_archive:<uuid> pattern."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SIMPLE_CONV])
+        nodes = self._run_extractor()
+        for node in nodes:
+            self.assertIn("extractor:claude_archive:conv-001", node.get("source_file", ""))
+
+    # ── referent_time ─────────────────────────────────────────────────
+
+    def test_referent_time_from_message_timestamps(self):
+        """Nodes should carry the created_at timestamp of their message."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SIMPLE_CONV])
+        nodes = self._run_extractor()
+        # First message is human at 10:00:00Z
+        self.assertEqual(nodes[0].get("referent_time"), "2025-06-01T10:00:00Z")
+        # Second message is assistant at 10:05:00Z
+        self.assertEqual(nodes[1].get("referent_time"), "2025-06-01T10:05:00Z")
+
+    # ── Incremental processing ────────────────────────────────────────
+
+    def test_incremental_skips_unchanged_conversations(self):
+        """Second run should produce no nodes for unchanged conversations."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SIMPLE_CONV])
+        ext = ClaudeArchiveExtractor()
+        # First pass
+        nodes1 = ext.extract(str(self.fixture_dir), model_fn=None, db_path=self.db_path)
+        self.assertEqual(len(nodes1), 2)
+        # Second pass - same conversations, same updated_at
+        nodes2 = ext.extract(str(self.fixture_dir), model_fn=None, db_path=self.db_path)
+        self.assertEqual(len(nodes2), 0)
+
+    def test_incremental_processes_updated_conversations(self):
+        """When a conversation's updated_at changes, it should be re-extracted."""
+        conv = copy.deepcopy(SIMPLE_CONV)
+        _make_conversations_json(self.fixture_dir / "conversations.json", [conv])
+        ext = ClaudeArchiveExtractor()
+        # First pass
+        nodes1 = ext.extract(str(self.fixture_dir), model_fn=None, db_path=self.db_path)
+        self.assertEqual(len(nodes1), 2)
+        # Update the conversation with new messages and a later updated_at
+        conv["updated_at"] = "2025-06-01T12:00:00Z"
+        conv["chat_messages"].append({
+            "uuid": "msg-003",
+            "sender": "human",
+            "text": "What about migration strategy? We should do it incrementally.",
+            "content": [{"type": "text", "text": "What about migration strategy? We should do it incrementally."}],
+            "created_at": "2025-06-01T11:00:00Z",
+            "parent_message_uuid": "msg-002",
+        })
+        _make_conversations_json(self.fixture_dir / "conversations.json", [conv])
+        # Second pass - should process new messages
+        nodes2 = ext.extract(str(self.fixture_dir), model_fn=None, db_path=self.db_path)
+        # Re-processing returns all messages in the conversation (dedup happens at registry level)
+        self.assertEqual(len(nodes2), 3)
+        self.assertTrue(any("migration strategy" in n["content"] for n in nodes2))
+
+    # ── Accepts both directory and file path ──────────────────────────
+
+    def test_accepts_directory_path(self):
+        """Should find conversations.json in a directory."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SIMPLE_CONV])
+        nodes = self._run_extractor(source_path=str(self.fixture_dir))
+        self.assertEqual(len(nodes), 2)
+
+    def test_accepts_direct_file_path(self):
+        """Should accept a direct path to conversations.json."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SIMPLE_CONV])
+        nodes = self._run_extractor(source_path=str(self.fixture_dir / "conversations.json"))
+        self.assertEqual(len(nodes), 2)
+
+    # ── Via the registry (integration) ────────────────────────────────
+
+    def test_works_through_registry(self):
+        """Should work when registered and run through ExtractorRegistry."""
+        _make_conversations_json(self.fixture_dir / "conversations.json", [SIMPLE_CONV])
+        registry = ExtractorRegistry(data_dir=str(self.fixture_dir))
+        registry.register(ClaudeArchiveExtractor())
+        result = registry.run("claude_archive", str(self.fixture_dir),
+                              model_fn=None, db_path=self.db_path)
+        self.assertEqual(result["nodes_created"], 2)
+        self.assertEqual(result["errors"], [])
+
+    def test_listed_in_registry(self):
+        """Extractor should be discoverable via list_extractors()."""
+        registry = ExtractorRegistry(data_dir=str(self.fixture_dir))
+        registry.register(ClaudeArchiveExtractor())
+        self.assertIn("claude_archive", registry.list_extractors())
+
+    # ── State persistence ─────────────────────────────────────────────
+
+    def test_state_persistence(self):
+        """get_state/set_state round-trips processed UUIDs."""
+        ext = ClaudeArchiveExtractor()
+        ext._processed = {"conv-001": "2025-06-01T11:00:00Z"}
+        state = ext.get_state()
+        self.assertIn("processed", state)
+        self.assertEqual(state["processed"]["conv-001"], "2025-06-01T11:00:00Z")
+        ext2 = ClaudeArchiveExtractor()
+        ext2.set_state(state)
+        self.assertEqual(ext2._processed, ext._processed)
+
+    # ── Error handling ────────────────────────────────────────────────
+
+    def test_nonexistent_path_returns_empty(self):
+        """Non-existent paths should produce an empty result, not crash."""
+        nodes = self._run_extractor(source_path="/nonexistent/path")
+        self.assertEqual(nodes, [])
+
+    def test_missing_conversations_json_returns_empty(self):
+        """Empty directory with no conversations.json should produce empty result."""
+        nodes = self._run_extractor(source_path=str(self.fixture_dir))
+        self.assertEqual(nodes, [])
+
+    def test_invalid_json_returns_empty(self):
+        """Malformed conversations.json should produce an empty result, not crash."""
+        with open(self.fixture_dir / "conversations.json", 'w') as f:
+            f.write("this is not json")
+        nodes = self._run_extractor()
+        self.assertEqual(nodes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a new extractor for claude.ai conversation archives, as discussed in #52.

**New file: `extractors/claude_archive.py`**
- Reads `conversations.json` from Claude.ai data export (both directory and direct file path)
- Walks content blocks to filter out `tool_use`/`tool_result` blocks — keeps only human/assistant text
- Incremental processing via conversation UUID + `updated_at` tracking
- LLM-based extraction via `model_fn` with typed node tagging (same pattern as sessions.py)
- Simple fallback extraction when no LLM available
- `referent_time` propagation from per-message `created_at` timestamps
- .cashewignore support
- Domain: `claude_conversations` (distinct from OpenClaw session domain)

**Updated files:**
- `extractors/__init__.py` — register `ClaudeArchiveExtractor`
- `cashew_cli.py` — add `claude_archive` to ingest choices + CLI epilog example
- `README.md` — new Ingest Sources section + CLI reference row
- `CLAUDE.md` — new entry in extractors table

**Tests: `tests/test_claude_archive_extractor.py`** — 17 tests covering:
- Basic extraction, tool call filtering, short message filtering, artifact detection
- Domain/source_file tagging, referent_time, incremental processing (skip + re-extract)
- Directory and direct file path acceptance
- Registry integration (registration + execution)
- State persistence round-trip
- Error handling (nonexistent path, missing file, invalid JSON)

```
python3 -m pytest tests/test_extractors.py tests/test_claude_archive_extractor.py -q
52 passed
```

*(Disclosure: I am Jasper, an AI agent working on behalf of Magnus Hedemark @magnus919. The design was reviewed with Raj in issue #52 before implementation.)*