### PR TITLE
fix: replace IN-subqueries with JOIN in _graph_walk()

### DIFF
--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -203,13 +203,14 @@ def _graph_walk(db_path: str, entry_points: List[str], walk_depth: int = 2) -> D
     cursor = conn.cursor()
     
     # Build adjacency lists for both directions
+    # JOIN is used instead of IN-subqueries because at scale (~50K edges across
+    # ~220K nodes) the IN-subquery path causes SQLite to generate bloom filters
+    # that fail to complete within practical timeouts (~60s+). The JOIN equivalent
+    # executes in under 1s on the same graph.
     cursor.execute("""
-        SELECT parent_id, child_id FROM derivation_edges
-        WHERE parent_id IN (
-            SELECT id FROM thought_nodes WHERE decayed IS NULL OR decayed = 0
-        ) AND child_id IN (
-            SELECT id FROM thought_nodes WHERE decayed IS NULL OR decayed = 0
-        )
+        SELECT e.parent_id, e.child_id FROM derivation_edges e
+        JOIN thought_nodes p ON e.parent_id = p.id AND (p.decayed IS NULL OR p.decayed = 0)
+        JOIN thought_nodes c ON e.child_id = c.id AND (c.decayed IS NULL OR c.decayed = 0)
     """)
     
     # Graph as adjacency lists (both directions)

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -409,3 +409,66 @@ class TestRetrieval:
         for result in results:
             assert isinstance(result, RetrievalResult)
             assert 0.0 <= result.score <= 1.0
+
+
+def test_graph_walk_excludes_decayed_nodes():
+    """Test that _graph_walk() excludes decayed nodes even when they have edges.
+    
+    The JOIN-based query in _graph_walk filters decayed=1 nodes from the
+    adjacency list. A decayed node with an edge to an active node should NOT
+    appear in walk results from that active node.
+    """
+    fd, db_path = tempfile.mkstemp(suffix='.db')
+    os.close(fd)
+    
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute("""
+        CREATE TABLE thought_nodes (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            node_type TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            decayed INTEGER DEFAULT 0
+        )
+    """)
+    c.execute("""
+        CREATE TABLE derivation_edges (
+            parent_id TEXT NOT NULL,
+            child_id TEXT NOT NULL,
+            weight REAL DEFAULT 0.8,
+            reasoning TEXT DEFAULT '',
+            PRIMARY KEY (parent_id, child_id),
+            FOREIGN KEY (parent_id) REFERENCES thought_nodes(id),
+            FOREIGN KEY (child_id) REFERENCES thought_nodes(id)
+        )
+    """)
+    
+    # Seed: one active node, one decayed node, edge connecting them
+    c.execute("INSERT INTO thought_nodes (id, content, node_type, timestamp, decayed) VALUES ('active1', 'I am active', 'observation', '2025-01-01T00:00:00', 0)")
+    c.execute("INSERT INTO thought_nodes (id, content, node_type, timestamp, decayed) VALUES ('decayed_active', 'I should appear in results', 'observation', '2025-01-01T00:00:00', 0)")
+    c.execute("INSERT INTO thought_nodes (id, content, node_type, timestamp, decayed) VALUES ('decayed_dark', 'I should NOT appear in results', 'observation', '2025-01-01T00:00:00', 1)")
+    
+    # Edge from active1 to decayed_dark (the decayed node IS connected)
+    c.execute("INSERT INTO derivation_edges (parent_id, child_id, weight, reasoning) VALUES ('active1', 'decayed_dark', 0.8, 'test')")
+    # Edge from active1 to decayed_active (a non-decayed neighbor)
+    c.execute("INSERT INTO derivation_edges (parent_id, child_id, weight, reasoning) VALUES ('active1', 'decayed_active', 0.8, 'test')")
+    conn.commit()
+    conn.close()
+    
+    # Walk from active1 at depth 2
+    walked = _graph_walk(db_path, ['active1'], walk_depth=2)
+    
+    # Active node and its non-decayed neighbor should be reachable
+    assert 'active1' in walked
+    assert 'decayed_active' in walked
+    
+    # The decayed node has an edge from active1 but should be excluded
+    # by the JOIN filter in _graph_walk
+    assert 'decayed_dark' not in walked, (
+        "Decayed node 'decayed_dark' was found in graph walk results even "
+        "though its decayed=1. The JOIN filter should exclude it."
+    )
+    
+    # Cleanup
+    os.unlink(db_path)


### PR DESCRIPTION
*This issue was filed on behalf of Magnus Hedemark by Jasper, his AI agent. If you need to discuss this with Magnus directly or want clarification about intent, please @mention him.*

## Problem

`_graph_walk()` in `core/retrieval.py` uses IN-subqueries to filter out decayed nodes when building the edge adjacency list. At scale — ~50K edges across ~220K nodes — this causes SQLite's query planner to generate bloom filter subqueries that fail to complete within practical timeouts (60s+), effectively breaking hybrid retrieval for any nontrivial graph.

The identical filter (`WHERE decayed IS NULL OR decayed = 0`) is evaluated twice per row, once for each side of the edge, via correlated subqueries that don't scale.

## Solution

Replace the IN-subquery pattern with JOIN syntax. This is a purely mechanical SQL change — no structural complexity added, no new dependencies, no API surface changes. The JOIN equivalent completes in under 1 second on the same graph:

```sql
SELECT e.parent_id, e.child_id FROM derivation_edges e
JOIN thought_nodes p ON e.parent_id = p.id AND (p.decayed IS NULL OR p.decayed = 0)
JOIN thought_nodes c ON e.child_id = c.id AND (c.decayed IS NULL OR c.decayed = 0)
```

## Why This Approach

- **Fractal simplicity** — the JOIN is structurally simpler than correlated subqueries
- **Backward compatible** — no schema changes, no config changes, same inputs/outputs
- **Consistent** — `retrieve_recursive_bfs()` already loads all edges without a decayed filter and filters in Python; the `_graph_walk()` path is the only one with this performance issue

## Testing

- Added `test_graph_walk_excludes_decayed_nodes()` — creates a graph with both active and decayed nodes connected by edges, then verifies that `_graph_walk()` correctly excludes the decayed node despite the edge existing
- All 16 existing retrieval tests continue to pass

Closes #78
