### PR TITLE
fix(cli): trigger in-process fallback when daemon returns empty string

### DIFF
--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -95,7 +95,7 @@ def cmd_context(args):
         except Exception as e:
             logger.debug(f"daemon unavailable, falling back: {e}")
 
-    if context is None:
+    if not context:
         context = generate_session_context(args.db, hints, tags=tags, exclude_tags=exclude)
     elapsed = time.time() - t0
     


### PR DESCRIPTION
The daemon returns \`{"ok": True, "result": ""}\` when it can't generate
context. The old check \`if context is None\` doesn't catch empty strings,
so the in-process fallback never ran and the user got "No context
generated" despite a working fallback path.

Fix: \`if not context\` catches both None and empty string.