### PR TITLE
fix: handle bare JSON array in extract --ingest

### DIFF
--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -223,16 +223,25 @@ def _cmd_extract_ingest(args):
     if not os.path.exists(ingest_path):
         print(f"❌ Error: Ingest file not found: {ingest_path}")
         return 1
-    
+
     with open(ingest_path, 'r') as f:
         data = json.load(f)
-    
+
+    # Handle both bare JSON array and wrapped dict with "insights" key
+    if isinstance(data, list):
+        insights = data
+    elif isinstance(data, dict):
+        insights = data.get("insights", [])
+    else:
+        print(f"❌ Error: Invalid JSON format (expected array or dict with 'insights' key)")
+        return 1
+
     from core.session import _ensure_schema, _create_node, _get_connection
     _ensure_schema(args.db)
-    
+
     new_nodes = 0
     new_node_ids = []
-    for item in data.get("insights", []):
+    for item in insights:
         content = item.get("content", "")
         node_type = item.get("type", "insight")
         domain = item.get("domain", None)


### PR DESCRIPTION
## Summary
The extraction pipeline outputs bare JSON arrays `[{...}, {...}]`, but the ingest parser only expected wrapped dicts with an `insights` key. This mismatch caused `AttributeError: 'list' object has no attribute 'get'`.

## Changes
- Handle both bare arrays and wrapped dicts in `_cmd_extract_ingest()`
- Validate JSON format and report clear error if neither is matched
- No changes to database schema or other code paths

## Why
Extraction is the primary data ingest mechanism. A format mismatch that breaks JSON parsing means the entire brain ingestion pipeline fails silently or with cryptic errors. This fix ensures robust handling of the JSON output shape without requiring manual workarounds.

## Testing
- Bare array: `cashew extract --ingest bare_array.json`
- Wrapped dict: `cashew extract --ingest wrapped_dict.json` (still works)
- Invalid format: `cashew extract --ingest bad.json` (clear error message)