### PR TITLE
fix(sleep): drop stale embeddings with non-modal dimension

### DIFF
--- a/core/sleep.py
+++ b/core/sleep.py
@@ -159,6 +159,15 @@ def _load_embedding_matrix(
         logger.warning("sleep: skipped %d bad embeddings", bad)
     if not vectors:
         return [], np.array([])
+    # Filter to modal dimension so stale embeddings from old models don't crash np.array()
+    from collections import Counter
+    modal_dim = Counter(len(v) for v in vectors).most_common(1)[0][0]
+    dim_filtered = [(nid, v) for nid, v in zip(valid_ids, vectors) if len(v) == modal_dim]
+    dropped = len(vectors) - len(dim_filtered)
+    if dropped:
+        logger.warning("sleep: dropped %d embeddings with non-modal dimension (modal=%d)", dropped, modal_dim)
+    valid_ids = [nid for nid, _ in dim_filtered]
+    vectors = [v for _, v in dim_filtered]
     return valid_ids, np.array(vectors)
 
 


### PR DESCRIPTION
## Summary

- Dream nodes embedded with the old `all-MiniLM-L6-v2` model (384-dim) crash `np.array()` when mixed with current `gte-large` embeddings (1024-dim)
- Filters `_load_embedding_matrix` to keep only the modal dimension, dropping stale embeddings with a warning log
- Fixes the sleep protocol crashing every cycle from mismatched embedding dimensions

## Test plan

- [ ] All 76 sleep tests pass (`pytest tests/ -k sleep`)
- [ ] Warning is emitted when non-modal embeddings are dropped
- [ ] Sleep cycle completes without `ValueError: setting an array element with a sequence`

Note: `test_think_ingest_respects_diversity_threshold` fails on main and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)