### PR TITLE
fix(retrieval): lazy-load edges in BFS instead of preloading all 14.5M

### DIFF
--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -398,12 +398,22 @@ def retrieve_recursive_bfs(db_path: str, query: str, top_k: int = 10, n_seeds: i
     conn = _get_connection(db_path)
     cursor = conn.cursor()
 
-    # Preload adjacency list (both directions)
-    neighbors = defaultdict(set)
-    cursor.execute("SELECT parent_id, child_id FROM derivation_edges")
-    for parent, child in cursor.fetchall():
-        neighbors[parent].add(child)
-        neighbors[child].add(parent)
+    # Lazy-load adjacency list during BFS traversal instead of upfront.
+    # This reduces O(14.5M edges) to O(explored_nodes + their_neighbors).
+    # Neighbors are fetched on-demand when a node is visited.
+    _neighbor_cache = {}
+
+    def get_neighbors(node_id: str) -> set:
+        """Lazily load neighbors for a node. Both parent->child and child->parent edges."""
+        if node_id not in _neighbor_cache:
+            cursor.execute("""
+                SELECT child_id FROM derivation_edges WHERE parent_id = ?
+                UNION
+                SELECT parent_id FROM derivation_edges WHERE child_id = ?
+            """, (node_id, node_id))
+            nbrs = {row[0] for row in cursor.fetchall()}
+            _neighbor_cache[node_id] = nbrs
+        return _neighbor_cache[node_id]
 
     # Cache for embeddings loaded on-demand during BFS
     _vec_cache = {}
@@ -435,7 +445,7 @@ def retrieve_recursive_bfs(db_path: str, query: str, top_k: int = 10, n_seeds: i
     for _depth in range(max_depth):
         next_frontier = []
         for node_id in frontier:
-            nbrs = neighbors.get(node_id, set())
+            nbrs = get_neighbors(node_id)
             if not nbrs:
                 continue
             scored = [(nid, cosine_sim(nid)) for nid in nbrs if nid not in candidates]
@@ -535,11 +545,23 @@ def retrieve_bfs_streaming(db_path: str, query: str, n_seeds: int = 5,
 
     conn = _get_connection(db_path)
     cursor = conn.cursor()
-    neighbors = defaultdict(set)
-    cursor.execute("SELECT parent_id, child_id FROM derivation_edges")
-    for parent, child in cursor.fetchall():
-        neighbors[parent].add(child)
-        neighbors[child].add(parent)
+
+    # Lazy-load adjacency list during BFS traversal instead of upfront.
+    # This reduces O(14.5M edges) to O(explored_nodes + their_neighbors).
+    # Neighbors are fetched on-demand when a node is visited.
+    _neighbor_cache = {}
+
+    def get_neighbors(node_id: str) -> set:
+        """Lazily load neighbors for a node. Both parent->child and child->parent edges."""
+        if node_id not in _neighbor_cache:
+            cursor.execute("""
+                SELECT child_id FROM derivation_edges WHERE parent_id = ?
+                UNION
+                SELECT parent_id FROM derivation_edges WHERE child_id = ?
+            """, (node_id, node_id))
+            nbrs = {row[0] for row in cursor.fetchall()}
+            _neighbor_cache[node_id] = nbrs
+        return _neighbor_cache[node_id]
 
     _vec_cache = {}
     def cosine_sim(node_id: str) -> float:
@@ -566,7 +588,7 @@ def retrieve_bfs_streaming(db_path: str, query: str, n_seeds: int = 5,
         next_frontier = []
         hop_nodes = []
         for node_id in frontier:
-            nbrs = neighbors.get(node_id, set())
+            nbrs = get_neighbors(node_id)
             if not nbrs:
                 continue
             scored = [(nid, cosine_sim(nid)) for nid in nbrs if nid not in candidates]


### PR DESCRIPTION
Preloading the full adjacency map from `derivation_edges` blocks retrieval for several seconds on the production brain (4136 nodes, 15M edges). Typical BFS walks explore only 150-200 nodes at `depth=3 picks_per_hop=3`, so the upfront load is wasted work.

Replaces the upfront `neighbors` dict in `retrieve_recursive_bfs` and `retrieve_bfs_streaming` with an on-demand `get_neighbors(node_id)` helper that hits the edges table only for nodes we actually traverse. Uses a single UNION query for bidirectional edges and a per-call cache to avoid re-fetching.

Complexity goes from O(|E|) to O(explored_nodes + their_neighbors). Expect 5-15x speedup on large brains.

All 15 retrieval tests pass, no regressions.

Replaces and supersedes #76 (which accidentally included the vendored `papers/locomo-run/cashew-gte/` directory in the diff).