### PR TITLE
refactor(extractors): shared LLM extraction helper

### DIFF
--- a/extractors/claude_archive.py
+++ b/extractors/claude_archive.py
@@ -40,7 +40,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.extractors import BaseExtractor
 from extractors.utils import (
+    PERMANENCE_INSTRUCTION,
     TYPE_TAGGING_INSTRUCTION,
+    extract_typed_nodes_via_llm,
     load_ignore_patterns,
     parse_extraction_lines,
     parse_typed_statement,
@@ -237,33 +239,21 @@ Return distinct knowledge statements that would be valuable to remember. Each sh
 - Actionable or memorable for future reference
 - Written in a clear, standalone format
 
-Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding, either it is worth a permanent node or it is not. Skip pleasantries and routine interactions.
+{PERMANENCE_INSTRUCTION} Skip pleasantries and routine interactions.
 
 {TYPE_TAGGING_INSTRUCTION}"""
 
-        try:
-            response = model_fn(prompt)
-            logger.debug(f"LLM raw ({conv_uuid[:12]}):\n{response}\n---")
-            statements = parse_extraction_lines(response)
-
-            nodes_out = []
-            for raw in statements:
-                node_type, content = parse_typed_statement(
-                    raw, fallback=self._classify_statement)
-                if len(content) <= 20:
-                    continue
-                nodes_out.append({
-                    "content": content,
-                    "type": node_type,
-                    "domain": "claude_conversations",
-                    "source_file": f"extractor:claude_archive:{conv_uuid}",
-                    "referent_time": batch_referent_time,
-                })
-            return nodes_out
-
-        except Exception as e:
-            logger.warning(f"LLM extraction failed for {conv_uuid[:12]}: {e}")
+        nodes_out = extract_typed_nodes_via_llm(
+            prompt, model_fn,
+            domain="claude_conversations",
+            source_file=f"extractor:claude_archive:{conv_uuid}",
+            debug_label=conv_uuid[:12],
+            referent_time=batch_referent_time,
+            classifier=self._classify_statement,
+        )
+        if nodes_out is None:
             return self._extract_simple(turns, conv_uuid, conv_name)
+        return nodes_out
 
     def _extract_simple(self, turns: List[Dict[str, Any]],
                         conv_uuid: str, conv_name: str) -> List[Dict[str, Any]]:

--- a/extractors/markdown_dir.py
+++ b/extractors/markdown_dir.py
@@ -20,7 +20,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.extractors import BaseExtractor
 from extractors.utils import (
+    PERMANENCE_INSTRUCTION,
     TYPE_TAGGING_INSTRUCTION,
+    extract_typed_nodes_via_llm,
     load_ignore_patterns, should_ignore, split_into_paragraphs,
     detect_domain_from_path, parse_extraction_lines, parse_typed_statement,
 )
@@ -125,33 +127,21 @@ Return distinct knowledge statements that would be valuable to remember. Each sh
 - Free of markdown formatting
 - Focused on substantive content
 
-Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding, either it is worth a permanent node or it is not. Skip formatting, navigation, and boilerplate text.
+{PERMANENCE_INSTRUCTION} Skip formatting, navigation, and boilerplate text.
 
 {TYPE_TAGGING_INSTRUCTION}"""
 
-        try:
-            response = model_fn(prompt)
-            logger.debug(f"LLM raw ({source_tag}):\n{response}\n---")
-            statements = parse_extraction_lines(response)
-            
-            nodes_out = []
-            for raw in statements:
-                node_type, content = parse_typed_statement(
-                    raw, fallback=self._classify_content)
-                if len(content) <= 15:
-                    continue
-                nodes_out.append({
-                    "content": content,
-                    "type": node_type,
-                    "domain": domain,
-                    "source_file": source_tag,
-                })
-            return nodes_out
-            
-        except Exception as e:
-            logger.warning(f"LLM extraction failed: {e}")
-            # Fallback to paragraph extraction
+        nodes_out = extract_typed_nodes_via_llm(
+            prompt, model_fn,
+            domain=domain,
+            source_file=source_tag,
+            debug_label=source_tag,
+            min_content_length=15,
+            classifier=self._classify_content,
+        )
+        if nodes_out is None:
             return self._extract_paragraphs(content, domain, source_tag)
+        return nodes_out
 
     def _extract_paragraphs(self, content: str, domain: str, 
                             source_tag: str) -> List[Dict[str, Any]]:

--- a/extractors/obsidian.py
+++ b/extractors/obsidian.py
@@ -24,7 +24,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.extractors import BaseExtractor
 from extractors.utils import (
+    PERMANENCE_INSTRUCTION,
     TYPE_TAGGING_INSTRUCTION,
+    extract_typed_nodes_via_llm,
     parse_frontmatter, extract_wikilinks, load_ignore_patterns,
     should_ignore, split_into_paragraphs, detect_domain_from_path,
     parse_extraction_lines, parse_typed_statement,
@@ -139,36 +141,24 @@ Return a list of distinct knowledge statements. Each should be:
 - Actionable or memorable
 - Free of markdown formatting
 
-Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding, either it is worth a permanent node or it is not. Focus on substantive content, not formatting or structure.
+{PERMANENCE_INSTRUCTION} Focus on substantive content, not formatting or structure.
 
 {TYPE_TAGGING_INSTRUCTION}"""
 
-        try:
-            response = model_fn(prompt)
-            logger.debug(f"LLM raw ({source_tag}):\n{response}\n---")
-            statements = parse_extraction_lines(response)
-            
-            nodes_out = []
-            for raw in statements:
-                # Obsidian historically defaulted untagged notes to "insight"
-                # rather than "observation"; preserve that for back-compat
-                # when the LLM does not tag.
-                node_type, content = parse_typed_statement(
-                    raw, default_type="insight")
-                if len(content) <= 20:
-                    continue
-                nodes_out.append({
-                    "content": content,
-                    "type": node_type,
-                    "domain": domain,
-                    "source_file": source_tag,
-                })
-            return nodes_out
-        except Exception as e:
-            logger.warning(f"LLM extraction failed: {e}")
-            # Fallback to paragraph extraction
+        # Obsidian historically defaults untagged notes to "insight" rather
+        # than "observation"; preserve that for back-compat when the LLM
+        # does not tag.
+        nodes_out = extract_typed_nodes_via_llm(
+            prompt, model_fn,
+            domain=domain,
+            source_file=source_tag,
+            debug_label=source_tag,
+            default_type="insight",
+        )
+        if nodes_out is None:
             _, body = parse_frontmatter(content)
             return self._extract_paragraphs(body, domain, source_tag)
+        return nodes_out
 
     def _extract_paragraphs(self, content: str, domain: str, 
                             source_tag: str) -> List[Dict[str, Any]]:

--- a/extractors/sessions.py
+++ b/extractors/sessions.py
@@ -22,7 +22,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.extractors import BaseExtractor
 from extractors.utils import (
+    PERMANENCE_INSTRUCTION,
     TYPE_TAGGING_INSTRUCTION,
+    extract_typed_nodes_via_llm,
     load_ignore_patterns,
     parse_extraction_lines,
     parse_typed_statement,
@@ -180,43 +182,31 @@ Return distinct knowledge statements that would be valuable to remember. Each sh
 - Actionable or memorable for future reference
 - Written in a clear, standalone format
 
-Before emitting each statement, ask yourself: should this node exist in the graph forever? If you would not want future-you to read it, drop it. There is no hedging and no padding, either it is worth a permanent node or it is not. Skip pleasantries and routine interactions.
+{PERMANENCE_INSTRUCTION} Skip pleasantries and routine interactions.
 
 {TYPE_TAGGING_INSTRUCTION}"""
 
-        try:
-            response = model_fn(prompt)
-            logger.debug(f"LLM raw ({session_id}):\n{response}\n---")
-            statements = parse_extraction_lines(response)
-            
-            # Event clock: use the latest message timestamp in this batch as the
-            # referent_time for extracted nodes. Session extractors already parse
-            # per-message timestamps — pass them through so imported historical
-            # sessions get proper event times (not today's ingest time).
-            batch_referent_time = None
-            for msg in messages:
-                ts = (msg.get('timestamp') or '').strip()
-                if ts:
-                    batch_referent_time = ts  # last non-empty wins
+        # Event clock: use the latest message timestamp in this batch as the
+        # referent_time for extracted nodes. Session extractors already parse
+        # per-message timestamps — pass them through so imported historical
+        # sessions get proper event times (not today's ingest time).
+        batch_referent_time = None
+        for msg in messages:
+            ts = (msg.get('timestamp') or '').strip()
+            if ts:
+                batch_referent_time = ts  # last non-empty wins
 
-            nodes_out = []
-            for raw in statements:
-                node_type, content = parse_typed_statement(
-                    raw, fallback=self._classify_statement)
-                if len(content) <= 20:
-                    continue
-                nodes_out.append({
-                    "content": content,
-                    "type": node_type,
-                    "domain": "conversations",
-                    "source_file": f"extractor:session:{session_id}",
-                    "referent_time": batch_referent_time,
-                })
-            return nodes_out
-            
-        except Exception as e:
-            logger.warning(f"LLM extraction failed for {session_id}: {e}")
+        nodes_out = extract_typed_nodes_via_llm(
+            prompt, model_fn,
+            domain="conversations",
+            source_file=f"extractor:session:{session_id}",
+            debug_label=session_id,
+            referent_time=batch_referent_time,
+            classifier=self._classify_statement,
+        )
+        if nodes_out is None:
             return self._extract_simple(messages, session_id)
+        return nodes_out
 
     def _extract_simple(self, messages: List[Dict[str, Any]], 
                         session_id: str) -> List[Dict[str, Any]]:

--- a/extractors/utils.py
+++ b/extractors/utils.py
@@ -4,10 +4,13 @@ Shared utilities for cashew extractors.
 """
 
 import fnmatch
+import logging
 import re
 import yaml
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("cashew.extractors.utils")
 
 
 # LLMs tag statements at extraction time with one of the configured node
@@ -45,6 +48,69 @@ TYPE_TAGGING_INSTRUCTION = (
     "When uncertain, use [observation].\n"
     "Output typed statements only, one per line."
 )
+
+# Shared "permanence test" framing. Each extractor appends its own trailing
+# clause (e.g. "Skip pleasantries..." vs "Skip formatting...") since the
+# noise it should reject is source-specific.
+PERMANENCE_INSTRUCTION = (
+    "Before emitting each statement, ask yourself: should this node exist "
+    "in the graph forever? If you would not want future-you to read it, "
+    "drop it. There is no hedging and no padding, either it is worth a "
+    "permanent node or it is not."
+)
+
+
+def extract_typed_nodes_via_llm(
+    prompt: str,
+    model_fn: Callable[[str], str],
+    *,
+    domain: str,
+    source_file: str,
+    debug_label: str = "",
+    referent_time: Optional[str] = None,
+    min_content_length: int = 20,
+    classifier: Optional[Callable[[str], str]] = None,
+    default_type: str = "observation",
+) -> Optional[List[Dict[str, Any]]]:
+    """Run an LLM, parse typed statements, and shape them into node dicts.
+
+    The pattern (model_fn -> parse_extraction_lines -> iterate typed statements
+    -> filter by length -> build node dict) is identical across every
+    extractor that supports an LLM path. This helper owns it.
+
+    Returns the node list on success, or ``None`` on LLM failure so the
+    caller can fall back to a deterministic path. Empty list means the LLM
+    ran but produced no statements that passed the length filter — that is
+    a legitimate result, not a failure.
+    """
+    try:
+        response = model_fn(prompt)
+    except Exception as e:
+        logger.warning(
+            f"LLM extraction failed{f' ({debug_label})' if debug_label else ''}: {e}"
+        )
+        return None
+
+    if debug_label:
+        logger.debug(f"LLM raw ({debug_label}):\n{response}\n---")
+    statements = parse_extraction_lines(response)
+
+    nodes_out: List[Dict[str, Any]] = []
+    for raw in statements:
+        node_type, content = parse_typed_statement(
+            raw, fallback=classifier, default_type=default_type)
+        if len(content) <= min_content_length:
+            continue
+        node: Dict[str, Any] = {
+            "content": content,
+            "type": node_type,
+            "domain": domain,
+            "source_file": source_file,
+        }
+        if referent_time is not None:
+            node["referent_time"] = referent_time
+        nodes_out.append(node)
+    return nodes_out
 
 
 def parse_typed_statement(

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -347,7 +347,7 @@ Another paragraph with useful information.""")
         def mock_model_fn(prompt):
             return "raw obsidian response with enough length here"
 
-        with patch("extractors.obsidian.logger") as mock_logger:
+        with patch("extractors.utils.logger") as mock_logger:
             ObsidianExtractor().extract(str(self.vault_path), mock_model_fn, str(self.db_path))
             debug_calls = " ".join(str(c) for c in mock_logger.debug.call_args_list)
             self.assertIn("raw obsidian response", debug_calls)
@@ -501,7 +501,7 @@ class TestSessionExtractor(unittest.TestCase):
         def mock_model_fn(prompt):
             return "raw session response with enough length here"
 
-        with patch("extractors.sessions.logger") as mock_logger:
+        with patch("extractors.utils.logger") as mock_logger:
             SessionExtractor().extract(str(self.session_dir), mock_model_fn, str(self.db_path))
             debug_calls = " ".join(str(c) for c in mock_logger.debug.call_args_list)
             self.assertIn("raw session response", debug_calls)
@@ -625,7 +625,7 @@ class TestMarkdownDirExtractor(unittest.TestCase):
         def mock_model_fn(prompt):
             return "raw markdown response with enough length here"
 
-        with patch("extractors.markdown_dir.logger") as mock_logger:
+        with patch("extractors.utils.logger") as mock_logger:
             MarkdownDirExtractor().extract(str(self.notes_dir), mock_model_fn, str(self.db_path))
             debug_calls = " ".join(str(c) for c in mock_logger.debug.call_args_list)
             self.assertIn("raw markdown response", debug_calls)


### PR DESCRIPTION
Every extractor that supports an LLM path was repeating the same five-step loop: call `model_fn`, log the raw response, `parse_extraction_lines`, iterate through `parse_typed_statement` with a length filter, build a node dict. Four copies of near-identical code with subtle drift in the min-length cutoff (15 vs 20) and the "should this node exist in the graph forever?" framing prose.

## Changes

- `extract_typed_nodes_via_llm()` in `extractors/utils.py` owns the call, debug logging, parsing, and per-statement filtering. Returns `None` on LLM exception so the caller can fall back to a deterministic path; returns `[]` when the LLM ran cleanly but produced nothing past the length filter.
- `PERMANENCE_INSTRUCTION` constant for the shared framing prose. Each extractor still appends its own trailing clause (pleasantries vs formatting vs boilerplate) since the noise it should reject is source-specific.
- `sessions.py`, `obsidian.py`, `markdown_dir.py`, and `claude_archive.py` updated to use both.

Net `-107 / +133`, with most of the `+133` living in `utils.py` once — per-extractor LLM blocks shrank from ~40 lines to ~10.

## Tests

`tests/test_extractors.py` patches updated: the LLM raw-response debug log now lives on `extractors.utils.logger` instead of each per-extractor logger.

All 52 extractor tests pass. End-to-end smoke on a synthetic claude.ai archive via the CLI produces the same 5 typed nodes (1 decision, 1 fact, 2 commitments, 1 observation) before and after the refactor.

## Follow-up

PR #61 review surfaced a real-world UX bug that affects all extractors: `<data_dir>/extractor_state/<name>.json` persists independently of `brain.db`. If a user wipes their brain but not the state dir, extractors silently skip "already-processed" items. Will open a separate issue.