### PR TITLE
fix(db): add PRAGMA busy_timeout to cli, sleep, stats, retrieval, embedding_cache

### DIFF
--- a/cashew_cli.py
+++ b/cashew_cli.py
@@ -68,7 +68,8 @@ def cmd_init(args):
     
     try:
         conn = sqlite3.connect(str(db_path))
-        
+        conn.execute("PRAGMA busy_timeout = 5000")
+
         # Create schema
         conn.execute('''
             CREATE TABLE IF NOT EXISTS thought_nodes (
@@ -457,6 +458,7 @@ def cmd_audit(args):
     if sub == "gc":
         retention = args.retention_days
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         try:
             pruned = gc_decay_audit(conn, retention_days=retention)
             conn.commit()
@@ -467,6 +469,7 @@ def cmd_audit(args):
 
     if sub == "show":
         conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         try:
             rows = conn.execute(
                 "SELECT decay_timestamp, decay_reason, node_type, source_file, "

--- a/core/embedding_cache.py
+++ b/core/embedding_cache.py
@@ -63,6 +63,7 @@ class EmbeddingCache:
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         conn.execute("PRAGMA journal_mode=WAL")
         return conn
 

--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -38,7 +38,9 @@ class RetrievalResult:
 
 def _get_connection(db_path: str) -> sqlite3.Connection:
     """Get database connection"""
-    return sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
 
 def _load_node_details(db_path: str, node_ids: List[str], domain_filter: Optional[str] = None, tag_filter: Optional[List[str]] = None, exclude_tags: Optional[List[str]] = None) -> Dict[str, Dict]:
     """Load node details for multiple node IDs with optional domain, tag, and exclusion filtering"""

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -789,6 +789,7 @@ def _run_dream_async(
     def _task():
         try:
             conn = sqlite3.connect(db_path)
+            conn.execute("PRAGMA busy_timeout = 5000")
             _set_wal(conn)
             dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
             orphans = _embed_orphans(conn)
@@ -852,6 +853,7 @@ def run_sleep_cycle(
 
     t_start = time.perf_counter()
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
     _set_wal(conn)
 
     # Check if embeddings table exists — required for vectorized pipeline
@@ -975,6 +977,7 @@ def run_sleep_cycle(
     # Decay-audit GC (one-shot per cycle)
     try:
         audit_conn = sqlite3.connect(db_path)
+        audit_conn.execute("PRAGMA busy_timeout = 5000")
         audit_pruned = gc_decay_audit(audit_conn, retention_days=7)
         audit_conn.commit()
         audit_conn.close()
@@ -1082,7 +1085,9 @@ class SleepProtocol:
     # ── internal helpers ──────────────────────────────────────────────────
 
     def _get_connection(self) -> sqlite3.Connection:
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
 
     def _log_event(self, event_type: str, details: dict):
         event = SleepEvent(

--- a/core/stats.py
+++ b/core/stats.py
@@ -13,7 +13,9 @@ from typing import Dict, Tuple, Union
 
 def get_connection(db_path: str) -> sqlite3.Connection:
     """Single connection factory for the graph database."""
-    return sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
 
 
 def get_active_node_count(cursor: sqlite3.Cursor) -> int:


### PR DESCRIPTION
## Summary

- Completes `PRAGMA busy_timeout = 5000` coverage across the codebase; PRs #59 and #83 covered the main session connection via `session.py` but missed these five files
- All direct `sqlite3.connect()` calls now set busy_timeout immediately after connection, preventing dead-locks under concurrent access

## Files changed

- `cashew_cli.py` — 3 connect calls (init, gc sub-command, show sub-command)
- `core/embedding_cache.py` — 1 connect call in `_connect()`
- `core/retrieval.py` — `_get_connection()` now assigns to variable, sets pragma, returns
- `core/sleep.py` — 4 connect calls (dream task, main loop, audit_conn, `SleepMonitor._get_connection()`)
- `core/stats.py` — `get_connection()` now assigns, sets pragma, returns

## Test plan

- 282 tests pass; 1 pre-existing failure in `test_prepare_ingest.py::test_think_ingest_respects_diversity_threshold` is unrelated to this change