### PR TITLE
fix(sleep): use resolved model name in _embed_orphans

### DIFF
--- a/core/sleep.py
+++ b/core/sleep.py
@@ -737,7 +737,9 @@ def _embed_orphans(conn: sqlite3.Connection) -> int:
     logger.info("sleep: embedding %d orphaned nodes…", len(rows))
 
     from sentence_transformers import SentenceTransformer
-    model = SentenceTransformer("all-MiniLM-L6-v2")
+    from .embedding_service import _resolve_default_model
+    _model_name = _resolve_default_model()
+    model = SentenceTransformer(_model_name)
 
     embedded = 0
     for nid, content in rows:
@@ -749,7 +751,7 @@ def _embed_orphans(conn: sqlite3.Connection) -> int:
                     "INSERT OR REPLACE INTO embeddings "
                     "(node_id, vector, model, updated_at) "
                     "VALUES (?, ?, ?, datetime('now'))",
-                    (nid, blob, "all-MiniLM-L6-v2"),
+                    (nid, blob, _model_name),
                 )
             except sqlite3.OperationalError:
                 conn.execute(


### PR DESCRIPTION
## Summary

- `_embed_orphans` in `core/sleep.py` hardcoded `all-MiniLM-L6-v2` (384-dim) as the embedding model
- Project has migrated to `thenlper/gte-large` (1024-dim), causing dimension mismatches when the sleep protocol ran on orphan nodes
- Fixed by importing `_resolve_default_model()` from `embedding_service.py` and using the resolved model name both for loading the model and storing in the `embeddings` table

## Test plan

- [x] `python3 -m pytest tests/test_sleep.py -x -q` — 38 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)