### PR TITLE
Fix extract --ingest to accept bare JSON arrays

### DIFF
--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -223,16 +223,18 @@ def _cmd_extract_ingest(args):
     if not os.path.exists(ingest_path):
         print(f"❌ Error: Ingest file not found: {ingest_path}")
         return 1
-    
+
     with open(ingest_path, 'r') as f:
         data = json.load(f)
-    
+
     from core.session import _ensure_schema, _create_node, _get_connection
     _ensure_schema(args.db)
-    
+
     new_nodes = 0
     new_node_ids = []
-    for item in data.get("insights", []):
+    # Handle both wrapped {"insights": [...]} and bare array [...] formats
+    insights = data.get("insights", []) if isinstance(data, dict) else data
+    for item in insights:
         content = item.get("content", "")
         node_type = item.get("type", "insight")
         domain = item.get("domain", None)


### PR DESCRIPTION
The extraction prompt outputs bare JSON arrays, but --ingest expected wrapped format `{"insights": [...]}`. Made ingest defensive to accept both, wrapping bare arrays internally.

Tested with both formats:
- Bare array: `[{...}, {...}]` - now works
- Wrapped format: `{"insights": [...]}` - still works (backwards compatible)

Verified nodes are correctly ingested in both cases.