### PR TITLE
release: v1.2.1 - hotfix embedding dim call on sentence-transformers < 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-06-29
+
+### Fixed
+- `'SentenceTransformer' object has no attribute 'get_embedding_dimension'` crash on every embed and extract call when installed against sentence-transformers < 5.5. v1.2.0 pre-emptively migrated to the new API name (#88) but sentence-transformers wasn't pinned, so existing installs broke. `core/embedding_service.py` now resolves the dim through a `_model_dim` shim that tries `get_embedding_dimension` first and falls back to the deprecated `get_sentence_embedding_dimension`, supporting both API generations.
+
 ## [1.2.0] - 2026-06-28
 
 This release pairs a major embedding upgrade with a substantial sleep-cycle reshape. Default embeddings move from MiniLM-384 to gte-large-1024; the sleep cycle is now work-capped and vectorized with batched DB writes; per-model similarity thresholds replace the previously hardcoded MiniLM-calibrated constants. A smooth-upgrade path (`cashew migrate-embeddings` + dim-mismatch warning) lets existing brains migrate cleanly. SQLite concurrency is hardened across every connection site with `PRAGMA busy_timeout`. New `ClaudeArchiveExtractor` ingests claude.ai conversation archives.
@@ -114,7 +119,8 @@ First public release on PyPI. `pip install cashew-brain` now works.
 - CLI entry point (`cashew`).
 - PyPI trusted-publishing release workflow (OIDC, no API tokens).
 
-[Unreleased]: https://github.com/rajkripal/cashew/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/rajkripal/cashew/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/rajkripal/cashew/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/rajkripal/cashew/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/rajkripal/cashew/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/rajkripal/cashew/releases/tag/v1.0.1

--- a/core/embedding_service.py
+++ b/core/embedding_service.py
@@ -89,6 +89,20 @@ class Backend(Protocol):
     def encode(self, texts: List[str]) -> np.ndarray: ...
 
 
+def _model_dim(model) -> int:
+    """Resolve embedding dim from a SentenceTransformer instance, supporting
+    both the new (sentence-transformers >= 5.5) and deprecated APIs."""
+    fn = getattr(model, "get_embedding_dimension", None) \
+        or getattr(model, "get_sentence_embedding_dimension", None)
+    if fn is None:
+        raise AttributeError(
+            "SentenceTransformer exposes neither get_embedding_dimension nor "
+            "get_sentence_embedding_dimension; sentence-transformers version "
+            "is unsupported."
+        )
+    return fn()
+
+
 class LocalBackend:
     """In-process sentence-transformer. Lazy-loads to keep import cheap."""
 
@@ -103,7 +117,7 @@ class LocalBackend:
         the dim isn't known a priori."""
         if self._dim is None:
             self._ensure_model()
-            self._dim = self._model.get_embedding_dimension()
+            self._dim = _model_dim(self._model)
         return self._dim
 
     def _ensure_model(self) -> None:
@@ -116,7 +130,7 @@ class LocalBackend:
             return np.zeros((0, self.dim), dtype=np.float32)
         self._ensure_model()
         # Update dim from the actual loaded model (authoritative).
-        self._dim = self._model.get_embedding_dimension()
+        self._dim = _model_dim(self._model)
         return self._model.encode(texts, convert_to_numpy=True).astype(np.float32)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cashew-brain"
-version = "1.2.0"
+version = "1.2.1"
 description = "Persistent thought-graph memory for AI agents. Provides context generation, knowledge extraction, and autonomous think cycles."
 authors = [{name = "rajkripal"}]
 license = {text = "MIT"}
@@ -27,7 +27,7 @@ dependencies = [
     # anthropic removed - LLM access is external via model_fn parameter
     "numpy",
     "scikit-learn",
-    "sentence-transformers",  # for embedding model
+    "sentence-transformers>=2.0",  # works on both pre-5.5 and 5.5+ via runtime shim in core/embedding_service.py
     "PyYAML",  # for config file support
 ]
 

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -144,3 +144,52 @@ class TestEmbeddingService:
         svc, *_ = service_with_fakes
         arr = svc.embed_np([])
         assert arr.shape == (0, EMBEDDING_DIM)
+
+
+# ── _model_dim shim (sentence-transformers <5.5 vs >=5.5) ────────────────
+
+
+class _ModelNewApi:
+    def get_embedding_dimension(self):
+        return 1024
+
+
+class _ModelOldApi:
+    def get_sentence_embedding_dimension(self):
+        return 384
+
+
+class _ModelBothApis:
+    def get_embedding_dimension(self):
+        return 1024
+
+    def get_sentence_embedding_dimension(self):
+        return 999  # should NOT be picked when new API exists
+
+
+class _ModelNoApi:
+    pass
+
+
+class TestModelDimShim:
+    """The shim must support both the new sentence-transformers >=5.5 API
+    (`get_embedding_dimension`) and the deprecated pre-5.5 API
+    (`get_sentence_embedding_dimension`). v1.2.0 shipped a call to the
+    new method without pinning the dep, breaking every install on <5.5."""
+
+    def test_uses_new_api_when_available(self):
+        from core.embedding_service import _model_dim
+        assert _model_dim(_ModelNewApi()) == 1024
+
+    def test_falls_back_to_deprecated_api(self):
+        from core.embedding_service import _model_dim
+        assert _model_dim(_ModelOldApi()) == 384
+
+    def test_prefers_new_api_when_both_exist(self):
+        from core.embedding_service import _model_dim
+        assert _model_dim(_ModelBothApis()) == 1024
+
+    def test_raises_when_neither_api_exists(self):
+        from core.embedding_service import _model_dim
+        with pytest.raises(AttributeError, match="get_embedding_dimension"):
+            _model_dim(_ModelNoApi())


### PR DESCRIPTION
## Summary

v1.2.0's #88 pre-emptively migrated `LocalBackend` to call `model.get_embedding_dimension()` to silence a sentence-transformers 5.5+ FutureWarning. But `sentence-transformers` was unpinned in `pyproject.toml`, and the new method doesn't exist on installed versions < 5.5. Every embed and extract call crashes with:

```
'SentenceTransformer' object has no attribute 'get_embedding_dimension'
```

Caught on prod 9 hours after the v1.2.0 release: brain extraction on the same Mac that built the release blew up because the local install was sentence-transformers 5.2.3 while CI ran against latest. Existing installs at < 5.5 are broken.

## Fix

- `core/embedding_service.py`: new `_model_dim(model)` helper that tries `get_embedding_dimension` first and falls back to `get_sentence_embedding_dimension`. Both `LocalBackend.dim` and `LocalBackend.encode` go through it. Works across both API generations.
- `pyproject.toml`: pins `sentence-transformers>=2.0` so the dep is at least bounded.
- `CHANGELOG.md`: new `[1.2.1] - 2026-06-29` section + footer link update.
- Bumps version 1.2.0 → 1.2.1.

## Test plan

- [x] `pytest tests/ -q` — 492 passed locally on sentence-transformers 5.2.3 (the version that previously crashed)
- [x] Manual smoke: `cashew_context.py extract` no longer raises AttributeError
- [ ] CI matrix on 3.10/3.11/3.12 (CI installs latest, exercises the new-API path)

## After merge

1. Tag `v1.2.1` on the merge commit
2. Push the tag → PyPI publish workflow fires
3. Approve the pypi environment gate → 1.2.1 ships
4. Cut GitHub release
5. `pip install --upgrade cashew-brain` on this box to restore brain writes locally