### PR TITLE
fix: replace deprecated get_sentence_embedding_dimension() with get_embedding_dimension()

### DIFF
--- a/core/embedding_service.py
+++ b/core/embedding_service.py
@@ -103,7 +103,7 @@ class LocalBackend:
         the dim isn't known a priori."""
         if self._dim is None:
             self._ensure_model()
-            self._dim = self._model.get_sentence_embedding_dimension()
+            self._dim = self._model.get_embedding_dimension()
         return self._dim
 
     def _ensure_model(self) -> None:
@@ -116,7 +116,7 @@ class LocalBackend:
             return np.zeros((0, self.dim), dtype=np.float32)
         self._ensure_model()
         # Update dim from the actual loaded model (authoritative).
-        self._dim = self._model.get_sentence_embedding_dimension()
+        self._dim = self._model.get_embedding_dimension()
         return self._model.encode(texts, convert_to_numpy=True).astype(np.float32)
 
 


### PR DESCRIPTION
## Summary

Replaces the deprecated `get_sentence_embedding_dimension()` with `get_embedding_dimension()` at both call sites in `LocalBackend`. This eliminates the `FutureWarning` emitted by sentence-transformers v5.5.0+ on every embedding model load.

## Changes

- `core/embedding_service.py` — lines 106 and 119: renamed method call

## Testing

Verified against sentence-transformers v5.5.1 with `-W error::FutureWarning`:

- `LocalBackend.dim` resolves correctly (384 for MiniLM, 1024 for gte-large)
- `LocalBackend.encode()` returns properly shaped vectors
- `EmbeddingService.embed()` works end-to-end
- **Zero FutureWarnings**

## Closes

Closes #87
