### PR TITLE
fix(db): add PRAGMA busy_timeout to remaining sqlite3.connect() sites

### DIFF
--- a/core/context.py
+++ b/core/context.py
@@ -44,7 +44,9 @@ class ContextRetriever:
     
     def _get_connection(self) -> sqlite3.Connection:
         """Get database connection"""
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
     
     def _extract_keywords(self, query: str) -> List[str]:
         """Extract meaningful keywords from query"""

--- a/core/decay.py
+++ b/core/decay.py
@@ -102,6 +102,7 @@ def cascade_decay(db_path: str, decayed_node_id: str) -> Dict:
         Dict with cascading statistics
     """
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     _ensure_edges_table(cursor)
 
@@ -197,6 +198,7 @@ def auto_decay(db_path: str, min_age_days: int = 14,
         Dict with pruning statistics
     """
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     _ensure_edges_table(cursor)
 
@@ -262,6 +264,7 @@ def get_decay_candidates(db_path: str, min_age_days: int = 14,
                         show_cascade_preview: bool = False) -> Dict:
     """Get statistics on nodes eligible for decay without actually decaying them."""
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     _ensure_edges_table(cursor)
 
@@ -311,6 +314,7 @@ def get_decay_candidates(db_path: str, min_age_days: int = 14,
 def simulate_cascade_decay(db_path: str, decayed_node_id: str) -> int:
     """Simulate cascading decay without modifying the database."""
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     _ensure_edges_table(cursor)
 

--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -101,6 +101,7 @@ def _warn_on_dim_mismatch(db_path: str) -> None:
         return
     try:
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         row = conn.execute(
             "SELECT LENGTH(vector) FROM embeddings WHERE vector IS NOT NULL LIMIT 1"
         ).fetchone()
@@ -134,6 +135,7 @@ def _warn_on_dim_mismatch(db_path: str) -> None:
 def _ensure_embeddings_table(db_path: str):
     """Ensure the embeddings table exists with the correct schema"""
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     
     # Check if table exists
@@ -233,6 +235,7 @@ def embed_nodes(db_path: str, batch_size: int = 100) -> dict:
     _warn_on_dim_mismatch(db_path)
 
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     _load_vec(conn)
     cursor = conn.cursor()
     
@@ -356,6 +359,7 @@ def search(db_path: str, query: str, top_k: int = 10) -> List[Tuple[str, float]]
     query_embedding = np.array(embed_text(query), dtype=np.float32)
     
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     
     # Try sqlite-vec first (O(log N)). Skip when the vec table's dim doesn't
     # match the query embedding (legacy 384-dim table under a 1024-dim model,
@@ -442,6 +446,7 @@ NOVELTY_THRESHOLD = _get_active_profile().novelty_threshold  # reject if nearest
 def load_all_embeddings(db_path: str) -> Dict[str, np.ndarray]:
     """Load all non-decayed node embeddings from DB. Call once, pass to check_novelty."""
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     cursor.execute("""
         SELECT e.node_id, e.vector 
@@ -477,6 +482,7 @@ def check_novelty(db_path: str, content: str, threshold: float = NOVELTY_THRESHO
     # Fast path: sqlite-vec nearest neighbor
     if preloaded_embeddings is None:
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         if (
             _vec_available
             and _has_vec_table(conn)
@@ -529,6 +535,7 @@ def backfill_vec_index(db_path: str) -> dict:
     _ensure_embeddings_table(db_path)
     
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     _load_vec(conn)
     cursor = conn.cursor()
     
@@ -657,6 +664,7 @@ def main():
         
         # Load node details for display
         conn = sqlite3.connect(args.db)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         
         print(f"\nTop {len(results)} results:")

--- a/core/export.py
+++ b/core/export.py
@@ -44,7 +44,9 @@ class GraphExporter:
     
     def _get_connection(self) -> sqlite3.Connection:
         """Get database connection"""
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
     
     def export_nodes(self) -> List[Dict]:
         """Export all nodes"""

--- a/core/extractors.py
+++ b/core/extractors.py
@@ -171,6 +171,7 @@ class ExtractorRegistry:
         import sqlite3
         
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         # Ensure referent_time column is present on older DBs.
         try:

--- a/core/graph_utils.py
+++ b/core/graph_utils.py
@@ -33,6 +33,7 @@ def load_embeddings(db_path: str) -> Tuple[List[str], np.ndarray, Dict[str, Dict
         node_meta: Dict of node_id -> {content, node_type, domain}
     """
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     
     cursor.execute("""

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -22,6 +22,7 @@ def is_metrics_enabled() -> bool:
 def ensure_metrics_table(db_path: str):
     """Ensure the metrics table exists in the database"""
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     
     cursor.execute("""
@@ -55,6 +56,7 @@ def record_metric(db_path: str, metric_type: str, duration_ms: float, **kwargs):
         ensure_metrics_table(db_path)
         
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         
         cursor.execute("""
@@ -138,6 +140,7 @@ def get_metrics_summary(db_path: str, hours: int = 24) -> Dict[str, Any]:
         ensure_metrics_table(db_path)
         
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         
         # Calculate time threshold
@@ -236,6 +239,7 @@ def get_metrics_timeseries(db_path: str, metric_type: str, hours: int = 24) -> L
         ensure_metrics_table(db_path)
         
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         
         since = (datetime.now() - timedelta(hours=hours)).isoformat()
@@ -287,6 +291,7 @@ def get_retrieval_stats(db_path: str, hours: int = 24) -> Dict[str, Any]:
         ensure_metrics_table(db_path)
         
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         
         since = (datetime.now() - timedelta(hours=hours)).isoformat()
@@ -368,6 +373,7 @@ def get_recent_metrics(db_path: str, limit: int = 20) -> List[Dict[str, Any]]:
         ensure_metrics_table(db_path)
         
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         
         cursor.execute("""
@@ -409,6 +415,7 @@ def clear_metrics(db_path: str):
         ensure_metrics_table(db_path)
         
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         cursor = conn.cursor()
         
         cursor.execute("DELETE FROM metrics")

--- a/core/permanence.py
+++ b/core/permanence.py
@@ -30,6 +30,7 @@ def promote_permanent_nodes(db_path: str, access_threshold: int = 10) -> Dict:
         Dict with promotion statistics
     """
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     
     # Find nodes that should be permanent but aren't yet
@@ -74,6 +75,7 @@ def get_permanence_stats(db_path: str) -> Dict:
         Dict with permanence statistics
     """
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     
     # Count permanent vs non-permanent nodes
@@ -140,6 +142,7 @@ def calculate_recommended_threshold(db_path: str) -> int:
         Recommended access threshold
     """
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     
     # Get access counts of current permanent nodes
@@ -200,6 +203,7 @@ def validate_embeddings_integrity(db_path: str) -> Dict:
     import numpy as np
 
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
 
     # Defensive: an embeddings table is optional in some DB layouts (older
@@ -284,6 +288,7 @@ def validate_permanence_integrity(db_path: str) -> Dict:
         Dict with validation results
     """
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     cursor = conn.cursor()
     
     # Check for permanent nodes that are marked as decayed (should never happen)

--- a/core/traversal.py
+++ b/core/traversal.py
@@ -49,7 +49,9 @@ class TraversalEngine:
     
     def _get_connection(self) -> sqlite3.Connection:
         """Get database connection"""
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
     
     def _load_node(self, node_id: str) -> Optional[ThoughtNode]:
         """Load a single node from database"""


### PR DESCRIPTION
## Summary

- Completes the work started by Magnus's PR #56 (session.py) and attempted in #59/#72
- Adds `PRAGMA busy_timeout = 5000` to all remaining raw `sqlite3.connect()` call sites across 9 files (29 total sites)
- For `return sqlite3.connect(...)` patterns (traversal.py, context.py, export.py), converts to the two-line form before returning

## Files changed

- `core/metrics.py` (7 sites)
- `core/decay.py` (4 sites)
- `core/traversal.py` (1 site, return pattern)
- `core/graph_utils.py` (1 site)
- `core/embeddings.py` (8 sites)
- `core/context.py` (1 site, return pattern)
- `core/export.py` (1 site, return pattern)
- `core/permanence.py` (5 sites)
- `core/extractors.py` (1 site)

## Test plan

- [x] All 491 tests pass (`python3 -m pytest tests/ -x -q`)
- [x] Verified every `sqlite3.connect()` call site has pragma on the next line