### PR TITLE
fix: add NOT NULL guards at embed_nodes and _embed_orphans INSERT sites

### DIFF
--- a/core/embeddings.py
+++ b/core/embeddings.py
@@ -286,7 +286,13 @@ def embed_nodes(db_path: str, batch_size: int = 100) -> dict:
             )
             for j, (node_id, content) in enumerate(batch):
                 vector_bytes = embeddings[j].astype(np.float32).tobytes()
-                
+
+                if not vector_bytes:
+                    logging.warning(
+                        f"embed_nodes: skipping node {node_id} — embedding produced empty bytes"
+                    )
+                    continue
+
                 cursor.execute("""
                     INSERT OR REPLACE INTO embeddings
                     (node_id, vector, model, updated_at)

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -769,6 +769,13 @@ def _embed_orphans(conn: sqlite3.Connection) -> int:
         try:
             vec = model.encode(content, normalize_embeddings=True)
             blob = vec.astype(np.float32).tobytes()
+
+            if not blob:
+                logger.warning(
+                    "sleep: skipping node %s — embedding produced empty bytes", nid[:8]
+                )
+                continue
+
             try:
                 conn.execute(
                     "INSERT OR REPLACE INTO embeddings "


### PR DESCRIPTION
## Summary

- Guards the `embed_nodes` loop in `core/embeddings.py`: skips INSERT and logs a warning if the embedding produces empty bytes
- Guards the `_embed_orphans` loop in `core/sleep.py`: same skip-and-warn pattern
- Follow-up to PR #101 (repair-embeddings, merged 2026-07-01) which cleaned 13 historical empty-vector rows; this prevents recurrence at the source

## Test plan

- [x] `KMP_DUPLICATE_LIB_OK=TRUE python3 -m pytest tests/ -x -q` — 496 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)