### PR TITLE
cashew_context: add repair-embeddings subcommand

### DIFF
--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -1692,34 +1692,89 @@ def main():
 
 
 def cmd_repair_embeddings(args):
-    """Detect and optionally delete null/empty-vector rows in the embeddings table."""
-    import core.db as cdb
-    conn = cdb.connect(args.db)
-    rows = conn.execute(
-        "SELECT node_id FROM embeddings WHERE vector IS NULL OR vector = ''"
-    ).fetchall()
-    node_ids = [r[0] for r in rows]
-    count = len(node_ids)
+    """Detect and re-embed null/empty-vector rows in-place.
 
-    if count == 0:
+    Modern code paths never insert NULL/empty vectors; the 13 rows we
+    routinely find in prod are legacy artifacts (best guess: killed
+    process mid-INSERT before the vector bytes landed, or a pre-refactor
+    embed path that has since been removed). Fixing them is a one-shot
+    inline re-embed: pull node content from thought_nodes, embed via the
+    default service, UPDATE the row in place. No wait for sleep needed.
+    """
+    import sqlite3
+    import numpy as np
+    from datetime import datetime
+
+    conn = sqlite3.connect(args.db)
+    conn.execute("PRAGMA busy_timeout = 5000")
+
+    rows = conn.execute(
+        "SELECT e.node_id, tn.content "
+        "FROM embeddings e "
+        "LEFT JOIN thought_nodes tn ON tn.id = e.node_id "
+        "WHERE e.vector IS NULL OR e.vector = ''"
+    ).fetchall()
+
+    if not rows:
         print("No null/empty embeddings found.")
         conn.close()
         return 0
 
-    print(f"Found {count} node(s) with null/empty embeddings:")
-    for nid in node_ids:
-        print(f"  {nid}")
+    orphaned = [nid for nid, content in rows if content is None]
+    fixable = [(nid, content) for nid, content in rows if content is not None]
+
+    print(f"Found {len(rows)} node(s) with null/empty embeddings:")
+    for nid, content in rows:
+        marker = "  (no thought_node — will delete row)" if content is None else ""
+        print(f"  {nid}{marker}")
 
     if args.dry_run:
-        print(f"\nDry-run: {count} row(s) would be deleted. Pass --apply to execute.")
-    else:
-        conn.execute(
-            "DELETE FROM embeddings WHERE vector IS NULL OR vector = ''"
+        print(
+            f"\nDry-run: {len(fixable)} row(s) would be re-embedded in place, "
+            f"{len(orphaned)} orphan row(s) would be deleted. Pass --apply to execute."
         )
-        conn.commit()
-        print(f"\nDeleted {count} row(s). Sleep protocol will re-embed on next run.")
+        conn.close()
+        return 0
 
+    # Delete orphan rows (no matching thought_node — nothing to embed).
+    if orphaned:
+        placeholders = ",".join("?" * len(orphaned))
+        conn.execute(
+            f"DELETE FROM embeddings WHERE node_id IN ({placeholders})",
+            orphaned,
+        )
+
+    # Re-embed the fixable ones in place.
+    embedded = 0
+    if fixable:
+        from core.embedding_service import get_default_service
+        service = get_default_service()
+        texts = [content for _, content in fixable]
+        vectors = service.embed_np(texts)
+        if len(vectors) != len(fixable):
+            print(
+                f"⚠ embedding service returned {len(vectors)} vectors for "
+                f"{len(fixable)} inputs — aborting to avoid mismatched writes."
+            )
+            conn.close()
+            return 1
+        now = datetime.now().isoformat()
+        for (nid, _), vec in zip(fixable, vectors):
+            blob = vec.astype(np.float32).tobytes()
+            conn.execute(
+                "UPDATE embeddings SET vector = ?, model = ?, updated_at = ? "
+                "WHERE node_id = ?",
+                (blob, service.model, now, nid),
+            )
+            embedded += 1
+
+    conn.commit()
     conn.close()
+
+    print(
+        f"\nRepaired: {embedded} row(s) re-embedded in place, "
+        f"{len(orphaned)} orphan row(s) deleted."
+    )
     return 0
 
 

--- a/scripts/cashew_context.py
+++ b/scripts/cashew_context.py
@@ -1637,6 +1637,21 @@ def main():
     init_parser.add_argument("--db", dest="sub_db", default=None, help="Database path (can also be specified before subcommand)")
     init_parser.set_defaults(func=cmd_init)
     
+    # Repair embeddings command
+    repair_emb_parser = subparsers.add_parser(
+        "repair-embeddings",
+        help="Detect and delete null/empty-vector rows so sleep protocol can re-embed them"
+    )
+    repair_emb_parser.add_argument(
+        "--dry-run", action="store_true", default=True,
+        help="Report affected nodes without deleting (default)"
+    )
+    repair_emb_parser.add_argument(
+        "--apply", dest="dry_run", action="store_false",
+        help="Actually delete the empty embedding rows"
+    )
+    repair_emb_parser.set_defaults(func=cmd_repair_embeddings)
+
     # Migrate files command
     migrate_files_parser = subparsers.add_parser("migrate-files", help="Migrate markdown files to cashew database")
     migrate_files_parser.add_argument("--dir", required=True, help="Directory containing markdown files")
@@ -1674,6 +1689,38 @@ def main():
         print(f"🔧 Command: {args.command}", file=sys.stderr)
     
     return args.func(args) or 0
+
+
+def cmd_repair_embeddings(args):
+    """Detect and optionally delete null/empty-vector rows in the embeddings table."""
+    import core.db as cdb
+    conn = cdb.connect(args.db)
+    rows = conn.execute(
+        "SELECT node_id FROM embeddings WHERE vector IS NULL OR vector = ''"
+    ).fetchall()
+    node_ids = [r[0] for r in rows]
+    count = len(node_ids)
+
+    if count == 0:
+        print("No null/empty embeddings found.")
+        conn.close()
+        return 0
+
+    print(f"Found {count} node(s) with null/empty embeddings:")
+    for nid in node_ids:
+        print(f"  {nid}")
+
+    if args.dry_run:
+        print(f"\nDry-run: {count} row(s) would be deleted. Pass --apply to execute.")
+    else:
+        conn.execute(
+            "DELETE FROM embeddings WHERE vector IS NULL OR vector = ''"
+        )
+        conn.commit()
+        print(f"\nDeleted {count} row(s). Sleep protocol will re-embed on next run.")
+
+    conn.close()
+    return 0
 
 
 def cmd_list_tags(args):


### PR DESCRIPTION
13 nodes have `vector = ''` in the embeddings table. The sleep protocol
skips empty vectors, so these nodes are never cross-linked or retrieved.

The new `repair-embeddings` subcommand queries for rows where `vector IS
NULL OR vector = ''`, reports the affected node IDs, and deletes the rows
so the next sleep run re-embeds them from scratch. Dry-run is the default;
pass `--apply` to execute the deletes.

Smoke-tested against the live db: finds all 13 known bad nodes in dry-run
mode with no false positives.