### PR TITLE
fix(dashboard): skip spring_layout for large graphs, use random positions

### DIFF
--- a/scripts/export_dashboard.py
+++ b/scripts/export_dashboard.py
@@ -12,6 +12,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+import random
+
 import networkx as nx
 
 # Add parent directory to path for imports
@@ -78,31 +80,37 @@ def export(db_path: str, output_path: str, title: str = "cashew"):
                 "reasoning": reasoning
             })
     
-    # Pre-compute layout positions using networkx
-    G = nx.Graph()
-    for n in nodes:
-        G.add_node(n["id"])
-    for e in edges:
-        G.add_edge(e["source"], e["target"], weight=e.get("weight", 0.5))
-
-    if len(G.nodes) > 0:
-        print(f"Computing layout for {len(G.nodes)} nodes...")
-        pos = nx.spring_layout(G, k=1.0/max(1, len(G.nodes)**0.3), iterations=100, seed=42)
-        # Normalize positions to 0-1 range
-        xs = [p[0] for p in pos.values()]
-        ys = [p[1] for p in pos.values()]
-        x_min, x_max = min(xs), max(xs)
-        y_min, y_max = min(ys), max(ys)
-        x_range = x_max - x_min or 1
-        y_range = y_max - y_min or 1
+    # Pre-compute layout positions using networkx (skipped for large graphs)
+    if len(nodes) > 2000 or len(edges) > 50000:
+        print(f"Graph too large for server-side layout ({len(nodes)} nodes, {len(edges)} edges), using random positions.")
         for n in nodes:
-            if n["id"] in pos:
-                n["x"] = (pos[n["id"]][0] - x_min) / x_range
-                n["y"] = (pos[n["id"]][1] - y_min) / y_range
-            else:
-                n["x"] = 0.5
-                n["y"] = 0.5
-        print("Layout computed.")
+            n["x"] = random.random()
+            n["y"] = random.random()
+    else:
+        G = nx.Graph()
+        for n in nodes:
+            G.add_node(n["id"])
+        for e in edges:
+            G.add_edge(e["source"], e["target"], weight=e.get("weight", 0.5))
+
+        if len(G.nodes) > 0:
+            print(f"Computing layout for {len(G.nodes)} nodes...")
+            pos = nx.spring_layout(G, k=1.0/max(1, len(G.nodes)**0.3), iterations=100, seed=42)
+            # Normalize positions to 0-1 range
+            xs = [p[0] for p in pos.values()]
+            ys = [p[1] for p in pos.values()]
+            x_min, x_max = min(xs), max(xs)
+            y_min, y_max = min(ys), max(ys)
+            x_range = x_max - x_min or 1
+            y_range = y_max - y_min or 1
+            for n in nodes:
+                if n["id"] in pos:
+                    n["x"] = (pos[n["id"]][0] - x_min) / x_range
+                    n["y"] = (pos[n["id"]][1] - y_min) / y_range
+                else:
+                    n["x"] = 0.5
+                    n["y"] = 0.5
+            print("Layout computed.")
 
     dashboard = {
         "metadata": {


### PR DESCRIPTION
`nx.spring_layout` is O(n^2) per iteration. On a graph with 4136 nodes
and 15M edges it hangs indefinitely.

If the graph exceeds 2000 nodes or 50000 edges, skip networkx entirely
and assign each node a random x/y in [0, 1). The client-side dashboard
renders its own layout, so pre-computed positions are optional. Small
graphs (under the threshold) continue to use `spring_layout` unchanged.