### PR TITLE
ci: add pytest workflow on push and pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    env:
+      # sentence-transformers spins up a torch backend that on macOS hits a
+      # known libomp duplicate-load warning. Setting this defensively also on
+      # Linux runners keeps test output noise-free across environments.
+      KMP_DUPLICATE_LIB_OK: "TRUE"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install sqlite-vec
+
+      - name: Run tests
+        run: pytest tests/ -q --tb=short

--- a/scripts/cashew_init.py
+++ b/scripts/cashew_init.py
@@ -11,7 +11,6 @@ import argparse
 import subprocess
 import json
 import shutil
-import requests
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
 


### PR DESCRIPTION
There was no CI pipeline. `release.yml` builds and publishes to PyPI on release but never runs the tests, so a broken `main` could ship.

This adds `.github/workflows/ci.yml` that runs pytest on every push to `main` and every pull request, against a 3.10/3.11/3.12 Python matrix.

## Gating

| Check | Gate |
|---|---|
| pytest | Hard — must pass |
| ruff | Not included (deferred per #69 gating plan, pre-existing debt) |
| mypy | Not included (same reason) |

Once the lint/type debt is worked down separately, those can be added as soft → hard gates.

## Why this is safe to land now

- Issue #68 (the stale embedding-dim assertions that would have made CI red) is resolved by PR #71 (merged tonight). Tests are green on current main: `460 passed in 17.81s`.
- Concurrency group cancels in-flight runs on the same ref, so rapid follow-up commits don't burn Actions minutes on stale code.
- `KMP_DUPLICATE_LIB_OK=TRUE` set explicitly to suppress the libomp warning the sentence-transformers backend produces — matches our local invocation pattern.

Closes #69.