### PR TITLE
fix(sleep): expose a bounded adapter integration contract

### DIFF
--- a/core/decay_audit.py
+++ b/core/decay_audit.py
@@ -5,7 +5,8 @@ Single helper that all decay execution sites call so the `decay_audit` table
 records every transition from live → decayed. Decay decision logic lives in
 the call sites; this module only writes audit rows.
 
-Schema (decay_audit) is created elsewhere; we only INSERT here.
+The schema is created lazily by :func:`ensure_decay_audit_schema` so sleep can
+upgrade legacy databases before the first audit write.
 """
 
 import json
@@ -23,6 +24,35 @@ DECAY_REASONS = (
 )
 
 _SUMMARY_LEN = 80
+
+
+def ensure_decay_audit_schema(conn: sqlite3.Connection) -> None:
+    """Create the additive decay-audit table before any audit write.
+
+    This is deliberately idempotent and does not alter graph tables.  Older
+    brains may have no audit table at all; creating it on the already-open
+    connection preserves their rows and makes subsequent decay decisions
+    observable.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS decay_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            node_id TEXT NOT NULL,
+            content_summary TEXT,
+            decay_reason TEXT,
+            confidence_at_decay REAL,
+            access_count_at_decay INTEGER,
+            last_access_date TEXT,
+            related_nodes TEXT,
+            source_file TEXT,
+            domain TEXT,
+            node_type TEXT,
+            decay_timestamp TEXT,
+            metadata TEXT
+        )
+        """
+    )
 
 
 def _summary(content: Optional[str]) -> str:

--- a/core/decay_audit.py
+++ b/core/decay_audit.py
@@ -53,6 +53,27 @@ def ensure_decay_audit_schema(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    # Some early installations created only a subset of the additive audit
+    # columns.  Migrate those tables in place, retaining all existing rows.
+    required = {
+        "id": "INTEGER",
+        "node_id": "TEXT",
+        "content_summary": "TEXT",
+        "decay_reason": "TEXT",
+        "confidence_at_decay": "REAL",
+        "access_count_at_decay": "INTEGER",
+        "last_access_date": "TEXT",
+        "related_nodes": "TEXT",
+        "source_file": "TEXT",
+        "domain": "TEXT",
+        "node_type": "TEXT",
+        "decay_timestamp": "TEXT",
+        "metadata": "TEXT",
+    }
+    present = {row[1] for row in conn.execute("PRAGMA table_info(decay_audit)")}
+    for name, sql_type in required.items():
+        if name not in present:
+            conn.execute(f"ALTER TABLE decay_audit ADD COLUMN {name} {sql_type}")
 
 
 def _summary(content: Optional[str]) -> str:

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -211,6 +211,70 @@ def _load_embedding_matrix(
 _SLEEP_CURSOR_NAME = "candidate_cursor_v1"
 
 
+def _create_sleep_state_table(conn: sqlite3.Connection) -> None:
+    """Create the private cursor table in its current on-disk shape."""
+    conn.execute(
+        "CREATE TABLE _cashew_sleep_state ("
+        "name TEXT PRIMARY KEY, cursor_timestamp TEXT NOT NULL, "
+        "cursor_node_id TEXT NOT NULL, epoch INTEGER NOT NULL)"
+    )
+
+
+def _ensure_sleep_state_schema(conn: sqlite3.Connection) -> None:
+    """Validate or transactionally migrate the private cursor table.
+
+    The table was introduced as private state and has no user-owned columns.
+    Rebuilding a partial shape is safer than letting a later cursor query fail
+    halfway through sleep.  A usable legacy cursor is retained; otherwise the
+    next page starts at the deterministic beginning.
+    """
+    entry = conn.execute(
+        "SELECT type FROM sqlite_master WHERE name='_cashew_sleep_state'"
+    ).fetchone()
+    if entry is None:
+        _create_sleep_state_table(conn)
+        return
+    if entry[0] != "table":
+        raise sqlite3.DatabaseError("sleep_state_schema_invalid")
+
+    info = conn.execute("PRAGMA table_info(_cashew_sleep_state)").fetchall()
+    shape = [(row[1], (row[2] or "").upper(), row[3], row[5]) for row in info]
+    expected = [
+        ("name", "TEXT", 0, 1),
+        ("cursor_timestamp", "TEXT", 1, 0),
+        ("cursor_node_id", "TEXT", 1, 0),
+        ("epoch", "INTEGER", 1, 0),
+    ]
+    if shape == expected:
+        return
+
+    columns = {row[1] for row in info}
+    saved = None
+    cursor_columns = {"name", "cursor_timestamp", "cursor_node_id"}
+    if cursor_columns.issubset(columns):
+        epoch_expr = "epoch" if "epoch" in columns else "0"
+        row = conn.execute(
+            "SELECT cursor_timestamp, cursor_node_id, " + epoch_expr + " "
+            "FROM _cashew_sleep_state WHERE name=? LIMIT 1",
+            (_SLEEP_CURSOR_NAME,),
+        ).fetchone()
+        if row is not None and row[0] is not None and row[1] is not None:
+            try:
+                epoch = max(0, int(row[2]))
+            except (TypeError, ValueError, OverflowError):
+                epoch = 0
+            saved = (str(row[0]), str(row[1]), epoch)
+
+    conn.execute("DROP TABLE _cashew_sleep_state")
+    _create_sleep_state_table(conn)
+    if saved is not None:
+        conn.execute(
+            "INSERT INTO _cashew_sleep_state "
+            "(name, cursor_timestamp, cursor_node_id, epoch) VALUES (?, ?, ?, ?)",
+            (_SLEEP_CURSOR_NAME, *saved),
+        )
+
+
 def _select_cycle_node_ids(
     conn: sqlite3.Connection, limit: Optional[int],
 ) -> List[str]:
@@ -242,11 +306,7 @@ def _select_cycle_node_ids(
 
     try:
         conn.execute("BEGIN IMMEDIATE")
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS _cashew_sleep_state ("
-            "name TEXT PRIMARY KEY, cursor_timestamp TEXT NOT NULL, "
-            "cursor_node_id TEXT NOT NULL, epoch INTEGER NOT NULL)"
-        )
+        _ensure_sleep_state_schema(conn)
         state = conn.execute(
             "SELECT cursor_timestamp, cursor_node_id, epoch "
             "FROM _cashew_sleep_state WHERE name = ?",
@@ -362,9 +422,13 @@ def _batch_cross_links(
         "candidates": len(cross_pairs), "created": 0, "repaired": 0,
         "skipped": 0, "failed": 0, "directed_rows": 0,
         "same_source_skipped": 0, "capped": False,
+        # Private handoff to dream generation.  Entries are added only after
+        # the transaction containing both directed rows commits.
+        "dream_pairs": [],
     }
     t0 = time.perf_counter()
     dirty = False
+    pending_dream_pairs: List[Tuple[str, str, float]] = []
     for pair_no, (i, j) in enumerate(cross_pairs):
         budget = stats["created"] + stats["repaired"]
         if max_edges is not None and budget >= max_edges:
@@ -419,11 +483,15 @@ def _batch_cross_links(
         else:
             stats["created"] += 1
         stats["directed_rows"] += len(missing)
-        if dirty and (pair_no + 1) % EDGES_PER_BATCH == 0:
+        pending_dream_pairs.append((n1, n2, weight))
+        if dirty and len(pending_dream_pairs) >= EDGES_PER_BATCH:
             conn.commit()
+            stats["dream_pairs"].extend(pending_dream_pairs)
+            pending_dream_pairs.clear()
             dirty = False
     if dirty:
         conn.commit()
+        stats["dream_pairs"].extend(pending_dream_pairs)
     elapsed = time.perf_counter() - t0
     logger.info(
         "sleep: cross-links %d created, %d repaired, %d skipped in %.1fs",
@@ -1476,11 +1544,7 @@ def run_sleep_cycle(
                 max_edges=max_edges,
             )
             if model_fn is not None:
-                for i, j in cross_pairs:
-                    cross_link_tuples.append((
-                        valid_ids[int(i)], valid_ids[int(j)],
-                        float(sim[int(i), int(j)]),
-                    ))
+                cross_link_tuples = list(cross_stats.get("dream_pairs", ()))
 
         # Preserve committed work if a later phase fails.  The outer failure
         # boundary below returns this snapshot instead of erasing persisted

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -846,17 +846,14 @@ def _vec_write_capability(conn: sqlite3.Connection) -> bool:
     except ImportError:
         return False
     try:
-        conn.enable_load_extension(True)
         try:
+            conn.enable_load_extension(True)
             sqlite_vec.load(conn)
-        except (OSError, sqlite3.OperationalError) as exc:
-            # Only failure to load the optional extension is ordinary-only
-            # degradation. Once loaded, schema/query failures are real errors.
-            text = str(exc).lower()
-            if any(token in text for token in
-                   ("not authorized", "cannot load", "no such module", "unable to load")):
-                return False
-            raise
+        except (OSError, sqlite3.Error):
+            # Enable/load failure is the only ordinary-only capability loss.
+            # Errors after this point prove that the extension loaded and must
+            # remain visible as a hard dual-write/schema failure.
+            return False
         conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()
         return True
     finally:
@@ -883,6 +880,7 @@ def _embed_orphans(
     stats = stats if stats is not None else {}
     stats.setdefault("orphan_write_failed", 0)
     stats.setdefault("orphan_vec_unavailable", 0)
+    stats.setdefault("orphan_ordinary_written", 0)
     rows = conn.execute(
         "SELECT tn.id, tn.content FROM thought_nodes tn "
         "LEFT JOIN embeddings e ON tn.id = e.node_id "
@@ -944,6 +942,7 @@ def _embed_orphans(
                     "INSERT OR REPLACE INTO embeddings (node_id, vector) VALUES (?, ?)",
                     (nid, blob),
                 )
+            stats["orphan_ordinary_written"] += 1
             if vec_available:
                 conn.execute(
                     "INSERT OR REPLACE INTO vec_embeddings "
@@ -1048,6 +1047,7 @@ def _empty_sleep_result(
         "dedup_components": 0, "dedup_nodes_merged": 0,
         "nodes_gc_decayed": 0, "nodes_made_permanent": 0,
         "core_promoted": 0, "core_demoted": 0, "orphans_embedded": 0,
+        "orphan_ordinary_written": 0,
         "orphan_write_failed": 0, "orphan_vec_unavailable": 0,
         "vec_rows_compacted": 0, "dream_id": None, "dream_pending": False,
         "dream_generation": "skipped", "elapsed_s": max(0.0, float(elapsed_s)),
@@ -1130,7 +1130,7 @@ def run_sleep_cycle(
         except Exception:
             if embedding_model:
                 return _empty_sleep_result("rejected", "uncalibrated_embedding_model")
-            profile = None
+            return _empty_sleep_result("unavailable", "uncalibrated_embedding_model")
         if all(supplied_embedding) and profile is not None:
             if profile.dim != expected_dimension:
                 return _empty_sleep_result("rejected", "embedding_dimension_mismatch")
@@ -1173,9 +1173,10 @@ def run_sleep_cycle(
         logger.info("sleep: selected %d nodes (limit=%s)", len(ids), limit)
 
         valid_ids, matrix = _load_embedding_matrix(conn, ids, expected_dimension)
+        orphan_stats: dict = {}
+        orphans = 0
         if len(valid_ids) < 2:
             logger.warning("sleep: too few valid embeddings — aborting")
-            orphan_stats: dict = {}
             orphans = _embed_orphans(
                 conn,
                 embedding_client=embedding_client,
@@ -1183,17 +1184,29 @@ def run_sleep_cycle(
                 expected_dimension=expected_dimension,
                 stats=orphan_stats,
             )
-            conn.close()
-            result = _empty_sleep_result("unavailable", "too_few_embeddings",
-                                         time.perf_counter() - t_start)
-            result["nodes_selected"] = len(ids)
-            result["nodes_with_embeddings"] = len(valid_ids)
-            result["orphans_embedded"] = orphans
-            result["orphan_write_failed"] = orphan_stats.get("orphan_write_failed", 0)
-            result["orphan_vec_unavailable"] = orphan_stats.get(
-                "orphan_vec_unavailable", 0
-            )
-            return result
+            rows = conn.execute(
+                "SELECT e.node_id FROM embeddings e "
+                "JOIN thought_nodes tn ON e.node_id = tn.id "
+                "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
+                "ORDER BY tn.timestamp ASC"
+            ).fetchall()
+            ids = [r[0] for r in rows]
+            valid_ids, matrix = _load_embedding_matrix(conn, ids, expected_dimension)
+            if len(valid_ids) < 2:
+                conn.close()
+                result = _empty_sleep_result("unavailable", "too_few_embeddings",
+                                             time.perf_counter() - t_start)
+                result["nodes_selected"] = len(ids)
+                result["nodes_with_embeddings"] = len(valid_ids)
+                result["orphans_embedded"] = orphans
+                result["orphan_ordinary_written"] = orphan_stats.get(
+                    "orphan_ordinary_written", 0
+                )
+                result["orphan_write_failed"] = orphan_stats.get("orphan_write_failed", 0)
+                result["orphan_vec_unavailable"] = orphan_stats.get(
+                    "orphan_vec_unavailable", 0
+                )
+                return result
 
         # Phase 1: candidate discovery
         cross_pairs, dedup_pairs, sim = _find_pairs(
@@ -1297,16 +1310,29 @@ def run_sleep_cycle(
                 dream_pending = True
             else:
                 dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
+        progress["dream_id"] = dream_id
 
         # Phase 9: embed orphans
         if background_dream:
             orphans = 0  # handled by background dream thread
         else:
-            orphan_stats = {}
-            orphans = _embed_orphans(
+            later_orphan_stats: dict = {}
+            later_orphans = _embed_orphans(
                 conn, embedding_client=embedding_client, embedding_model=embedding_model,
-                expected_dimension=expected_dimension, stats=orphan_stats,
+                expected_dimension=expected_dimension, stats=later_orphan_stats,
             )
+            orphans += later_orphans
+            for key in ("orphan_write_failed", "orphan_vec_unavailable",
+                        "orphan_ordinary_written"):
+                orphan_stats[key] = orphan_stats.get(key, 0) + later_orphan_stats.get(key, 0)
+            orphan_stats["capability_missing"] = (
+                orphan_stats.get("capability_missing", False)
+                or later_orphan_stats.get("capability_missing", False)
+            )
+        progress["orphans_embedded"] = orphans
+        progress["orphan_ordinary_written"] = orphan_stats.get(
+            "orphan_ordinary_written", 0
+        )
 
         if background_dream:
             orphan_stats = {}
@@ -1353,6 +1379,9 @@ def run_sleep_cycle(
             cross_stats.get("created", 0) or cross_stats.get("repaired", 0)
             or dedup_stats.get("nodes_merged", 0) or gc_count
             or perm_stats.get("nodes_promoted", 0) or core_stats.get("promoted", 0)
+            or core_stats.get("demoted", 0)
+            or orphan_stats.get("orphan_ordinary_written", 0)
+            or dream_id
         )
         if cross_stats.get("failed"):
             result_status = "partial" if phase_committed else "failed"
@@ -1392,6 +1421,7 @@ def run_sleep_cycle(
             "dream_pending": dream_pending,
             "dream_generation": dream_generation,
             "orphans_embedded": orphans,
+            "orphan_ordinary_written": orphan_stats.get("orphan_ordinary_written", 0),
             "orphan_write_failed": orphan_stats.get("orphan_write_failed", 0),
             "orphan_vec_unavailable": orphan_stats.get("orphan_vec_unavailable", 0),
             "total_nodes": len(metrics),
@@ -1419,7 +1449,7 @@ def run_sleep_cycle(
             )
 
         if dream_generation == "failed" and summary["status"] == "completed":
-            summary["status"] = "partial"
+            summary["status"] = "partial" if phase_committed else "failed"
             summary["error"] = "dream_failed"
         return summary
 
@@ -1429,7 +1459,11 @@ def run_sleep_cycle(
             "cross_links_repaired", 0
         ) + progress.get("dedup_nodes_merged", 0) + progress.get(
             "nodes_gc_decayed", 0
-        )
+        ) + progress.get("nodes_made_permanent", 0) + progress.get(
+            "core_promoted", 0
+        ) + progress.get("core_demoted", 0) + progress.get(
+            "orphan_ordinary_written", 0
+        ) + bool(progress.get("dream_id"))
         if persisted:
             progress["status"] = "partial"
             progress["error"] = "sleep_cycle_failed"

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -1057,6 +1057,15 @@ def _empty_sleep_result(
     return result
 
 
+def _public_sleep_result(result: dict) -> dict:
+    """Project internal phase bookkeeping onto the stable public schema."""
+    public = _empty_sleep_result(
+        result.get("status", "failed"), result.get("error"), result.get("elapsed_s", 0.0)
+    )
+    public.update({key: value for key, value in result.items() if key in public})
+    return public
+
+
 def run_sleep_cycle(
     db_path: Optional[str] = None,
     limit: Optional[int] = None,
@@ -1490,7 +1499,7 @@ def run_sleep_cycle(
             progress["status"] = "partial"
             progress["error"] = "sleep_cycle_failed"
             progress["elapsed_s"] = round(time.perf_counter() - t_start, 1)
-            return progress
+            return _public_sleep_result(progress)
         return _empty_sleep_result("failed", "sleep_cycle_failed",
                                    time.perf_counter() - t_start)
     finally:

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -942,17 +942,20 @@ def _embed_orphans(
                     "INSERT OR REPLACE INTO embeddings (node_id, vector) VALUES (?, ?)",
                     (nid, blob),
                 )
-            stats["orphan_ordinary_written"] += 1
             if vec_available:
                 conn.execute(
                     "INSERT OR REPLACE INTO vec_embeddings "
                     "(node_id, embedding) VALUES (?, ?)",
                     (nid, blob),
                 )
+            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            # Count only after the savepoint has released successfully. A
+            # failed vec write must not claim an ordinary row that rolled back.
+            stats["orphan_ordinary_written"] += 1
+            if vec_available:
                 embedded += 1
             else:
                 stats["orphan_vec_unavailable"] += 1
-            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
         except Exception as exc:
             try:
                 conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
@@ -1192,9 +1195,27 @@ def run_sleep_cycle(
             ).fetchall()
             ids = [r[0] for r in rows]
             valid_ids, matrix = _load_embedding_matrix(conn, ids, expected_dimension)
+            progress.update({
+                "nodes_selected": len(ids),
+                "nodes_with_embeddings": len(valid_ids),
+                "orphans_embedded": orphans,
+                "orphan_ordinary_written": orphan_stats.get(
+                    "orphan_ordinary_written", 0
+                ),
+            })
             if len(valid_ids) < 2:
                 conn.close()
-                result = _empty_sleep_result("unavailable", "too_few_embeddings",
+                durable = bool(
+                    orphans or orphan_stats.get("orphan_ordinary_written", 0)
+                )
+                error = (
+                    "orphan_write_failed" if orphan_stats.get("orphan_write_failed")
+                    else "vec_capability_unavailable"
+                    if orphan_stats.get("orphan_vec_unavailable")
+                    else "too_few_embeddings"
+                )
+                result = _empty_sleep_result(
+                    "partial" if durable else "unavailable", error,
                                              time.perf_counter() - t_start)
                 result["nodes_selected"] = len(ids)
                 result["nodes_with_embeddings"] = len(valid_ids)
@@ -1311,6 +1332,11 @@ def run_sleep_cycle(
             else:
                 dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
         progress["dream_id"] = dream_id
+        progress["dream_generation"] = (
+            "pending" if dream_pending else ("ran" if dream_id else "skipped")
+        )
+        if model_fn is not None and cross_link_tuples and not background_dream and dream_id is None:
+            progress["dream_generation"] = "failed"
 
         # Phase 9: embed orphans
         if background_dream:

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -209,6 +209,15 @@ def _load_embedding_matrix(
 
 
 _SLEEP_CURSOR_NAME = "candidate_cursor_v1"
+_ORPHAN_MISSING_CURSOR_NAME = "orphan_missing_cursor_v1"
+_ORPHAN_REPAIR_CURSOR_NAME = "orphan_repair_cursor_v1"
+_ORPHAN_PHASE_CURSOR_NAME = "orphan_phase_cursor_v1"
+_SLEEP_CURSOR_NAMES = {
+    _SLEEP_CURSOR_NAME,
+    _ORPHAN_MISSING_CURSOR_NAME,
+    _ORPHAN_REPAIR_CURSOR_NAME,
+    _ORPHAN_PHASE_CURSOR_NAME,
+}
 
 
 def _create_sleep_state_table(conn: sqlite3.Connection) -> None:
@@ -217,6 +226,18 @@ def _create_sleep_state_table(conn: sqlite3.Connection) -> None:
         "CREATE TABLE _cashew_sleep_state ("
         "name TEXT PRIMARY KEY, cursor_timestamp TEXT NOT NULL, "
         "cursor_node_id TEXT NOT NULL, epoch INTEGER NOT NULL)"
+    )
+
+
+def _valid_sleep_cursor_row(row: tuple) -> bool:
+    """Return whether one private cursor row has canonical SQLite types."""
+    return (
+        len(row) == 3
+        and isinstance(row[0], str)
+        and isinstance(row[1], str)
+        and isinstance(row[2], int)
+        and not isinstance(row[2], bool)
+        and row[2] >= 0
     )
 
 
@@ -246,32 +267,47 @@ def _ensure_sleep_state_schema(conn: sqlite3.Connection) -> None:
         ("epoch", "INTEGER", 1, 0),
     ]
     if shape == expected:
+        for name in sorted(_SLEEP_CURSOR_NAMES):
+            row = conn.execute(
+                "SELECT cursor_timestamp, cursor_node_id, epoch "
+                "FROM _cashew_sleep_state WHERE name=?",
+                (name,),
+            ).fetchone()
+            if row is not None and not _valid_sleep_cursor_row(row):
+                conn.execute(
+                    "DELETE FROM _cashew_sleep_state WHERE name=?", (name,)
+                )
         return
 
     columns = {row[1] for row in info}
-    saved = None
+    saved: List[Tuple[str, str, str, int]] = []
     cursor_columns = {"name", "cursor_timestamp", "cursor_node_id"}
     if cursor_columns.issubset(columns):
         epoch_expr = "epoch" if "epoch" in columns else "0"
-        row = conn.execute(
-            "SELECT cursor_timestamp, cursor_node_id, " + epoch_expr + " "
-            "FROM _cashew_sleep_state WHERE name=? LIMIT 1",
-            (_SLEEP_CURSOR_NAME,),
-        ).fetchone()
-        if row is not None and row[0] is not None and row[1] is not None:
-            try:
-                epoch = max(0, int(row[2]))
-            except (TypeError, ValueError, OverflowError):
-                epoch = 0
-            saved = (str(row[0]), str(row[1]), epoch)
+        for name in sorted(_SLEEP_CURSOR_NAMES):
+            rows = conn.execute(
+                "SELECT cursor_timestamp, cursor_node_id, " + epoch_expr + " "
+                "FROM _cashew_sleep_state WHERE name=?",
+                (name,),
+            ).fetchall()
+            # A malformed table may contain duplicate or type-confused rows.
+            # There is no canonical owner in that case, so reset this private
+            # cursor to its deterministic origin rather than preserving an
+            # arbitrary SQLite row.
+            if len(rows) != 1:
+                continue
+            if not _valid_sleep_cursor_row(rows[0]):
+                continue
+            timestamp, node_id, epoch_value = rows[0]
+            saved.append((name, timestamp, node_id, epoch_value))
 
     conn.execute("DROP TABLE _cashew_sleep_state")
     _create_sleep_state_table(conn)
-    if saved is not None:
-        conn.execute(
+    if saved:
+        conn.executemany(
             "INSERT INTO _cashew_sleep_state "
             "(name, cursor_timestamp, cursor_node_id, epoch) VALUES (?, ?, ?, ?)",
-            (_SLEEP_CURSOR_NAME, *saved),
+            saved,
         )
 
 
@@ -410,6 +446,7 @@ def _batch_cross_links(
     sim: np.ndarray,
     source_files: Optional[Dict[str, str]] = None,
     max_edges: Optional[int] = None,
+    progress: Optional[dict] = None,
 ) -> dict:
     """Insert cross-link pairs atomically, with pair-budget accounting.
 
@@ -429,10 +466,103 @@ def _batch_cross_links(
     t0 = time.perf_counter()
     dirty = False
     pending_dream_pairs: List[Tuple[str, str, float]] = []
+    pending_created = 0
+    pending_repaired = 0
+    pending_directed_rows = 0
+    pending_pairs: List[Tuple[str, str, bool]] = []
+
+    def publish_progress(*, uncertain: bool = False) -> None:
+        if progress is None:
+            return
+        progress.update({
+            "cross_links_created": stats["created"],
+            "cross_links_repaired": stats["repaired"],
+            "cross_links_skipped": stats["skipped"],
+            "cross_link_directed_rows": stats["directed_rows"],
+            "cross_link_same_source_skipped": stats["same_source_skipped"],
+            "cross_link_capped": stats["capped"],
+        })
+        if uncertain:
+            progress["_outcome_uncertain"] = True
+
+    def apply_pending() -> None:
+        nonlocal dirty, pending_created, pending_repaired, pending_directed_rows
+        if not dirty:
+            return
+        stats["created"] += pending_created
+        stats["repaired"] += pending_repaired
+        stats["directed_rows"] += pending_directed_rows
+        stats["dream_pairs"].extend(pending_dream_pairs)
+        pending_dream_pairs.clear()
+        pending_pairs.clear()
+        pending_created = 0
+        pending_repaired = 0
+        pending_directed_rows = 0
+        dirty = False
+        publish_progress()
+
+    def commit_pending() -> bool:
+        if not dirty:
+            return True
+        try:
+            conn.commit()
+        except Exception:
+            try:
+                conn.rollback()
+            except sqlite3.Error:
+                pass
+            # Verify the attempted transaction after rollback.  SQLite commit
+            # errors normally leave every pending pair at its original shape;
+            # a wrapper can also raise after a successful commit.  Only those
+            # two all-or-nothing outcomes are knowable.  A failed verification
+            # or mixed state is genuinely uncertain and must not invent public
+            # counters or dream inputs.
+            try:
+                final_counts = []
+                for n1, n2, _was_repair in pending_pairs:
+                    final_counts.append(conn.execute(
+                        "SELECT count(*) FROM derivation_edges "
+                        "WHERE (parent_id=? AND child_id=?) OR "
+                        "(parent_id=? AND child_id=?)",
+                        (n1, n2, n2, n1),
+                    ).fetchone()[0])
+            except Exception:
+                publish_progress(uncertain=True)
+                raise
+            original_counts = [1 if repaired else 0 for _, _, repaired in pending_pairs]
+            if final_counts == [2] * len(pending_pairs):
+                apply_pending()
+            elif final_counts != original_counts:
+                publish_progress(uncertain=True)
+                raise
+            else:
+                pending_dream_pairs.clear()
+                pending_pairs.clear()
+                # The whole attempted transaction rolled back.  The already
+                # committed prefix remains exact and the failed suffix does
+                # not contribute to pair or directed-row counters.
+                nonlocal_reset_pending()
+                publish_progress()
+            stats["failed"] += 1
+            return False
+        apply_pending()
+        return True
+
+    def nonlocal_reset_pending() -> None:
+        nonlocal dirty, pending_created, pending_repaired, pending_directed_rows
+        pending_created = 0
+        pending_repaired = 0
+        pending_directed_rows = 0
+        dirty = False
+
     for pair_no, (i, j) in enumerate(cross_pairs):
-        budget = stats["created"] + stats["repaired"]
+        budget = (
+            stats["created"] + stats["repaired"]
+            + pending_created + pending_repaired
+        )
         if max_edges is not None and budget >= max_edges:
             stats["capped"] = True
+            publish_progress()
             break
         n1, n2 = ids[int(i)], ids[int(j)]
         if source_files is not None:
@@ -451,7 +581,10 @@ def _batch_cross_links(
         missing = [(n1, n2), (n2, n1)]
         missing = [(p, c) for p, c in missing if (p, c) not in present]
         name = f"cross_pair_{pair_no}"
+        started_batch = not dirty
         try:
+            if started_batch:
+                conn.execute("BEGIN IMMEDIATE")
             conn.execute(f"SAVEPOINT {name}")
             weight = float(sim[int(i), int(j)])
             conn.executemany(
@@ -475,23 +608,27 @@ def _batch_cross_links(
                 conn.execute(f"RELEASE SAVEPOINT {name}")
             except sqlite3.Error:
                 pass
+            if started_batch:
+                try:
+                    conn.rollback()
+                except sqlite3.Error:
+                    pass
             stats["failed"] += 1
             logger.warning("sleep: cross-link pair failed: %s", type(exc).__name__)
             continue
         if len(present) == 1:
-            stats["repaired"] += 1
+            pending_repaired += 1
         else:
-            stats["created"] += 1
-        stats["directed_rows"] += len(missing)
+            pending_created += 1
+        pending_directed_rows += len(missing)
         pending_dream_pairs.append((n1, n2, weight))
+        pending_pairs.append((n1, n2, len(present) == 1))
         if dirty and len(pending_dream_pairs) >= EDGES_PER_BATCH:
-            conn.commit()
-            stats["dream_pairs"].extend(pending_dream_pairs)
-            pending_dream_pairs.clear()
-            dirty = False
+            if not commit_pending():
+                break
     if dirty:
-        conn.commit()
-        stats["dream_pairs"].extend(pending_dream_pairs)
+        commit_pending()
+    publish_progress()
     elapsed = time.perf_counter() - t0
     logger.info(
         "sleep: cross-links %d created, %d repaired, %d skipped in %.1fs",
@@ -998,8 +1135,11 @@ def _vec_write_capability(conn: sqlite3.Connection) -> bool:
     if not row:
         return False
     ddl = (row[0] or "").lower()
-    if "using vec0" not in ddl:
-        return True
+    if (
+        re.match(r"\s*create\s+virtual\s+table\b", ddl) is None
+        or re.search(r"\busing\s+vec0\s*\(", ddl) is None
+    ):
+        return False
     try:
         import sqlite_vec
     except ImportError:
@@ -1020,6 +1160,127 @@ def _vec_write_capability(conn: sqlite3.Connection) -> bool:
             conn.enable_load_extension(False)
         except sqlite3.Error:
             pass
+
+
+def _claim_orphan_phase_order(
+    conn: sqlite3.Connection, *, capped: bool, vec_available: bool,
+) -> Tuple[str, ...]:
+    """Alternate capped ordinary and vec-repair admission across cycles."""
+    if not capped or not vec_available:
+        return ("ordinary", "repair") if vec_available else ("ordinary",)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        _ensure_sleep_state_schema(conn)
+        row = conn.execute(
+            "SELECT epoch FROM _cashew_sleep_state WHERE name=?",
+            (_ORPHAN_PHASE_CURSOR_NAME,),
+        ).fetchone()
+        try:
+            epoch = int(row[0]) if row is not None else 0
+        except (TypeError, ValueError, OverflowError):
+            epoch = 0
+        epoch = max(0, epoch)
+        conn.execute(
+            "INSERT OR REPLACE INTO _cashew_sleep_state "
+            "(name, cursor_timestamp, cursor_node_id, epoch) VALUES (?, '', '', ?)",
+            (_ORPHAN_PHASE_CURSOR_NAME, epoch + 1),
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return ("ordinary", "repair") if epoch % 2 == 0 else ("repair", "ordinary")
+
+
+def _select_orphan_page(
+    conn: sqlite3.Connection,
+    *,
+    kind: str,
+    take: int,
+    timestamp_expr: str,
+    embedding_columns: Set[str],
+) -> Tuple[List[tuple], bool]:
+    """Claim one durable capped orphan page before inference or DML.
+
+    The boolean is true at a deterministic ordering boundary.  Callers stop
+    this phase there so a short tail is not immediately followed by the same
+    oldest failing rows in one cycle.
+    """
+    if kind == "ordinary":
+        state_name = _ORPHAN_MISSING_CURSOR_NAME
+        select = f"SELECT tn.id, tn.content, {timestamp_expr} "
+        source = (
+            "FROM thought_nodes tn "
+            "LEFT JOIN embeddings e ON tn.id = e.node_id "
+            "WHERE e.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed = 0) "
+            "AND tn.content IS NOT NULL AND TRIM(tn.content) != '' "
+        )
+        id_expr = "tn.id"
+    elif kind == "repair":
+        state_name = _ORPHAN_REPAIR_CURSOR_NAME
+        select = (
+            "SELECT e.node_id, e.vector, "
+            + ("COALESCE(e.model, '')" if "model" in embedding_columns else "''")
+            + f", {timestamp_expr} "
+        )
+        source = (
+            "FROM embeddings e "
+            "LEFT JOIN vec_embeddings v ON v.node_id=e.node_id "
+            "JOIN thought_nodes tn ON tn.id=e.node_id "
+            "WHERE v.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed=0) "
+        )
+        id_expr = "e.node_id"
+    else:
+        raise ValueError("invalid_orphan_phase")
+
+    order = f"ORDER BY {timestamp_expr}, {id_expr} LIMIT ?"
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        _ensure_sleep_state_schema(conn)
+        state = conn.execute(
+            "SELECT cursor_timestamp, cursor_node_id, epoch "
+            "FROM _cashew_sleep_state WHERE name=?",
+            (state_name,),
+        ).fetchone()
+        rows: List[tuple] = []
+        wrapped = False
+        epoch = 0
+        if (
+            state is not None
+            and isinstance(state[0], str)
+            and isinstance(state[1], str)
+        ):
+            cursor_timestamp, cursor_node_id, epoch_value = state
+            try:
+                epoch = max(0, int(epoch_value))
+            except (TypeError, ValueError, OverflowError):
+                epoch = 0
+            rows = conn.execute(
+                select
+                + source
+                + f"AND ({timestamp_expr} > ? OR "
+                + f"({timestamp_expr} = ? AND {id_expr} > ?)) "
+                + order,
+                (cursor_timestamp, cursor_timestamp, cursor_node_id, take),
+            ).fetchall()
+            if not rows:
+                wrapped = True
+                rows = conn.execute(select + source + order, (take,)).fetchall()
+        else:
+            rows = conn.execute(select + source + order, (take,)).fetchall()
+        if rows:
+            last_id = rows[-1][0]
+            last_timestamp = rows[-1][-1]
+            conn.execute(
+                "INSERT OR REPLACE INTO _cashew_sleep_state "
+                "(name, cursor_timestamp, cursor_node_id, epoch) VALUES (?, ?, ?, ?)",
+                (state_name, last_timestamp, last_id, epoch + 1),
+            )
+        conn.commit()
+        return rows, wrapped or len(rows) < take
+    except Exception:
+        conn.rollback()
+        raise
 
 
 def _embed_orphans(
@@ -1167,8 +1428,15 @@ def _embed_orphans(
         return True
 
     ordinary_cursor: Optional[Tuple[str, str]] = None
-    while remaining is None or remaining > 0:
-        take = batch_size if remaining is None else min(batch_size, remaining)
+    repair_cursor: Optional[Tuple[str, str]] = None
+
+    def ordinary_page(take: int) -> Tuple[List[tuple], bool]:
+        nonlocal ordinary_cursor
+        if limit is not None:
+            return _select_orphan_page(
+                conn, kind="ordinary", take=take,
+                timestamp_expr=timestamp_expr, embedding_columns=columns,
+            )
         cursor_sql = ""
         params: List[object] = []
         if ordinary_cursor is not None:
@@ -1189,40 +1457,19 @@ def _embed_orphans(
             + f"ORDER BY {timestamp_expr}, tn.id LIMIT ?",
             params,
         ).fetchall()
-        if not rows:
-            break
-        stats["orphan_examined"] += len(rows)
-        if remaining is not None:
-            remaining -= len(rows)
-        ordinary_cursor = (rows[-1][2], rows[-1][0])
-        try:
-            raw = embedding_client.encode([content for _, content, _ in rows])
-            array = np.asarray(raw)
-            if array.shape != (len(rows), expected):
-                raise ValueError("embedding_shape_mismatch")
-            vectors = [np.asarray(item, dtype=np.float32) for item in array]
-            if any(
-                not np.all(np.isfinite(vec)) or np.allclose(vec, 0)
-                for vec in vectors
-            ):
-                raise ValueError("embedding_invalid")
-        except Exception as exc:
-            logger.warning(
-                "sleep: orphan embedding batch rejected: %s", type(exc).__name__
-            )
-            stats["orphan_write_failed"] += len(rows)
-            break
-        if not commit_batch([
-            (nid, vec.tobytes(), str(embedding_model))
-            for (nid, _content, _timestamp), vec in zip(rows, vectors)
-        ]):
-            break
+        if rows:
+            ordinary_cursor = (rows[-1][2], rows[-1][0])
+        return rows, False
 
-    repair_cursor: Optional[Tuple[str, str]] = None
-    while vec_available and (remaining is None or remaining > 0):
-        take = batch_size if remaining is None else min(batch_size, remaining)
+    def repair_page(take: int) -> Tuple[List[tuple], bool]:
+        nonlocal repair_cursor
+        if limit is not None:
+            return _select_orphan_page(
+                conn, kind="repair", take=take,
+                timestamp_expr=timestamp_expr, embedding_columns=columns,
+            )
         cursor_sql = ""
-        params = []
+        params: List[object] = []
         if repair_cursor is not None:
             cursor_sql = (
                 f"AND ({timestamp_expr} > ? OR "
@@ -1230,7 +1477,7 @@ def _embed_orphans(
             )
             params.extend([repair_cursor[0], repair_cursor[0], repair_cursor[1]])
         params.append(take)
-        repair_rows = conn.execute(
+        rows = conn.execute(
             "SELECT e.node_id, e.vector, "
             + ("COALESCE(e.model, '')" if "model" in columns else "''")
             + f", {timestamp_expr} FROM embeddings e "
@@ -1241,27 +1488,77 @@ def _embed_orphans(
             + f"ORDER BY {timestamp_expr}, e.node_id LIMIT ?",
             params,
         ).fetchall()
-        if not repair_rows:
-            break
-        stats["orphan_examined"] += len(repair_rows)
-        if remaining is not None:
-            remaining -= len(repair_rows)
-        repair_cursor = (repair_rows[-1][3], repair_rows[-1][0])
-        items: List[Tuple[str, bytes, str]] = []
-        for nid, blob, stored_model, _timestamp in repair_rows:
-            try:
-                vec = np.frombuffer(blob, dtype=np.float32)
-                if embedding_model and stored_model and stored_model != embedding_model:
-                    raise ValueError("embedding_model_mismatch")
-                if (len(vec) != expected or not np.all(np.isfinite(vec))
-                        or np.allclose(vec, 0)):
-                    raise ValueError("embedding_invalid")
-            except (TypeError, ValueError, BufferError):
-                stats["orphan_write_failed"] += 1
-                continue
-            items.append((nid, bytes(blob), stored_model or str(embedding_model)))
-        if not commit_batch(items):
-            break
+        if rows:
+            repair_cursor = (rows[-1][3], rows[-1][0])
+        return rows, False
+
+    phase_order = _claim_orphan_phase_order(
+        conn, capped=limit is not None, vec_available=vec_available,
+    )
+    for phase in phase_order:
+        while remaining is None or remaining > 0:
+            take = batch_size if remaining is None else min(batch_size, remaining)
+            if phase == "ordinary":
+                rows, at_boundary = ordinary_page(take)
+                if not rows:
+                    break
+                stats["orphan_examined"] += len(rows)
+                if remaining is not None:
+                    remaining -= len(rows)
+                try:
+                    raw = embedding_client.encode([content for _, content, _ in rows])
+                    array = np.asarray(raw)
+                    if array.shape != (len(rows), expected):
+                        raise ValueError("embedding_shape_mismatch")
+                    vectors = [np.asarray(item, dtype=np.float32) for item in array]
+                    if any(
+                        not np.all(np.isfinite(vec)) or np.allclose(vec, 0)
+                        for vec in vectors
+                    ):
+                        raise ValueError("embedding_invalid")
+                except Exception as exc:
+                    logger.warning(
+                        "sleep: orphan embedding batch rejected: %s",
+                        type(exc).__name__,
+                    )
+                    stats["orphan_write_failed"] += len(rows)
+                    break
+                if not commit_batch([
+                    (nid, vec.tobytes(), str(embedding_model))
+                    for (nid, _content, _timestamp), vec in zip(rows, vectors)
+                ]):
+                    break
+            else:
+                rows, at_boundary = repair_page(take)
+                if not rows:
+                    break
+                stats["orphan_examined"] += len(rows)
+                if remaining is not None:
+                    remaining -= len(rows)
+                items: List[Tuple[str, bytes, str]] = []
+                for nid, blob, stored_model, _timestamp in rows:
+                    try:
+                        vec = np.frombuffer(blob, dtype=np.float32)
+                        if (
+                            embedding_model
+                            and stored_model
+                            and stored_model != embedding_model
+                        ):
+                            raise ValueError("embedding_model_mismatch")
+                        if (
+                            len(vec) != expected
+                            or not np.all(np.isfinite(vec))
+                            or np.allclose(vec, 0)
+                        ):
+                            raise ValueError("embedding_invalid")
+                    except (TypeError, ValueError, BufferError):
+                        stats["orphan_write_failed"] += 1
+                        continue
+                    items.append((nid, bytes(blob), stored_model or str(embedding_model)))
+                if not commit_batch(items):
+                    break
+            if at_boundary:
+                break
 
     logger.info("sleep: embedded/repaired %d orphaned nodes", embedded)
     return embedded
@@ -1538,10 +1835,17 @@ def run_sleep_cycle(
         cross_stats = {"created": 0, "skipped": 0}
         cross_link_tuples: List[Tuple[str, str, float]] = []
         if len(cross_pairs) > 0:
+            progress.update({
+                "nodes_selected": len(ids),
+                "nodes_with_embeddings": len(valid_ids),
+                "cross_link_candidates": len(cross_pairs),
+                "dedup_candidates": len(dedup_pairs),
+            })
             cross_stats = _batch_cross_links(
                 conn, valid_ids, cross_pairs, sim,
                 source_files=source_files if cross_source_only else None,
                 max_edges=max_edges,
+                progress=progress,
             )
             if model_fn is not None:
                 cross_link_tuples = list(cross_stats.get("dream_pairs", ()))
@@ -1765,6 +2069,11 @@ def run_sleep_cycle(
 
     except Exception as exc:
         logger.warning("sleep: cycle failed: %s", type(exc).__name__)
+        if progress.get("_outcome_uncertain"):
+            progress["status"] = "uncertain"
+            progress["error"] = "cross_link_commit_uncertain"
+            progress["elapsed_s"] = round(time.perf_counter() - t_start, 1)
+            return _public_sleep_result(progress)
         persisted = progress.get("cross_links_created", 0) + progress.get(
             "cross_links_repaired", 0
         ) + progress.get("dedup_nodes_merged", 0) + progress.get(

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -262,10 +262,10 @@ def _batch_cross_links(
 ) -> dict:
     """Insert cross-link pairs atomically, with pair-budget accounting.
 
-    Each candidate is committed in a savepoint and verified in both
-    directions. This keeps a trigger, constraint, or interrupted write from
-    producing a claimed half-pair. Existing complete pairs consume no budget;
-    a single-direction legacy pair is repaired and consumes one pair.
+    Each candidate is isolated in a savepoint and verified in both directions.
+    Successful pairs are committed in bounded batches so a trigger,
+    constraint, or interrupted write cannot produce a claimed half-pair while
+    a large cycle still avoids one transaction per edge.
     """
     stats = {
         "candidates": len(cross_pairs), "created": 0, "repaired": 0,
@@ -273,6 +273,7 @@ def _batch_cross_links(
         "same_source_skipped": 0, "capped": False,
     }
     t0 = time.perf_counter()
+    dirty = False
     for pair_no, (i, j) in enumerate(cross_pairs):
         budget = stats["created"] + stats["repaired"]
         if max_edges is not None and budget >= max_edges:
@@ -312,7 +313,7 @@ def _batch_cross_links(
             if len(final) != 2:
                 raise sqlite3.IntegrityError("cross_link_pair_not_persisted")
             conn.execute(f"RELEASE SAVEPOINT {name}")
-            conn.commit()
+            dirty = True
         except Exception as exc:
             try:
                 conn.execute(f"ROLLBACK TO SAVEPOINT {name}")
@@ -327,6 +328,11 @@ def _batch_cross_links(
         else:
             stats["created"] += 1
         stats["directed_rows"] += len(missing)
+        if dirty and (pair_no + 1) % EDGES_PER_BATCH == 0:
+            conn.commit()
+            dirty = False
+    if dirty:
+        conn.commit()
     elapsed = time.perf_counter() - t0
     logger.info(
         "sleep: cross-links %d created, %d repaired, %d skipped in %.1fs",
@@ -836,14 +842,28 @@ def _vec_write_capability(conn: sqlite3.Connection) -> bool:
     if "using vec0" not in ddl:
         return True
     try:
-        from .embeddings import _load_vec, _vec_available
-        if not _vec_available:
-            return False
-        _load_vec(conn)
+        import sqlite_vec
+    except ImportError:
+        return False
+    try:
+        conn.enable_load_extension(True)
+        try:
+            sqlite_vec.load(conn)
+        except (OSError, sqlite3.OperationalError) as exc:
+            # Only failure to load the optional extension is ordinary-only
+            # degradation. Once loaded, schema/query failures are real errors.
+            text = str(exc).lower()
+            if any(token in text for token in
+                   ("not authorized", "cannot load", "no such module", "unable to load")):
+                return False
+            raise
         conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()
         return True
-    except (ImportError, sqlite3.Error, OSError):
-        return False
+    finally:
+        try:
+            conn.enable_load_extension(False)
+        except sqlite3.Error:
+            pass
 
 
 def _embed_orphans(
@@ -880,8 +900,10 @@ def _embed_orphans(
         ).fetchall()
     if not rows and not repair_rows:
         return 0
-    if rows and (embedding_client is None or not embedding_model or
-                 expected_dimension is None or int(expected_dimension) <= 0):
+    if (rows or repair_rows) and (
+        embedding_client is None or not embedding_model or
+        expected_dimension is None or int(expected_dimension) <= 0
+    ):
         stats["capability_missing"] = True
         return 0
     expected = int(expected_dimension) if expected_dimension is not None else 0
@@ -945,18 +967,18 @@ def _embed_orphans(
     for (nid, _content), vec in zip(rows, vectors):
         write_pair(nid, vec.tobytes(), str(embedding_model))
     for nid, blob, stored_model in repair_rows:
-        vec = np.frombuffer(blob, dtype=np.float32)
-        if embedding_model and stored_model and stored_model != embedding_model:
-            stats["orphan_write_failed"] += 1
-            continue
-        repair_dim = (
-            int(expected_dimension)
-            if expected_dimension is not None else len(vec)
-        )
-        if len(vec) != repair_dim:
-            stats["orphan_write_failed"] += 1
-            continue
-        if not np.all(np.isfinite(vec)) or np.allclose(vec, 0):
+        try:
+            vec = np.frombuffer(blob, dtype=np.float32)
+            if embedding_model and stored_model and stored_model != embedding_model:
+                raise ValueError("embedding_model_mismatch")
+            repair_dim = (
+                int(expected_dimension)
+                if expected_dimension is not None else len(vec)
+            )
+            if (len(vec) != repair_dim or not np.all(np.isfinite(vec))
+                    or np.allclose(vec, 0)):
+                raise ValueError("embedding_invalid")
+        except (TypeError, ValueError, BufferError):
             stats["orphan_write_failed"] += 1
             continue
         write_pair(nid, bytes(blob), stored_model or str(embedding_model or ""))
@@ -1079,6 +1101,7 @@ def run_sleep_cycle(
     """
     conn = None
     t_start = time.perf_counter()
+    progress = _empty_sleep_result("failed", "sleep_cycle_failed")
     try:
         if db_path is None:
             db_path = get_db_path()
@@ -1102,12 +1125,15 @@ def run_sleep_cycle(
             or expected_dimension <= 0
         ):
             return _empty_sleep_result("rejected", "invalid_embedding_contract")
-        profile = None
-        if embedding_model:
-            try:
-                profile = _get_active_profile(embedding_model)
-            except Exception:
+        try:
+            profile = _get_active_profile(embedding_model)
+        except Exception:
+            if embedding_model:
                 return _empty_sleep_result("rejected", "uncalibrated_embedding_model")
+            profile = None
+        if all(supplied_embedding) and profile is not None:
+            if profile.dim != expected_dimension:
+                return _empty_sleep_result("rejected", "embedding_dimension_mismatch")
         conn = sqlite3.connect(db_path)
         conn.execute("PRAGMA busy_timeout = 5000")
         if journal_policy == "manage":
@@ -1204,10 +1230,30 @@ def run_sleep_cycle(
                         float(sim[int(i), int(j)]),
                     ))
 
+        # Preserve committed work if a later phase fails.  The outer failure
+        # boundary below returns this snapshot instead of erasing persisted
+        # cross-link progress.
+        progress.update({
+            "nodes_selected": len(ids),
+            "nodes_with_embeddings": len(valid_ids),
+            "cross_link_candidates": len(cross_pairs),
+            "cross_links_created": cross_stats.get("created", 0),
+            "cross_links_repaired": cross_stats.get("repaired", 0),
+            "cross_links_skipped": cross_stats.get("skipped", 0),
+            "cross_link_directed_rows": cross_stats.get("directed_rows", 0),
+            "cross_link_same_source_skipped": cross_stats.get("same_source_skipped", 0),
+            "cross_link_capped": cross_stats.get("capped", False),
+            "dedup_candidates": len(dedup_pairs),
+        })
+
         # Phase 3: dedup
         dedup_stats = {"components": 0, "nodes_merged": 0}
         if len(dedup_pairs) > 0:
             dedup_stats = _run_dedup(conn, valid_ids, dedup_pairs)
+        progress.update({
+            "dedup_components": dedup_stats.get("components", 0),
+            "dedup_nodes_merged": dedup_stats.get("nodes_merged", 0),
+        })
 
         # Phase 4: metrics
         metrics = _compute_metrics(conn)
@@ -1225,12 +1271,16 @@ def run_sleep_cycle(
             think_cycle_penalty=gc_think_cycle_penalty_val,
             mode=gc_mode,
         ))
+        progress["nodes_gc_decayed"] = gc_count
 
         # Phase 6: permanence
         perm_stats = _evaluate_permanence(conn)
+        progress["nodes_made_permanent"] = perm_stats.get("nodes_promoted", 0)
 
         # Phase 7: core memory
         core_stats = _promote_core_memories(conn, metrics)
+        progress["core_promoted"] = core_stats.get("promoted", 0)
+        progress["core_demoted"] = core_stats.get("demoted", 0)
 
         # Phase 8: dream generation
         dream_id = None
@@ -1264,6 +1314,7 @@ def run_sleep_cycle(
         elapsed = round(time.perf_counter() - t_start, 1)
 
         # Decay-audit GC (one-shot per cycle)
+        audit_conn = None
         try:
             audit_conn = sqlite3.connect(db_path)
             audit_conn.execute("PRAGMA busy_timeout = 5000")
@@ -1272,11 +1323,13 @@ def run_sleep_cycle(
             ensure_decay_audit_schema(audit_conn)
             audit_pruned = gc_decay_audit(audit_conn, retention_days=7)
             audit_conn.commit()
-            audit_conn.close()
             if audit_pruned:
                 logger.info("sleep: decay-audit GC pruned %d rows", audit_pruned)
         except Exception as e:
             logger.warning("sleep: decay-audit GC failed: %s", e)
+        finally:
+            if audit_conn is not None:
+                audit_conn.close()
 
         # Vec-index compaction (one-shot per cycle): decay never touched the vec
         # index, so prune rows for nodes decayed this cycle (and any backlog) to
@@ -1301,7 +1354,10 @@ def run_sleep_cycle(
             or dedup_stats.get("nodes_merged", 0) or gc_count
             or perm_stats.get("nodes_promoted", 0) or core_stats.get("promoted", 0)
         )
-        if orphan_stats.get("capability_missing"):
+        if cross_stats.get("failed"):
+            result_status = "partial" if phase_committed else "failed"
+            result_error = "cross_link_failed"
+        elif orphan_stats.get("capability_missing"):
             result_status = "partial" if phase_committed else "unavailable"
             result_error = "embedding_capability_unavailable"
         elif orphan_stats.get("orphan_vec_unavailable"):
@@ -1369,6 +1425,16 @@ def run_sleep_cycle(
 
     except Exception as exc:
         logger.warning("sleep: cycle failed: %s", type(exc).__name__)
+        persisted = progress.get("cross_links_created", 0) + progress.get(
+            "cross_links_repaired", 0
+        ) + progress.get("dedup_nodes_merged", 0) + progress.get(
+            "nodes_gc_decayed", 0
+        )
+        if persisted:
+            progress["status"] = "partial"
+            progress["error"] = "sleep_cycle_failed"
+            progress["elapsed_s"] = round(time.perf_counter() - t_start, 1)
+            return progress
         return _empty_sleep_result("failed", "sleep_cycle_failed",
                                    time.perf_counter() - t_start)
     finally:

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -1380,6 +1380,7 @@ def run_sleep_cycle(
             or dedup_stats.get("nodes_merged", 0) or gc_count
             or perm_stats.get("nodes_promoted", 0) or core_stats.get("promoted", 0)
             or core_stats.get("demoted", 0)
+            or orphans
             or orphan_stats.get("orphan_ordinary_written", 0)
             or dream_id
         )
@@ -1463,7 +1464,7 @@ def run_sleep_cycle(
             "core_promoted", 0
         ) + progress.get("core_demoted", 0) + progress.get(
             "orphan_ordinary_written", 0
-        ) + bool(progress.get("dream_id"))
+        ) + progress.get("orphans_embedded", 0) + bool(progress.get("dream_id"))
         if persisted:
             progress["status"] = "partial"
             progress["error"] = "sleep_cycle_failed"

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -53,6 +53,7 @@ DEDUP_THRESHOLD       = _profile.dedup_threshold       # cosine ≥ this → ded
 MAX_NODES_PER_CYCLE   = 2000   # work cap: process at most N oldest nodes
 MAX_EDGES_PER_CYCLE   = 100_000  # hard cap on cross-links per cycle
 EDGES_PER_BATCH       = 500    # commit watermark for batched inserts
+ORPHANS_PER_BATCH     = 100    # conservative caller-facing encode batch
 GC_K_NODES            = 50     # random sample size for garbage collection
 GC_THRESHOLD          = 0.0    # fitness below this → collectable (config overrides)
 GC_ACCESS_FLOOR       = 3      # nodes retrieved at least this often are never GC'd
@@ -205,6 +206,96 @@ def _load_embedding_matrix(
     # zero / overflow / invalid) under Apple's Accelerate BLAS even though the
     # results are finite and correct (float32 vs float64 differ by ~1e-6).
     return valid_ids, np.array(vectors, dtype=np.float64)
+
+
+_SLEEP_CURSOR_NAME = "candidate_cursor_v1"
+
+
+def _select_cycle_node_ids(
+    conn: sqlite3.Connection, limit: Optional[int],
+) -> List[str]:
+    """Select one deterministic page and durably advance its private cursor.
+
+    Uncapped callers retain the historical full oldest-first pass and do not
+    create cursor state.  Capped callers rotate through ``(timestamp, id)`` so
+    an already-saturated or unproductive oldest page cannot monopolize every
+    cycle.  The cursor claim commits before expensive work: a crash can defer a
+    page until the next wrap, but cannot corrupt the cursor or starve later
+    pages forever.
+    """
+    thought_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(thought_nodes)")
+    }
+    timestamp_expr = (
+        "COALESCE(tn.timestamp, '')" if "timestamp" in thought_columns else "''"
+    )
+    base = (
+        f"SELECT e.node_id, {timestamp_expr} AS sleep_ts "
+        "FROM embeddings e JOIN thought_nodes tn ON e.node_id = tn.id "
+        "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
+    )
+    order = "ORDER BY sleep_ts ASC, e.node_id ASC "
+    if limit is None:
+        return [row[0] for row in conn.execute(base + order).fetchall()]
+    if limit == 0:
+        return []
+
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS _cashew_sleep_state ("
+            "name TEXT PRIMARY KEY, cursor_timestamp TEXT NOT NULL, "
+            "cursor_node_id TEXT NOT NULL, epoch INTEGER NOT NULL)"
+        )
+        state = conn.execute(
+            "SELECT cursor_timestamp, cursor_node_id, epoch "
+            "FROM _cashew_sleep_state WHERE name = ?",
+            (_SLEEP_CURSOR_NAME,),
+        ).fetchone()
+        rows: List[tuple] = []
+        epoch = 0
+        if state is not None:
+            cursor_timestamp, cursor_node_id, epoch = state
+            rows.extend(
+                conn.execute(
+                    base
+                    + f"AND ({timestamp_expr} > ? OR "
+                    f"({timestamp_expr} = ? AND e.node_id > ?)) "
+                    + order
+                    + "LIMIT ?",
+                    (cursor_timestamp, cursor_timestamp, cursor_node_id, limit),
+                ).fetchall()
+            )
+        if len(rows) < limit:
+            remaining = limit - len(rows)
+            if state is None:
+                rows.extend(
+                    conn.execute(base + order + "LIMIT ?", (remaining,)).fetchall()
+                )
+            else:
+                cursor_timestamp, cursor_node_id, _ = state
+                rows.extend(
+                    conn.execute(
+                        base
+                        + f"AND ({timestamp_expr} < ? OR "
+                        f"({timestamp_expr} = ? AND e.node_id <= ?)) "
+                        + order
+                        + "LIMIT ?",
+                        (cursor_timestamp, cursor_timestamp, cursor_node_id, remaining),
+                    ).fetchall()
+                )
+        if rows:
+            last_id, last_timestamp = rows[-1]
+            conn.execute(
+                "INSERT OR REPLACE INTO _cashew_sleep_state "
+                "(name, cursor_timestamp, cursor_node_id, epoch) VALUES (?, ?, ?, ?)",
+                (_SLEEP_CURSOR_NAME, last_timestamp, last_id, int(epoch) + 1),
+            )
+        conn.commit()
+        return [row[0] for row in rows]
+    except Exception:
+        conn.rollback()
+        raise
 
 
 # ── Phase 1: candidate discovery (vectorized) ────────────────────────────
@@ -869,67 +960,73 @@ def _embed_orphans(
     embedding_client=None,
     embedding_model: Optional[str] = None,
     expected_dimension: Optional[int] = None,
+    limit: Optional[int] = None,
+    batch_size: int = ORPHANS_PER_BATCH,
     stats: Optional[dict] = None,
 ) -> int:
     """Embed active orphans through the caller-owned ``encode`` client.
 
     The client is injected so sleep never constructs a model or selects a
-    device. Each node is dual-written under a savepoint; a loaded vec index
-    that rejects a write rolls back the ordinary row as well.
+    device. Inference happens one bounded batch at a time before its write
+    transaction. Each node is dual-written under a savepoint; a loaded vec
+    index that rejects a write rolls back the ordinary row as well.
     """
     stats = stats if stats is not None else {}
     stats.setdefault("orphan_write_failed", 0)
     stats.setdefault("orphan_vec_unavailable", 0)
     stats.setdefault("orphan_ordinary_written", 0)
-    rows = conn.execute(
-        "SELECT tn.id, tn.content FROM thought_nodes tn "
-        "LEFT JOIN embeddings e ON tn.id = e.node_id "
-        "WHERE e.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed = 0) "
-        "AND tn.content IS NOT NULL AND TRIM(tn.content) != ''"
-    ).fetchall()
-    vec_available = _vec_write_capability(conn)
-    repair_rows = []
-    if vec_available:
-        repair_rows = conn.execute(
-            "SELECT e.node_id, e.vector, COALESCE(e.model, '') "
-            "FROM embeddings e LEFT JOIN vec_embeddings v ON v.node_id=e.node_id "
-            "JOIN thought_nodes tn ON tn.id=e.node_id "
-            "WHERE v.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed=0)"
-        ).fetchall()
-    if not rows and not repair_rows:
+    stats.setdefault("orphan_examined", 0)
+    if limit is not None and (
+        not isinstance(limit, int) or isinstance(limit, bool) or limit < 0
+    ):
+        raise ValueError("invalid_orphan_limit")
+    if (
+        not isinstance(batch_size, int)
+        or isinstance(batch_size, bool)
+        or batch_size <= 0
+        or batch_size > ORPHANS_PER_BATCH
+    ):
+        raise ValueError("invalid_orphan_batch_size")
+    if limit == 0:
         return 0
-    if (rows or repair_rows) and (
+
+    vec_available = _vec_write_capability(conn)
+    ordinary_exists = conn.execute(
+        "SELECT 1 FROM thought_nodes tn LEFT JOIN embeddings e ON tn.id=e.node_id "
+        "WHERE e.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed=0) "
+        "AND tn.content IS NOT NULL AND TRIM(tn.content) != '' LIMIT 1"
+    ).fetchone()
+    repair_exists = None
+    if vec_available:
+        repair_exists = conn.execute(
+            "SELECT 1 FROM embeddings e LEFT JOIN vec_embeddings v ON v.node_id=e.node_id "
+            "JOIN thought_nodes tn ON tn.id=e.node_id "
+            "WHERE v.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed=0) LIMIT 1"
+        ).fetchone()
+    if not ordinary_exists and not repair_exists:
+        return 0
+    if (
         embedding_client is None or not embedding_model or
         expected_dimension is None or int(expected_dimension) <= 0
     ):
         stats["capability_missing"] = True
         return 0
+
     expected = int(expected_dimension) if expected_dimension is not None else 0
-    vectors: List[np.ndarray] = []
-    if rows:
-        try:
-            raw = embedding_client.encode([content for _, content in rows])
-            array = np.asarray(raw)
-            if array.shape != (len(rows), expected):
-                raise ValueError("embedding_shape_mismatch")
-            for item in array:
-                vec = np.asarray(item, dtype=np.float32)
-                if not np.all(np.isfinite(vec)) or np.allclose(vec, 0):
-                    raise ValueError("embedding_invalid")
-                vectors.append(vec)
-        except Exception as exc:
-            logger.warning(
-                "sleep: orphan embedding batch rejected: %s", type(exc).__name__
-            )
-            stats["orphan_write_failed"] += len(rows)
-            return 0
     embedded = 0
-    def write_pair(nid: str, blob: bytes, model_name: str) -> None:
-        nonlocal embedded
+    remaining = limit
+    columns = {r[1] for r in conn.execute("PRAGMA table_info(embeddings)")}
+    thought_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(thought_nodes)")
+    }
+    timestamp_expr = (
+        "COALESCE(tn.timestamp, '')" if "timestamp" in thought_columns else "''"
+    )
+
+    def write_pair(nid: str, blob: bytes, model_name: str) -> bool:
         savepoint = "orphan_" + re.sub(r"[^A-Za-z0-9_]", "_", nid)[:40]
         try:
             conn.execute(f"SAVEPOINT {savepoint}")
-            columns = {r[1] for r in conn.execute("PRAGMA table_info(embeddings)")}
             if {"model", "updated_at"}.issubset(columns):
                 conn.execute(
                     "INSERT OR REPLACE INTO embeddings "
@@ -949,42 +1046,155 @@ def _embed_orphans(
                     (nid, blob),
                 )
             conn.execute(f"RELEASE SAVEPOINT {savepoint}")
-            # Count only after the savepoint has released successfully. A
-            # failed vec write must not claim an ordinary row that rolled back.
-            stats["orphan_ordinary_written"] += 1
-            if vec_available:
-                embedded += 1
-            else:
-                stats["orphan_vec_unavailable"] += 1
+            return True
         except Exception as exc:
             try:
                 conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
                 conn.execute(f"RELEASE SAVEPOINT {savepoint}")
             except sqlite3.Error:
                 pass
-            stats["orphan_write_failed"] += 1
             logger.warning(
                 "sleep: orphan %s dual-write failed: %s", nid[:8], type(exc).__name__
             )
-    for (nid, _content), vec in zip(rows, vectors):
-        write_pair(nid, vec.tobytes(), str(embedding_model))
-    for nid, blob, stored_model in repair_rows:
+            return False
+
+    def commit_batch(items: List[Tuple[str, bytes, str]]) -> bool:
+        nonlocal embedded
+        if not items:
+            return True
         try:
-            vec = np.frombuffer(blob, dtype=np.float32)
-            if embedding_model and stored_model and stored_model != embedding_model:
-                raise ValueError("embedding_model_mismatch")
-            repair_dim = (
-                int(expected_dimension)
-                if expected_dimension is not None else len(vec)
+            conn.execute("BEGIN IMMEDIATE")
+        except Exception as exc:
+            try:
+                conn.rollback()
+            except sqlite3.Error:
+                pass
+            stats["orphan_write_failed"] += len(items)
+            logger.warning(
+                "sleep: orphan batch admission failed: %s", type(exc).__name__
             )
-            if (len(vec) != repair_dim or not np.all(np.isfinite(vec))
-                    or np.allclose(vec, 0)):
+            return False
+        written = 0
+        failed = 0
+        for nid, blob, model_name in items:
+            if write_pair(nid, blob, model_name):
+                written += 1
+            else:
+                failed += 1
+        try:
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            stats["orphan_write_failed"] += len(items)
+            logger.warning(
+                "sleep: orphan batch commit failed: %s", type(exc).__name__
+            )
+            return False
+        stats["orphan_write_failed"] += failed
+        stats["orphan_ordinary_written"] += written
+        if vec_available:
+            embedded += written
+        else:
+            stats["orphan_vec_unavailable"] += written
+        return True
+
+    ordinary_cursor: Optional[Tuple[str, str]] = None
+    while remaining is None or remaining > 0:
+        take = batch_size if remaining is None else min(batch_size, remaining)
+        cursor_sql = ""
+        params: List[object] = []
+        if ordinary_cursor is not None:
+            cursor_sql = (
+                f"AND ({timestamp_expr} > ? OR "
+                f"({timestamp_expr} = ? AND tn.id > ?)) "
+            )
+            params.extend(
+                [ordinary_cursor[0], ordinary_cursor[0], ordinary_cursor[1]]
+            )
+        params.append(take)
+        rows = conn.execute(
+            f"SELECT tn.id, tn.content, {timestamp_expr} FROM thought_nodes tn "
+            "LEFT JOIN embeddings e ON tn.id = e.node_id "
+            "WHERE e.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed = 0) "
+            "AND tn.content IS NOT NULL AND TRIM(tn.content) != '' "
+            + cursor_sql
+            + f"ORDER BY {timestamp_expr}, tn.id LIMIT ?",
+            params,
+        ).fetchall()
+        if not rows:
+            break
+        stats["orphan_examined"] += len(rows)
+        if remaining is not None:
+            remaining -= len(rows)
+        ordinary_cursor = (rows[-1][2], rows[-1][0])
+        try:
+            raw = embedding_client.encode([content for _, content, _ in rows])
+            array = np.asarray(raw)
+            if array.shape != (len(rows), expected):
+                raise ValueError("embedding_shape_mismatch")
+            vectors = [np.asarray(item, dtype=np.float32) for item in array]
+            if any(
+                not np.all(np.isfinite(vec)) or np.allclose(vec, 0)
+                for vec in vectors
+            ):
                 raise ValueError("embedding_invalid")
-        except (TypeError, ValueError, BufferError):
-            stats["orphan_write_failed"] += 1
-            continue
-        write_pair(nid, bytes(blob), stored_model or str(embedding_model or ""))
-    conn.commit()
+        except Exception as exc:
+            logger.warning(
+                "sleep: orphan embedding batch rejected: %s", type(exc).__name__
+            )
+            stats["orphan_write_failed"] += len(rows)
+            break
+        if not commit_batch([
+            (nid, vec.tobytes(), str(embedding_model))
+            for (nid, _content, _timestamp), vec in zip(rows, vectors)
+        ]):
+            break
+
+    repair_cursor: Optional[Tuple[str, str]] = None
+    while vec_available and (remaining is None or remaining > 0):
+        take = batch_size if remaining is None else min(batch_size, remaining)
+        cursor_sql = ""
+        params = []
+        if repair_cursor is not None:
+            cursor_sql = (
+                f"AND ({timestamp_expr} > ? OR "
+                f"({timestamp_expr} = ? AND e.node_id > ?)) "
+            )
+            params.extend([repair_cursor[0], repair_cursor[0], repair_cursor[1]])
+        params.append(take)
+        repair_rows = conn.execute(
+            "SELECT e.node_id, e.vector, "
+            + ("COALESCE(e.model, '')" if "model" in columns else "''")
+            + f", {timestamp_expr} FROM embeddings e "
+            "LEFT JOIN vec_embeddings v ON v.node_id=e.node_id "
+            "JOIN thought_nodes tn ON tn.id=e.node_id "
+            "WHERE v.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed=0) "
+            + cursor_sql
+            + f"ORDER BY {timestamp_expr}, e.node_id LIMIT ?",
+            params,
+        ).fetchall()
+        if not repair_rows:
+            break
+        stats["orphan_examined"] += len(repair_rows)
+        if remaining is not None:
+            remaining -= len(repair_rows)
+        repair_cursor = (repair_rows[-1][3], repair_rows[-1][0])
+        items: List[Tuple[str, bytes, str]] = []
+        for nid, blob, stored_model, _timestamp in repair_rows:
+            try:
+                vec = np.frombuffer(blob, dtype=np.float32)
+                if embedding_model and stored_model and stored_model != embedding_model:
+                    raise ValueError("embedding_model_mismatch")
+                if (len(vec) != expected or not np.all(np.isfinite(vec))
+                        or np.allclose(vec, 0)):
+                    raise ValueError("embedding_invalid")
+            except (TypeError, ValueError, BufferError):
+                stats["orphan_write_failed"] += 1
+                continue
+            items.append((nid, bytes(blob), stored_model or str(embedding_model)))
+        if not commit_batch(items):
+            break
+
     logger.info("sleep: embedded/repaired %d orphaned nodes", embedded)
     return embedded
 
@@ -1000,6 +1210,8 @@ def _run_dream_async(
     embedding_model: Optional[str] = None,
     expected_dimension: Optional[int] = None,
     journal_policy: str = "manage",
+    orphan_limit: Optional[int] = None,
+    orphan_batch_size: int = ORPHANS_PER_BATCH,
 ) -> None:
     """Run Phase 8 (dream) + Phase 9 (orphan embedding) in a daemon thread.
 
@@ -1017,6 +1229,7 @@ def _run_dream_async(
             orphans = _embed_orphans(
                 conn, embedding_client=embedding_client,
                 embedding_model=embedding_model, expected_dimension=expected_dimension,
+                limit=orphan_limit, batch_size=orphan_batch_size,
             )
             logger.info(
                 "sleep: background dream complete (id=%s, orphans=%d)",
@@ -1078,6 +1291,8 @@ def run_sleep_cycle(
     embedding_model: Optional[str] = None,
     expected_dimension: Optional[int] = None,
     journal_policy: str = "manage",
+    orphan_limit: Optional[int] = None,
+    orphan_batch_size: int = ORPHANS_PER_BATCH,
 ) -> dict:
     """Run one complete refactored sleep cycle.
 
@@ -1104,6 +1319,12 @@ def run_sleep_cycle(
     cross_source_only : bool
         When True, only cross-link pairs from different ``source_file``
         values (reduces same-source noise).
+    orphan_limit : Optional[int]
+        Maximum orphan rows examined across both repair passes. ``None`` keeps
+        the historical behavior of repairing every eligible orphan.
+    orphan_batch_size : int
+        Encode and commit at most this many orphans at once. Values from 1 to
+        100 are accepted so bounded embedding clients are never overfilled.
 
     Returns
     -------
@@ -1123,6 +1344,19 @@ def run_sleep_cycle(
             return _empty_sleep_result("rejected", "invalid_limit")
         if not isinstance(max_edges, int) or max_edges < 0:
             return _empty_sleep_result("rejected", "invalid_max_edges")
+        if orphan_limit is not None and (
+            not isinstance(orphan_limit, int)
+            or isinstance(orphan_limit, bool)
+            or orphan_limit < 0
+        ):
+            return _empty_sleep_result("rejected", "invalid_orphan_limit")
+        if (
+            not isinstance(orphan_batch_size, int)
+            or isinstance(orphan_batch_size, bool)
+            or orphan_batch_size <= 0
+            or orphan_batch_size > ORPHANS_PER_BATCH
+        ):
+            return _empty_sleep_result("rejected", "invalid_orphan_batch_size")
         supplied_embedding = (
             embedding_client is not None,
             bool(embedding_model),
@@ -1162,25 +1396,8 @@ def run_sleep_cycle(
             return _empty_sleep_result("unavailable", "no_embeddings_table",
                                        time.perf_counter() - t_start)
 
-        # ── Select nodes for this cycle (oldest-first) ──
-        if limit is None:
-            rows = conn.execute(
-                "SELECT e.node_id FROM embeddings e "
-                "JOIN thought_nodes tn ON e.node_id = tn.id "
-                "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
-                "ORDER BY tn.timestamp ASC"
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                "SELECT e.node_id FROM embeddings e "
-                "JOIN thought_nodes tn ON e.node_id = tn.id "
-                "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
-                "ORDER BY tn.timestamp ASC "
-                "LIMIT ?",
-                (limit,),
-            ).fetchall()
-
-        ids = [r[0] for r in rows]
+        # ── Select one fair deterministic page for this cycle ──
+        ids = _select_cycle_node_ids(conn, limit)
         logger.info("sleep: selected %d nodes (limit=%s)", len(ids), limit)
 
         valid_ids, matrix = _load_embedding_matrix(conn, ids, expected_dimension)
@@ -1193,15 +1410,11 @@ def run_sleep_cycle(
                 embedding_client=embedding_client,
                 embedding_model=embedding_model,
                 expected_dimension=expected_dimension,
+                limit=orphan_limit,
+                batch_size=orphan_batch_size,
                 stats=orphan_stats,
             )
-            rows = conn.execute(
-                "SELECT e.node_id FROM embeddings e "
-                "JOIN thought_nodes tn ON e.node_id = tn.id "
-                "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
-                "ORDER BY tn.timestamp ASC"
-            ).fetchall()
-            ids = [r[0] for r in rows]
+            ids = _select_cycle_node_ids(conn, limit)
             valid_ids, matrix = _load_embedding_matrix(conn, ids, expected_dimension)
             progress.update({
                 "nodes_selected": len(ids),
@@ -1324,6 +1537,11 @@ def run_sleep_cycle(
         # Phase 8: dream generation
         dream_id = None
         dream_pending = False
+        remaining_orphan_limit = (
+            None
+            if orphan_limit is None
+            else max(0, orphan_limit - orphan_stats.get("orphan_examined", 0))
+        )
         if model_fn is not None and cross_link_tuples:
             if background_dream:
                 _run_dream_async(
@@ -1332,6 +1550,8 @@ def run_sleep_cycle(
                     model_fn=model_fn,
                     embedding_client=embedding_client, embedding_model=embedding_model,
                     expected_dimension=expected_dimension, journal_policy=journal_policy,
+                    orphan_limit=remaining_orphan_limit,
+                    orphan_batch_size=orphan_batch_size,
                 )
                 dream_pending = True
             else:
@@ -1345,28 +1565,23 @@ def run_sleep_cycle(
 
         # Phase 9: embed orphans
         if background_dream:
-            orphans = 0  # handled by background dream thread
+            # Preserve any synchronous prefix needed to establish two anchors;
+            # late background repairs are reported only in the worker log.
+            pass
         else:
-            later_orphan_stats: dict = {}
             later_orphans = _embed_orphans(
                 conn, embedding_client=embedding_client, embedding_model=embedding_model,
-                expected_dimension=expected_dimension, stats=later_orphan_stats,
+                expected_dimension=expected_dimension,
+                limit=remaining_orphan_limit,
+                batch_size=orphan_batch_size,
+                stats=orphan_stats,
             )
             orphans += later_orphans
-            for key in ("orphan_write_failed", "orphan_vec_unavailable",
-                        "orphan_ordinary_written"):
-                orphan_stats[key] = orphan_stats.get(key, 0) + later_orphan_stats.get(key, 0)
-            orphan_stats["capability_missing"] = (
-                orphan_stats.get("capability_missing", False)
-                or later_orphan_stats.get("capability_missing", False)
-            )
         progress["orphans_embedded"] = orphans
         progress["orphan_ordinary_written"] = orphan_stats.get(
             "orphan_ordinary_written", 0
         )
 
-        if background_dream:
-            orphan_stats = {}
         conn.close()
         elapsed = round(time.perf_counter() - t_start, 1)
 
@@ -1580,7 +1795,8 @@ class SleepProtocol:
             LLM callable for dream generation.
         **kwargs
             Passed through to :func:`run_sleep_cycle`: ``limit``,
-            ``background_dream``, ``max_edges``, ``cross_source_only``.
+            ``background_dream``, ``max_edges``, ``cross_source_only``,
+            ``orphan_limit``, and ``orphan_batch_size``.
         """
         conn = self._get_connection()
         active_count = conn.execute(
@@ -1599,6 +1815,8 @@ class SleepProtocol:
             embedding_model=kwargs.get("embedding_model"),
             expected_dimension=kwargs.get("expected_dimension"),
             journal_policy=kwargs.get("journal_policy", "manage"),
+            orphan_limit=kwargs.get("orphan_limit"),
+            orphan_batch_size=kwargs.get("orphan_batch_size", ORPHANS_PER_BATCH),
         )
 
         # Map vectorized result back to old-style summary keys for compat

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -260,81 +260,73 @@ def _batch_cross_links(
     source_files: Optional[Dict[str, str]] = None,
     max_edges: Optional[int] = None,
 ) -> dict:
-    """Insert cross-link edges in batches. Returns stats dict.
+    """Insert cross-link pairs atomically, with pair-budget accounting.
 
-    When *source_files* is provided, pairs whose nodes share the same
-    ``source_file`` are skipped (counted in ``same_source_skipped``).
-    When *max_edges* is set, stops after reaching the cap.
+    Each candidate is committed in a savepoint and verified in both
+    directions. This keeps a trigger, constraint, or interrupted write from
+    producing a claimed half-pair. Existing complete pairs consume no budget;
+    a single-direction legacy pair is repaired and consumes one pair.
     """
     stats = {
-        "candidates": len(cross_pairs),
-        "created": 0,
-        "repaired": 0,
-        "skipped": 0,
-        "directed_rows": 0,
-        "same_source_skipped": 0,
-        "capped": False,
+        "candidates": len(cross_pairs), "created": 0, "repaired": 0,
+        "skipped": 0, "failed": 0, "directed_rows": 0,
+        "same_source_skipped": 0, "capped": False,
     }
-    pending: List[Tuple[str, str, float]] = []
     t0 = time.perf_counter()
-
-    def flush() -> None:
-        nonlocal pending
-        if pending:
+    for pair_no, (i, j) in enumerate(cross_pairs):
+        budget = stats["created"] + stats["repaired"]
+        if max_edges is not None and budget >= max_edges:
+            stats["capped"] = True
+            break
+        n1, n2 = ids[int(i)], ids[int(j)]
+        if source_files is not None:
+            sf1, sf2 = source_files.get(n1, ""), source_files.get(n2, "")
+            if sf1 and sf2 and sf1 == sf2:
+                stats["same_source_skipped"] += 1
+                continue
+        present = {(p, c) for p, c in conn.execute(
+            "SELECT parent_id, child_id FROM derivation_edges "
+            "WHERE (parent_id=? AND child_id=?) OR (parent_id=? AND child_id=?)",
+            (n1, n2, n2, n1),
+        ).fetchall()}
+        if len(present) == 2:
+            stats["skipped"] += 1
+            continue
+        missing = [(n1, n2), (n2, n1)]
+        missing = [(p, c) for p, c in missing if (p, c) not in present]
+        name = f"cross_pair_{pair_no}"
+        try:
+            conn.execute(f"SAVEPOINT {name}")
+            weight = float(sim[int(i), int(j)])
             conn.executemany(
                 "INSERT OR IGNORE INTO derivation_edges "
                 "(parent_id, child_id, weight, reasoning) VALUES (?, ?, ?, ?)",
-                [
-                    (p, c, w, f"cross_link - similarity={w:.3f}")
-                    for p, c, w in pending
-                ],
+                [(p, c, weight, f"cross_link - similarity={weight:.3f}")
+                 for p, c in missing],
             )
-            conn.commit()
-            pending.clear()
-
-    for batch_start in range(0, len(cross_pairs), EDGES_PER_BATCH):
-        batch = cross_pairs[batch_start:batch_start + EDGES_PER_BATCH]
-        for i, j in batch:
-            if (max_edges is not None
-                    and (stats["created"] + stats["repaired"]) >= max_edges):
-                stats["capped"] = True
-                break
-            n1 = ids[int(i)]
-            n2 = ids[int(j)]
-            # Same-source check
-            if source_files is not None:
-                sf1 = source_files.get(n1, "")
-                sf2 = source_files.get(n2, "")
-                if sf1 and sf2 and sf1 == sf2:
-                    stats["same_source_skipped"] += 1
-                    continue
-            directions = conn.execute(
+            final = {(p, c) for p, c in conn.execute(
                 "SELECT parent_id, child_id FROM derivation_edges "
                 "WHERE (parent_id=? AND child_id=?) OR (parent_id=? AND child_id=?)",
                 (n1, n2, n2, n1),
-            ).fetchall()
-            present = {(p, c) for p, c in directions}
-            if len(present) == 2:
-                stats["skipped"] += 1
-                continue
-            sim_val = float(sim[int(i), int(j)])
-            missing = [(n1, n2), (n2, n1)]
-            missing = [(p, c) for p, c in missing if (p, c) not in present]
-            pending.extend((p, c, sim_val) for p, c in missing)
-            if len(present) == 1:
-                stats["repaired"] += 1
-            else:
-                stats["created"] += 1
-            stats["directed_rows"] += len(missing)
-
-        if (max_edges is not None
-                and (stats["created"] + stats["repaired"]) >= max_edges):
-            stats["capped"] = True
-            flush()
-            break
-
-        flush()
-
+            ).fetchall()}
+            if len(final) != 2:
+                raise sqlite3.IntegrityError("cross_link_pair_not_persisted")
+            conn.execute(f"RELEASE SAVEPOINT {name}")
+            conn.commit()
+        except Exception as exc:
+            try:
+                conn.execute(f"ROLLBACK TO SAVEPOINT {name}")
+                conn.execute(f"RELEASE SAVEPOINT {name}")
+            except sqlite3.Error:
+                pass
+            stats["failed"] += 1
+            logger.warning("sleep: cross-link pair failed: %s", type(exc).__name__)
+            continue
+        if len(present) == 1:
+            stats["repaired"] += 1
+        else:
+            stats["created"] += 1
+        stats["directed_rows"] += len(missing)
     elapsed = time.perf_counter() - t0
     logger.info(
         "sleep: cross-links %d created, %d repaired, %d skipped in %.1fs",
@@ -826,6 +818,34 @@ def _generate_dream(
 # ── Phase 9: orphan embedding ────────────────────────────────────────────
 
 
+def _vec_write_capability(conn: sqlite3.Connection) -> bool:
+    """Return whether this connection can actually read/write the vec table.
+
+    A virtual ``vec0`` table requires loading sqlite-vec on *this* connection;
+    merely finding its name in sqlite_master is insufficient.  A missing
+    extension/table is a genuine ordinary-only capability loss.  Once the
+    virtual table is readable, later write errors remain hard dual-write
+    failures and are handled by the per-node savepoint.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='vec_embeddings'"
+    ).fetchone()
+    if not row:
+        return False
+    ddl = (row[0] or "").lower()
+    if "using vec0" not in ddl:
+        return True
+    try:
+        from .embeddings import _load_vec, _vec_available
+        if not _vec_available:
+            return False
+        _load_vec(conn)
+        conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()
+        return True
+    except (ImportError, sqlite3.Error, OSError):
+        return False
+
+
 def _embed_orphans(
     conn: sqlite3.Connection,
     *,
@@ -849,11 +869,9 @@ def _embed_orphans(
         "WHERE e.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed = 0) "
         "AND tn.content IS NOT NULL AND TRIM(tn.content) != ''"
     ).fetchall()
-    vec_exists = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='vec_embeddings'"
-    ).fetchone() is not None
+    vec_available = _vec_write_capability(conn)
     repair_rows = []
-    if vec_exists:
+    if vec_available:
         repair_rows = conn.execute(
             "SELECT e.node_id, e.vector, COALESCE(e.model, '') "
             "FROM embeddings e LEFT JOIN vec_embeddings v ON v.node_id=e.node_id "
@@ -904,7 +922,7 @@ def _embed_orphans(
                     "INSERT OR REPLACE INTO embeddings (node_id, vector) VALUES (?, ?)",
                     (nid, blob),
                 )
-            if vec_exists:
+            if vec_available:
                 conn.execute(
                     "INSERT OR REPLACE INTO vec_embeddings "
                     "(node_id, embedding) VALUES (?, ?)",
@@ -1016,10 +1034,10 @@ def run_sleep_cycle(
     db_path: Optional[str] = None,
     limit: Optional[int] = None,
     model_fn=None,
-    *,
     background_dream: bool = False,
     max_edges: int = MAX_EDGES_PER_CYCLE,
     cross_source_only: bool = False,
+    *,
     embedding_client=None,
     embedding_model: Optional[str] = None,
     expected_dimension: Optional[int] = None,
@@ -1056,265 +1074,303 @@ def run_sleep_cycle(
     dict
         Statistics for each phase.
     """
-    if db_path is None:
-        db_path = get_db_path()
-
+    conn = None
     t_start = time.perf_counter()
-    if journal_policy not in {"manage", "preserve"}:
-        return _empty_sleep_result("rejected", "invalid_journal_policy")
-    if limit is not None and (not isinstance(limit, int) or limit < 0):
-        return _empty_sleep_result("rejected", "invalid_limit")
-    if not isinstance(max_edges, int) or max_edges < 0:
-        return _empty_sleep_result("rejected", "invalid_max_edges")
-    profile = None
-    if embedding_model:
-        try:
-            profile = _get_active_profile(embedding_model)
-        except Exception:
-            return _empty_sleep_result("rejected", "uncalibrated_embedding_model")
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA busy_timeout = 5000")
-    if journal_policy == "manage":
-        _set_wal(conn)
-    ensure_decay_audit_schema(conn)
-
-    # Check if embeddings table exists — required for vectorized pipeline
-    table_check = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='embeddings'"
-    ).fetchone()
-    if not table_check:
-        logger.warning("sleep: no embeddings table — aborting (run cashew init first)")
-        conn.commit()
-        conn.close()
-        return _empty_sleep_result("unavailable", "no_embeddings_table",
-                                   time.perf_counter() - t_start)
-
-    # ── Select nodes for this cycle (oldest-first) ──
-    if limit is None:
-        rows = conn.execute(
-            "SELECT e.node_id FROM embeddings e "
-            "JOIN thought_nodes tn ON e.node_id = tn.id "
-            "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
-            "ORDER BY tn.timestamp ASC"
-        ).fetchall()
-    else:
-        rows = conn.execute(
-            "SELECT e.node_id FROM embeddings e "
-            "JOIN thought_nodes tn ON e.node_id = tn.id "
-            "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
-            "ORDER BY tn.timestamp ASC "
-            "LIMIT ?",
-            (limit,),
-        ).fetchall()
-
-    ids = [r[0] for r in rows]
-    logger.info("sleep: selected %d nodes (limit=%s)", len(ids), limit)
-
-    valid_ids, matrix = _load_embedding_matrix(conn, ids, expected_dimension)
-    if len(valid_ids) < 2:
-        logger.warning("sleep: too few valid embeddings — aborting")
-        conn.close()
-        result = _empty_sleep_result("unavailable", "too_few_embeddings",
-                                     time.perf_counter() - t_start)
-        result["nodes_selected"] = len(ids)
-        result["nodes_with_embeddings"] = len(valid_ids)
-        return result
-
-    # Phase 1: candidate discovery
-    cross_pairs, dedup_pairs, sim = _find_pairs(
-        valid_ids, matrix,
-        cross_threshold=profile.cross_link_threshold if profile else None,
-        dedup_threshold=profile.dedup_threshold if profile else None,
-    )
-
-    # Build source_file map for cross-source filtering
-    source_files: Optional[Dict[str, str]] = None
-    if cross_source_only and len(cross_pairs) > 0:
-        sf_rows = conn.execute(
-            "SELECT id, COALESCE(source_file, '') FROM thought_nodes "
-            "WHERE id IN ({})".format(
-                ",".join("?" * len(valid_ids))
-            ),
-            valid_ids,
-        ).fetchall()
-        source_files = {r[0]: r[1] for r in sf_rows}
-
-    # Phase 2: cross-linking
-    cross_stats = {"created": 0, "skipped": 0}
-    cross_link_tuples: List[Tuple[str, str, float]] = []
-    if len(cross_pairs) > 0:
-        cross_stats = _batch_cross_links(
-            conn, valid_ids, cross_pairs, sim,
-            source_files=source_files if cross_source_only else None,
-            max_edges=max_edges,
-        )
-        if model_fn is not None:
-            for i, j in cross_pairs:
-                cross_link_tuples.append((
-                    valid_ids[int(i)], valid_ids[int(j)],
-                    float(sim[int(i), int(j)]),
-                ))
-
-    # Phase 3: dedup
-    dedup_stats = {"components": 0, "nodes_merged": 0}
-    if len(dedup_pairs) > 0:
-        dedup_stats = _run_dedup(conn, valid_ids, dedup_pairs)
-
-    # Phase 4: metrics
-    metrics = _compute_metrics(conn)
-
-    # Phase 5: garbage collection (config-driven)
-    gc_mode = getattr(config, 'gc_mode', 'soft')
-    gc_threshold = getattr(config, 'gc_threshold', 0.05)
-    gc_grace_days = getattr(config, 'gc_grace_days', 7)
-    gc_think_cycle_penalty_val = getattr(config, 'gc_think_cycle_penalty', 1.5)
-    gc_count = len(_garbage_collect(
-        conn, metrics,
-        threshold=gc_threshold,
-        sample_k=GC_K_NODES,
-        grace_days=gc_grace_days,
-        think_cycle_penalty=gc_think_cycle_penalty_val,
-        mode=gc_mode,
-    ))
-
-    # Phase 6: permanence
-    perm_stats = _evaluate_permanence(conn)
-
-    # Phase 7: core memory
-    core_stats = _promote_core_memories(conn, metrics)
-
-    # Phase 8: dream generation
-    dream_id = None
-    dream_pending = False
-    if model_fn is not None and cross_link_tuples:
-        if background_dream:
-            _run_dream_async(
-                db_path=db_path,
-                cross_link_tuples=cross_link_tuples,
-                model_fn=model_fn,
-                embedding_client=embedding_client, embedding_model=embedding_model,
-                expected_dimension=expected_dimension, journal_policy=journal_policy,
-            )
-            dream_pending = True
-        else:
-            dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
-
-    # Phase 9: embed orphans
-    if background_dream:
-        orphans = 0  # handled by background dream thread
-    else:
-        orphan_stats: dict = {}
-        orphans = _embed_orphans(
-            conn, embedding_client=embedding_client, embedding_model=embedding_model,
-            expected_dimension=expected_dimension, stats=orphan_stats,
-        )
-
-    if background_dream:
-        orphan_stats = {}
-    conn.close()
-    elapsed = round(time.perf_counter() - t_start, 1)
-
-    # Decay-audit GC (one-shot per cycle)
     try:
-        audit_conn = sqlite3.connect(db_path)
-        audit_conn.execute("PRAGMA busy_timeout = 5000")
+        if db_path is None:
+            db_path = get_db_path()
+
+        if journal_policy not in {"manage", "preserve"}:
+            return _empty_sleep_result("rejected", "invalid_journal_policy")
+        if limit is not None and (not isinstance(limit, int) or limit < 0):
+            return _empty_sleep_result("rejected", "invalid_limit")
+        if not isinstance(max_edges, int) or max_edges < 0:
+            return _empty_sleep_result("rejected", "invalid_max_edges")
+        supplied_embedding = (
+            embedding_client is not None,
+            bool(embedding_model),
+            expected_dimension is not None,
+        )
+        if any(supplied_embedding) and not all(supplied_embedding):
+            return _empty_sleep_result("rejected", "invalid_embedding_contract")
+        if all(supplied_embedding) and (
+            not callable(getattr(embedding_client, "encode", None))
+            or not isinstance(expected_dimension, int)
+            or expected_dimension <= 0
+        ):
+            return _empty_sleep_result("rejected", "invalid_embedding_contract")
+        profile = None
+        if embedding_model:
+            try:
+                profile = _get_active_profile(embedding_model)
+            except Exception:
+                return _empty_sleep_result("rejected", "uncalibrated_embedding_model")
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout = 5000")
         if journal_policy == "manage":
-            _set_wal(audit_conn)
-        ensure_decay_audit_schema(audit_conn)
-        audit_pruned = gc_decay_audit(audit_conn, retention_days=7)
-        audit_conn.commit()
-        audit_conn.close()
-        if audit_pruned:
-            logger.info("sleep: decay-audit GC pruned %d rows", audit_pruned)
-    except Exception as e:
-        logger.warning("sleep: decay-audit GC failed: %s", e)
+            _set_wal(conn)
+        ensure_decay_audit_schema(conn)
 
-    # Vec-index compaction (one-shot per cycle): decay never touched the vec
-    # index, so prune rows for nodes decayed this cycle (and any backlog) to
-    # keep the fast search path in sync with the live graph.
-    vec_compacted = 0
-    try:
-        from .embeddings import compact_vec_index
-        vec_compacted = compact_vec_index(db_path)
-        if vec_compacted:
-            logger.info("sleep: vec-index compaction pruned %d stale rows", vec_compacted)
-    except Exception as e:
-        logger.warning("sleep: vec-index compaction failed: %s", e)
+        # Check if embeddings table exists — required for vectorized pipeline
+        table_check = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='embeddings'"
+        ).fetchone()
+        if not table_check:
+            logger.warning("sleep: no embeddings table — aborting (run cashew init first)")
+            conn.commit()
+            conn.close()
+            return _empty_sleep_result("unavailable", "no_embeddings_table",
+                                       time.perf_counter() - t_start)
 
-    dream_generation = (
-        "pending" if dream_pending else ("ran" if dream_id else "skipped")
-    )
-    if (model_fn is not None and cross_link_tuples and not background_dream
-            and dream_id is None):
-        dream_generation = "failed"
-    phase_committed = bool(
-        cross_stats.get("created", 0) or cross_stats.get("repaired", 0)
-        or dedup_stats.get("nodes_merged", 0) or gc_count
-        or perm_stats.get("nodes_promoted", 0) or core_stats.get("promoted", 0)
-    )
-    if orphan_stats.get("capability_missing"):
-        result_status = "partial" if phase_committed else "unavailable"
-        result_error = "embedding_capability_unavailable"
-    elif orphan_stats.get("orphan_write_failed"):
-        result_status = "partial" if phase_committed else "failed"
-        result_error = "orphan_write_failed"
-    else:
-        result_status, result_error = "completed", None
-    summary = {
-        "status": result_status,
-        "error": result_error,
-        "nodes_selected": len(ids),
-        "nodes_with_embeddings": len(valid_ids),
-        "cross_link_candidates": len(cross_pairs),
-        "dedup_candidates": len(dedup_pairs),
-        "cross_links_created": cross_stats["created"],
-        "cross_links_repaired": cross_stats.get("repaired", 0),
-        "cross_links_skipped": cross_stats["skipped"],
-        "cross_link_directed_rows": cross_stats.get("directed_rows", 0),
-        "cross_link_same_source_skipped": cross_stats.get("same_source_skipped", 0),
-        "cross_link_capped": cross_stats.get("capped", False),
-        "dedup_components": dedup_stats["components"],
-        "dedup_nodes_merged": dedup_stats["nodes_merged"],
-        "nodes_gc_decayed": gc_count,
-        "vec_rows_compacted": vec_compacted,
-        "nodes_made_permanent": perm_stats.get("nodes_promoted", 0),
-        "core_promoted": core_stats.get("promoted", 0),
-        "core_demoted": core_stats.get("demoted", 0),
-        "dream_id": dream_id,
-        "dream_pending": dream_pending,
-        "dream_generation": dream_generation,
-        "orphans_embedded": orphans,
-        "orphan_write_failed": orphan_stats.get("orphan_write_failed", 0),
-        "orphan_vec_unavailable": orphan_stats.get("orphan_vec_unavailable", 0),
-        "total_nodes": len(metrics),
-        "elapsed_s": elapsed,
-    }
+        # ── Select nodes for this cycle (oldest-first) ──
+        if limit is None:
+            rows = conn.execute(
+                "SELECT e.node_id FROM embeddings e "
+                "JOIN thought_nodes tn ON e.node_id = tn.id "
+                "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
+                "ORDER BY tn.timestamp ASC"
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT e.node_id FROM embeddings e "
+                "JOIN thought_nodes tn ON e.node_id = tn.id "
+                "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
+                "ORDER BY tn.timestamp ASC "
+                "LIMIT ?",
+                (limit,),
+            ).fetchall()
 
-    if dream_pending:
-        logger.info(
-            "sleep: sync phases complete in %.1fs — %d nodes, %d cross-links, "
-            "%d dedups, %d GC, %d permanent, %d core (dream pending)",
-            elapsed, summary["total_nodes"],
-            summary["cross_links_created"], summary["dedup_nodes_merged"],
-            summary["nodes_gc_decayed"], summary["nodes_made_permanent"],
-            summary["core_promoted"],
-        )
-    else:
-        logger.info(
-            "sleep: cycle complete in %.1fs — %d nodes, %d cross-links, "
-            "%d dedups, %d GC, %d permanent, %d core, %s dream, %d embedded",
-            elapsed, summary["total_nodes"],
-            summary["cross_links_created"], summary["dedup_nodes_merged"],
-            summary["nodes_gc_decayed"], summary["nodes_made_permanent"],
-            summary["core_promoted"],
-            "1" if dream_id else "0", orphans,
+        ids = [r[0] for r in rows]
+        logger.info("sleep: selected %d nodes (limit=%s)", len(ids), limit)
+
+        valid_ids, matrix = _load_embedding_matrix(conn, ids, expected_dimension)
+        if len(valid_ids) < 2:
+            logger.warning("sleep: too few valid embeddings — aborting")
+            orphan_stats: dict = {}
+            orphans = _embed_orphans(
+                conn,
+                embedding_client=embedding_client,
+                embedding_model=embedding_model,
+                expected_dimension=expected_dimension,
+                stats=orphan_stats,
+            )
+            conn.close()
+            result = _empty_sleep_result("unavailable", "too_few_embeddings",
+                                         time.perf_counter() - t_start)
+            result["nodes_selected"] = len(ids)
+            result["nodes_with_embeddings"] = len(valid_ids)
+            result["orphans_embedded"] = orphans
+            result["orphan_write_failed"] = orphan_stats.get("orphan_write_failed", 0)
+            result["orphan_vec_unavailable"] = orphan_stats.get(
+                "orphan_vec_unavailable", 0
+            )
+            return result
+
+        # Phase 1: candidate discovery
+        cross_pairs, dedup_pairs, sim = _find_pairs(
+            valid_ids, matrix,
+            cross_threshold=profile.cross_link_threshold if profile else None,
+            dedup_threshold=profile.dedup_threshold if profile else None,
         )
 
-    if dream_generation == "failed" and summary["status"] == "completed":
-        summary["status"] = "partial"
-        summary["error"] = "dream_failed"
-    return summary
+        # Build source_file map for cross-source filtering
+        source_files: Optional[Dict[str, str]] = None
+        if cross_source_only and len(cross_pairs) > 0:
+            sf_rows = conn.execute(
+                "SELECT id, COALESCE(source_file, '') FROM thought_nodes "
+                "WHERE id IN ({})".format(
+                    ",".join("?" * len(valid_ids))
+                ),
+                valid_ids,
+            ).fetchall()
+            source_files = {r[0]: r[1] for r in sf_rows}
 
+        # Phase 2: cross-linking
+        cross_stats = {"created": 0, "skipped": 0}
+        cross_link_tuples: List[Tuple[str, str, float]] = []
+        if len(cross_pairs) > 0:
+            cross_stats = _batch_cross_links(
+                conn, valid_ids, cross_pairs, sim,
+                source_files=source_files if cross_source_only else None,
+                max_edges=max_edges,
+            )
+            if model_fn is not None:
+                for i, j in cross_pairs:
+                    cross_link_tuples.append((
+                        valid_ids[int(i)], valid_ids[int(j)],
+                        float(sim[int(i), int(j)]),
+                    ))
+
+        # Phase 3: dedup
+        dedup_stats = {"components": 0, "nodes_merged": 0}
+        if len(dedup_pairs) > 0:
+            dedup_stats = _run_dedup(conn, valid_ids, dedup_pairs)
+
+        # Phase 4: metrics
+        metrics = _compute_metrics(conn)
+
+        # Phase 5: garbage collection (config-driven)
+        gc_mode = getattr(config, 'gc_mode', 'soft')
+        gc_threshold = getattr(config, 'gc_threshold', 0.05)
+        gc_grace_days = getattr(config, 'gc_grace_days', 7)
+        gc_think_cycle_penalty_val = getattr(config, 'gc_think_cycle_penalty', 1.5)
+        gc_count = len(_garbage_collect(
+            conn, metrics,
+            threshold=gc_threshold,
+            sample_k=GC_K_NODES,
+            grace_days=gc_grace_days,
+            think_cycle_penalty=gc_think_cycle_penalty_val,
+            mode=gc_mode,
+        ))
+
+        # Phase 6: permanence
+        perm_stats = _evaluate_permanence(conn)
+
+        # Phase 7: core memory
+        core_stats = _promote_core_memories(conn, metrics)
+
+        # Phase 8: dream generation
+        dream_id = None
+        dream_pending = False
+        if model_fn is not None and cross_link_tuples:
+            if background_dream:
+                _run_dream_async(
+                    db_path=db_path,
+                    cross_link_tuples=cross_link_tuples,
+                    model_fn=model_fn,
+                    embedding_client=embedding_client, embedding_model=embedding_model,
+                    expected_dimension=expected_dimension, journal_policy=journal_policy,
+                )
+                dream_pending = True
+            else:
+                dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
+
+        # Phase 9: embed orphans
+        if background_dream:
+            orphans = 0  # handled by background dream thread
+        else:
+            orphan_stats = {}
+            orphans = _embed_orphans(
+                conn, embedding_client=embedding_client, embedding_model=embedding_model,
+                expected_dimension=expected_dimension, stats=orphan_stats,
+            )
+
+        if background_dream:
+            orphan_stats = {}
+        conn.close()
+        elapsed = round(time.perf_counter() - t_start, 1)
+
+        # Decay-audit GC (one-shot per cycle)
+        try:
+            audit_conn = sqlite3.connect(db_path)
+            audit_conn.execute("PRAGMA busy_timeout = 5000")
+            if journal_policy == "manage":
+                _set_wal(audit_conn)
+            ensure_decay_audit_schema(audit_conn)
+            audit_pruned = gc_decay_audit(audit_conn, retention_days=7)
+            audit_conn.commit()
+            audit_conn.close()
+            if audit_pruned:
+                logger.info("sleep: decay-audit GC pruned %d rows", audit_pruned)
+        except Exception as e:
+            logger.warning("sleep: decay-audit GC failed: %s", e)
+
+        # Vec-index compaction (one-shot per cycle): decay never touched the vec
+        # index, so prune rows for nodes decayed this cycle (and any backlog) to
+        # keep the fast search path in sync with the live graph.
+        vec_compacted = 0
+        try:
+            from .embeddings import compact_vec_index
+            vec_compacted = compact_vec_index(db_path)
+            if vec_compacted:
+                logger.info("sleep: vec-index compaction pruned %d stale rows", vec_compacted)
+        except Exception as e:
+            logger.warning("sleep: vec-index compaction failed: %s", e)
+
+        dream_generation = (
+            "pending" if dream_pending else ("ran" if dream_id else "skipped")
+        )
+        if (model_fn is not None and cross_link_tuples and not background_dream
+                and dream_id is None):
+            dream_generation = "failed"
+        phase_committed = bool(
+            cross_stats.get("created", 0) or cross_stats.get("repaired", 0)
+            or dedup_stats.get("nodes_merged", 0) or gc_count
+            or perm_stats.get("nodes_promoted", 0) or core_stats.get("promoted", 0)
+        )
+        if orphan_stats.get("capability_missing"):
+            result_status = "partial" if phase_committed else "unavailable"
+            result_error = "embedding_capability_unavailable"
+        elif orphan_stats.get("orphan_vec_unavailable"):
+            result_status = "partial" if phase_committed else "unavailable"
+            result_error = "vec_capability_unavailable"
+        elif orphan_stats.get("orphan_write_failed"):
+            result_status = "partial" if phase_committed else "failed"
+            result_error = "orphan_write_failed"
+        else:
+            result_status, result_error = "completed", None
+        summary = {
+            "status": result_status,
+            "error": result_error,
+            "nodes_selected": len(ids),
+            "nodes_with_embeddings": len(valid_ids),
+            "cross_link_candidates": len(cross_pairs),
+            "dedup_candidates": len(dedup_pairs),
+            "cross_links_created": cross_stats["created"],
+            "cross_links_repaired": cross_stats.get("repaired", 0),
+            "cross_links_skipped": cross_stats["skipped"],
+            "cross_link_directed_rows": cross_stats.get("directed_rows", 0),
+            "cross_link_same_source_skipped": cross_stats.get("same_source_skipped", 0),
+            "cross_link_capped": cross_stats.get("capped", False),
+            "dedup_components": dedup_stats["components"],
+            "dedup_nodes_merged": dedup_stats["nodes_merged"],
+            "nodes_gc_decayed": gc_count,
+            "vec_rows_compacted": vec_compacted,
+            "nodes_made_permanent": perm_stats.get("nodes_promoted", 0),
+            "core_promoted": core_stats.get("promoted", 0),
+            "core_demoted": core_stats.get("demoted", 0),
+            "dream_id": dream_id,
+            "dream_pending": dream_pending,
+            "dream_generation": dream_generation,
+            "orphans_embedded": orphans,
+            "orphan_write_failed": orphan_stats.get("orphan_write_failed", 0),
+            "orphan_vec_unavailable": orphan_stats.get("orphan_vec_unavailable", 0),
+            "total_nodes": len(metrics),
+            "elapsed_s": elapsed,
+        }
+
+        if dream_pending:
+            logger.info(
+                "sleep: sync phases complete in %.1fs — %d nodes, %d cross-links, "
+                "%d dedups, %d GC, %d permanent, %d core (dream pending)",
+                elapsed, summary["total_nodes"],
+                summary["cross_links_created"], summary["dedup_nodes_merged"],
+                summary["nodes_gc_decayed"], summary["nodes_made_permanent"],
+                summary["core_promoted"],
+            )
+        else:
+            logger.info(
+                "sleep: cycle complete in %.1fs — %d nodes, %d cross-links, "
+                "%d dedups, %d GC, %d permanent, %d core, %s dream, %d embedded",
+                elapsed, summary["total_nodes"],
+                summary["cross_links_created"], summary["dedup_nodes_merged"],
+                summary["nodes_gc_decayed"], summary["nodes_made_permanent"],
+                summary["core_promoted"],
+                "1" if dream_id else "0", orphans,
+            )
+
+        if dream_generation == "failed" and summary["status"] == "completed":
+            summary["status"] = "partial"
+            summary["error"] = "dream_failed"
+        return summary
+
+    except Exception as exc:
+        logger.warning("sleep: cycle failed: %s", type(exc).__name__)
+        return _empty_sleep_result("failed", "sleep_cycle_failed",
+                                   time.perf_counter() - t_start)
+    finally:
+        if conn is not None:
+            conn.close()
 
 # ── backward-compatible SleepProtocol class ──────────────────────────────
 

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -1050,7 +1050,6 @@ def _empty_sleep_result(
         "dedup_components": 0, "dedup_nodes_merged": 0,
         "nodes_gc_decayed": 0, "nodes_made_permanent": 0,
         "core_promoted": 0, "core_demoted": 0, "orphans_embedded": 0,
-        "orphan_ordinary_written": 0,
         "orphan_write_failed": 0, "orphan_vec_unavailable": 0,
         "vec_rows_compacted": 0, "dream_id": None, "dream_pending": False,
         "dream_generation": "skipped", "elapsed_s": max(0.0, float(elapsed_s)),
@@ -1220,9 +1219,6 @@ def run_sleep_cycle(
                 result["nodes_selected"] = len(ids)
                 result["nodes_with_embeddings"] = len(valid_ids)
                 result["orphans_embedded"] = orphans
-                result["orphan_ordinary_written"] = orphan_stats.get(
-                    "orphan_ordinary_written", 0
-                )
                 result["orphan_write_failed"] = orphan_stats.get("orphan_write_failed", 0)
                 result["orphan_vec_unavailable"] = orphan_stats.get(
                     "orphan_vec_unavailable", 0
@@ -1448,7 +1444,6 @@ def run_sleep_cycle(
             "dream_pending": dream_pending,
             "dream_generation": dream_generation,
             "orphans_embedded": orphans,
-            "orphan_ordinary_written": orphan_stats.get("orphan_ordinary_written", 0),
             "orphan_write_failed": orphan_stats.get("orphan_write_failed", 0),
             "orphan_vec_unavailable": orphan_stats.get("orphan_vec_unavailable", 0),
             "total_nodes": len(metrics),

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -37,7 +37,7 @@ import numpy as np
 logger = logging.getLogger("cashew.sleep")
 
 from .config import get_db_path, config, DEFAULT_EMBEDDING_MODEL
-from .decay_audit import log_decay_event, gc_decay_audit
+from .decay_audit import log_decay_event, gc_decay_audit, ensure_decay_audit_schema
 
 # ── module-level defaults (tunable) ──────────────────────────────────────
 
@@ -137,18 +137,16 @@ def _parse_ts(value: Optional[str]) -> Optional[datetime]:
 
 
 def _resolve_expected_dim() -> int:
-    """Configured embedding model's dim, with a MiniLM fallback if the
-    embedding service cannot be constructed (e.g. in CI without the model
-    cached)."""
+    """Configured profile dimension without constructing an embedding model."""
     try:
-        from .embedding_service import get_default_service
-        return get_default_service().dim
+        return _get_active_profile().dim
     except Exception:
         return 384
 
 
 def _load_embedding_matrix(
     conn: sqlite3.Connection, node_ids: List[str],
+    expected_dimension: Optional[int] = None,
 ) -> Tuple[List[str], np.ndarray]:
     """Load embeddings for *node_ids* from the ``embeddings`` table.
 
@@ -167,7 +165,10 @@ def _load_embedding_matrix(
         node_ids,
     ).fetchall()
 
-    expected_dim = _resolve_expected_dim()
+    expected_dim = (
+        int(expected_dimension)
+        if expected_dimension is not None else _resolve_expected_dim()
+    )
 
     vectors: List[np.ndarray] = []
     valid_ids: List[str] = []
@@ -211,6 +212,8 @@ def _load_embedding_matrix(
 
 def _find_pairs(
     ids: List[str], matrix: np.ndarray,
+    cross_threshold: Optional[float] = None,
+    dedup_threshold: Optional[float] = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Return (cross_link_pairs, dedup_pairs, similarity_matrix).
 
@@ -227,8 +230,12 @@ def _find_pairs(
     )
 
     upper = np.triu(sim, k=1)
-    cross_mask = (upper >= CROSS_LINK_THRESHOLD) & (upper < DEDUP_THRESHOLD)
-    dedup_mask = upper >= DEDUP_THRESHOLD
+    cross_threshold = (
+        CROSS_LINK_THRESHOLD if cross_threshold is None else cross_threshold
+    )
+    dedup_threshold = DEDUP_THRESHOLD if dedup_threshold is None else dedup_threshold
+    cross_mask = (upper >= cross_threshold) & (upper < dedup_threshold)
+    dedup_mask = upper >= dedup_threshold
 
     cross_pairs = np.argwhere(cross_mask)
     dedup_pairs = np.argwhere(dedup_mask)
@@ -262,17 +269,34 @@ def _batch_cross_links(
     stats = {
         "candidates": len(cross_pairs),
         "created": 0,
+        "repaired": 0,
         "skipped": 0,
+        "directed_rows": 0,
         "same_source_skipped": 0,
         "capped": False,
     }
     pending: List[Tuple[str, str, float]] = []
     t0 = time.perf_counter()
 
+    def flush() -> None:
+        nonlocal pending
+        if pending:
+            conn.executemany(
+                "INSERT OR IGNORE INTO derivation_edges "
+                "(parent_id, child_id, weight, reasoning) VALUES (?, ?, ?, ?)",
+                [
+                    (p, c, w, f"cross_link - similarity={w:.3f}")
+                    for p, c, w in pending
+                ],
+            )
+            conn.commit()
+            pending.clear()
+
     for batch_start in range(0, len(cross_pairs), EDGES_PER_BATCH):
         batch = cross_pairs[batch_start:batch_start + EDGES_PER_BATCH]
         for i, j in batch:
-            if max_edges is not None and stats["created"] >= max_edges:
+            if (max_edges is not None
+                    and (stats["created"] + stats["repaired"]) >= max_edges):
                 stats["capped"] = True
                 break
             n1 = ids[int(i)]
@@ -284,39 +308,37 @@ def _batch_cross_links(
                 if sf1 and sf2 and sf1 == sf2:
                     stats["same_source_skipped"] += 1
                     continue
-            row = conn.execute(
-                "SELECT COUNT(*) FROM derivation_edges "
+            directions = conn.execute(
+                "SELECT parent_id, child_id FROM derivation_edges "
                 "WHERE (parent_id=? AND child_id=?) OR (parent_id=? AND child_id=?)",
                 (n1, n2, n2, n1),
-            ).fetchone()
-            if row[0] > 0:
+            ).fetchall()
+            present = {(p, c) for p, c in directions}
+            if len(present) == 2:
                 stats["skipped"] += 1
                 continue
             sim_val = float(sim[int(i), int(j)])
-            pending.append((n1, n2, sim_val))
-            pending.append((n2, n1, sim_val))
-            stats["created"] += 1
+            missing = [(n1, n2), (n2, n1)]
+            missing = [(p, c) for p, c in missing if (p, c) not in present]
+            pending.extend((p, c, sim_val) for p, c in missing)
+            if len(present) == 1:
+                stats["repaired"] += 1
+            else:
+                stats["created"] += 1
+            stats["directed_rows"] += len(missing)
 
-        if max_edges is not None and stats["created"] >= max_edges:
+        if (max_edges is not None
+                and (stats["created"] + stats["repaired"]) >= max_edges):
             stats["capped"] = True
+            flush()
             break
 
-        if pending:
-            conn.executemany(
-                "INSERT OR IGNORE INTO derivation_edges "
-                "(parent_id, child_id, weight, reasoning) VALUES (?, ?, ?, ?)",
-                [
-                    (p, c, w, f"cross_link - similarity={w:.3f}")
-                    for p, c, w in pending
-                ],
-            )
-            conn.commit()
-        pending.clear()
+        flush()
 
     elapsed = time.perf_counter() - t0
     logger.info(
-        "sleep: cross-links %d created, %d skipped in %.1fs",
-        stats["created"], stats["skipped"], elapsed,
+        "sleep: cross-links %d created, %d repaired, %d skipped in %.1fs",
+        stats["created"], stats["repaired"], stats["skipped"], elapsed,
     )
     return stats
 
@@ -804,68 +826,121 @@ def _generate_dream(
 # ── Phase 9: orphan embedding ────────────────────────────────────────────
 
 
-def _embed_orphans(conn: sqlite3.Connection) -> int:
-    """Embed any active nodes lacking an embedding row. Returns count."""
+def _embed_orphans(
+    conn: sqlite3.Connection,
+    *,
+    embedding_client=None,
+    embedding_model: Optional[str] = None,
+    expected_dimension: Optional[int] = None,
+    stats: Optional[dict] = None,
+) -> int:
+    """Embed active orphans through the caller-owned ``encode`` client.
+
+    The client is injected so sleep never constructs a model or selects a
+    device. Each node is dual-written under a savepoint; a loaded vec index
+    that rejects a write rolls back the ordinary row as well.
+    """
+    stats = stats if stats is not None else {}
+    stats.setdefault("orphan_write_failed", 0)
+    stats.setdefault("orphan_vec_unavailable", 0)
     rows = conn.execute(
         "SELECT tn.id, tn.content FROM thought_nodes tn "
         "LEFT JOIN embeddings e ON tn.id = e.node_id "
-        "WHERE e.node_id IS NULL "
-        "AND (tn.decayed IS NULL OR tn.decayed = 0) "
+        "WHERE e.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed = 0) "
         "AND tn.content IS NOT NULL AND TRIM(tn.content) != ''"
     ).fetchall()
-
-    if not rows:
+    vec_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='vec_embeddings'"
+    ).fetchone() is not None
+    repair_rows = []
+    if vec_exists:
+        repair_rows = conn.execute(
+            "SELECT e.node_id, e.vector, COALESCE(e.model, '') "
+            "FROM embeddings e LEFT JOIN vec_embeddings v ON v.node_id=e.node_id "
+            "JOIN thought_nodes tn ON tn.id=e.node_id "
+            "WHERE v.node_id IS NULL AND (tn.decayed IS NULL OR tn.decayed=0)"
+        ).fetchall()
+    if not rows and not repair_rows:
         return 0
-
-    logger.info("sleep: embedding %d orphaned nodes…", len(rows))
-
-    from sentence_transformers import SentenceTransformer
-    from .config import get_embedding_model
-    # Use the CONFIGURED model, not the hardcoded default — otherwise, under a
-    # CASHEW_EMBEDDING_MODEL override, orphans get embedded at the wrong dim,
-    # get filtered out as wrong-dim every subsequent sleep cycle (re-embedded
-    # forever), and are unusable in search.
-    model_name = get_embedding_model()
-    model = SentenceTransformer(model_name)
-
-    embedded = 0
-    for nid, content in rows:
+    if rows and (embedding_client is None or not embedding_model or
+                 expected_dimension is None or int(expected_dimension) <= 0):
+        stats["capability_missing"] = True
+        return 0
+    expected = int(expected_dimension) if expected_dimension is not None else 0
+    vectors: List[np.ndarray] = []
+    if rows:
         try:
-            vec = model.encode(content, normalize_embeddings=True)
-            blob = vec.astype(np.float32).tobytes()
-
-            if not blob:
-                logger.warning(
-                    "sleep: skipping node %s — embedding produced empty bytes", nid[:8]
-                )
-                continue
-
-            try:
+            raw = embedding_client.encode([content for _, content in rows])
+            array = np.asarray(raw)
+            if array.shape != (len(rows), expected):
+                raise ValueError("embedding_shape_mismatch")
+            for item in array:
+                vec = np.asarray(item, dtype=np.float32)
+                if not np.all(np.isfinite(vec)) or np.allclose(vec, 0):
+                    raise ValueError("embedding_invalid")
+                vectors.append(vec)
+        except Exception as exc:
+            logger.warning(
+                "sleep: orphan embedding batch rejected: %s", type(exc).__name__
+            )
+            stats["orphan_write_failed"] += len(rows)
+            return 0
+    embedded = 0
+    def write_pair(nid: str, blob: bytes, model_name: str) -> None:
+        nonlocal embedded
+        savepoint = "orphan_" + re.sub(r"[^A-Za-z0-9_]", "_", nid)[:40]
+        try:
+            conn.execute(f"SAVEPOINT {savepoint}")
+            columns = {r[1] for r in conn.execute("PRAGMA table_info(embeddings)")}
+            if {"model", "updated_at"}.issubset(columns):
                 conn.execute(
                     "INSERT OR REPLACE INTO embeddings "
                     "(node_id, vector, model, updated_at) "
                     "VALUES (?, ?, ?, datetime('now'))",
                     (nid, blob, model_name),
                 )
-            except sqlite3.OperationalError:
+            else:
                 conn.execute(
                     "INSERT OR REPLACE INTO embeddings (node_id, vector) VALUES (?, ?)",
                     (nid, blob),
                 )
-            try:
+            if vec_exists:
                 conn.execute(
                     "INSERT OR REPLACE INTO vec_embeddings "
                     "(node_id, embedding) VALUES (?, ?)",
-                    (nid, blob),   # bytes, like embed_nodes — a Python list raises
-                )                  # ProgrammingError (not the OperationalError caught
-            except sqlite3.OperationalError:  # below), which left orphans with an
-                pass                          # embeddings row but no vec-index row.
-            embedded += 1
-        except Exception as e:
-            logger.warning("sleep: failed to embed node %s: %s", nid[:8], e)
-
+                    (nid, blob),
+                )
+                embedded += 1
+            else:
+                stats["orphan_vec_unavailable"] += 1
+            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+        except Exception as exc:
+            try:
+                conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            except sqlite3.Error:
+                pass
+            stats["orphan_write_failed"] += 1
+            logger.warning(
+                "sleep: orphan %s dual-write failed: %s", nid[:8], type(exc).__name__
+            )
+    for (nid, _content), vec in zip(rows, vectors):
+        write_pair(nid, vec.tobytes(), str(embedding_model))
+    for nid, blob, stored_model in repair_rows:
+        vec = np.frombuffer(blob, dtype=np.float32)
+        repair_dim = (
+            int(expected_dimension)
+            if expected_dimension is not None else len(vec)
+        )
+        if len(vec) != repair_dim:
+            stats["orphan_write_failed"] += 1
+            continue
+        if not np.all(np.isfinite(vec)) or np.allclose(vec, 0):
+            stats["orphan_write_failed"] += 1
+            continue
+        write_pair(nid, bytes(blob), stored_model or str(embedding_model or ""))
     conn.commit()
-    logger.info("sleep: embedded %d orphaned nodes", embedded)
+    logger.info("sleep: embedded/repaired %d orphaned nodes", embedded)
     return embedded
 
 
@@ -876,6 +951,10 @@ def _run_dream_async(
     db_path: str,
     cross_link_tuples: List[Tuple[str, str, float]],
     model_fn,
+    embedding_client=None,
+    embedding_model: Optional[str] = None,
+    expected_dimension: Optional[int] = None,
+    journal_policy: str = "manage",
 ) -> None:
     """Run Phase 8 (dream) + Phase 9 (orphan embedding) in a daemon thread.
 
@@ -883,19 +962,26 @@ def _run_dream_async(
     the new session's sync worker writes.
     """
     def _task():
+        conn = None
         try:
             conn = sqlite3.connect(db_path)
             conn.execute("PRAGMA busy_timeout = 5000")
-            _set_wal(conn)
+            if journal_policy == "manage":
+                _set_wal(conn)
             dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
-            orphans = _embed_orphans(conn)
-            conn.close()
+            orphans = _embed_orphans(
+                conn, embedding_client=embedding_client,
+                embedding_model=embedding_model, expected_dimension=expected_dimension,
+            )
             logger.info(
                 "sleep: background dream complete (id=%s, orphans=%d)",
                 dream_id or "none", orphans,
             )
         except Exception:
             logger.warning("sleep: background dream failed", exc_info=True)
+        finally:
+            if conn is not None:
+                conn.close()
 
     t = threading.Thread(target=_task, daemon=True)
     t.start()
@@ -905,13 +991,39 @@ def _run_dream_async(
 # ── main entry point (free function) ─────────────────────────────────────
 
 
+def _empty_sleep_result(
+    status: str, error: Optional[str], elapsed_s: float = 0.0
+) -> dict:
+    """Return the stable JSON shape for preflight/capability outcomes."""
+    result = {
+        "status": status, "error": error,
+        "nodes_selected": 0, "nodes_with_embeddings": 0, "total_nodes": 0,
+        "cross_link_candidates": 0, "cross_links_created": 0,
+        "cross_links_repaired": 0, "cross_links_skipped": 0,
+        "cross_link_directed_rows": 0, "cross_link_capped": False,
+        "cross_link_same_source_skipped": 0, "dedup_candidates": 0,
+        "dedup_components": 0, "dedup_nodes_merged": 0,
+        "nodes_gc_decayed": 0, "nodes_made_permanent": 0,
+        "core_promoted": 0, "core_demoted": 0, "orphans_embedded": 0,
+        "orphan_write_failed": 0, "orphan_vec_unavailable": 0,
+        "vec_rows_compacted": 0, "dream_id": None, "dream_pending": False,
+        "dream_generation": "skipped", "elapsed_s": max(0.0, float(elapsed_s)),
+    }
+    return result
+
+
 def run_sleep_cycle(
-    db_path: str = None,
+    db_path: Optional[str] = None,
     limit: Optional[int] = None,
     model_fn=None,
+    *,
     background_dream: bool = False,
     max_edges: int = MAX_EDGES_PER_CYCLE,
     cross_source_only: bool = False,
+    embedding_client=None,
+    embedding_model: Optional[str] = None,
+    expected_dimension: Optional[int] = None,
+    journal_policy: str = "manage",
 ) -> dict:
     """Run one complete refactored sleep cycle.
 
@@ -948,9 +1060,23 @@ def run_sleep_cycle(
         db_path = get_db_path()
 
     t_start = time.perf_counter()
+    if journal_policy not in {"manage", "preserve"}:
+        return _empty_sleep_result("rejected", "invalid_journal_policy")
+    if limit is not None and (not isinstance(limit, int) or limit < 0):
+        return _empty_sleep_result("rejected", "invalid_limit")
+    if not isinstance(max_edges, int) or max_edges < 0:
+        return _empty_sleep_result("rejected", "invalid_max_edges")
+    profile = None
+    if embedding_model:
+        try:
+            profile = _get_active_profile(embedding_model)
+        except Exception:
+            return _empty_sleep_result("rejected", "uncalibrated_embedding_model")
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA busy_timeout = 5000")
-    _set_wal(conn)
+    if journal_policy == "manage":
+        _set_wal(conn)
+    ensure_decay_audit_schema(conn)
 
     # Check if embeddings table exists — required for vectorized pipeline
     table_check = conn.execute(
@@ -958,8 +1084,10 @@ def run_sleep_cycle(
     ).fetchone()
     if not table_check:
         logger.warning("sleep: no embeddings table — aborting (run cashew init first)")
+        conn.commit()
         conn.close()
-        return {"error": "no embeddings table", "nodes_selected": 0}
+        return _empty_sleep_result("unavailable", "no_embeddings_table",
+                                   time.perf_counter() - t_start)
 
     # ── Select nodes for this cycle (oldest-first) ──
     if limit is None:
@@ -982,14 +1110,22 @@ def run_sleep_cycle(
     ids = [r[0] for r in rows]
     logger.info("sleep: selected %d nodes (limit=%s)", len(ids), limit)
 
-    valid_ids, matrix = _load_embedding_matrix(conn, ids)
+    valid_ids, matrix = _load_embedding_matrix(conn, ids, expected_dimension)
     if len(valid_ids) < 2:
         logger.warning("sleep: too few valid embeddings — aborting")
         conn.close()
-        return {"error": "too few nodes", "nodes_selected": len(ids)}
+        result = _empty_sleep_result("unavailable", "too_few_embeddings",
+                                     time.perf_counter() - t_start)
+        result["nodes_selected"] = len(ids)
+        result["nodes_with_embeddings"] = len(valid_ids)
+        return result
 
     # Phase 1: candidate discovery
-    cross_pairs, dedup_pairs, sim = _find_pairs(valid_ids, matrix)
+    cross_pairs, dedup_pairs, sim = _find_pairs(
+        valid_ids, matrix,
+        cross_threshold=profile.cross_link_threshold if profile else None,
+        dedup_threshold=profile.dedup_threshold if profile else None,
+    )
 
     # Build source_file map for cross-source filtering
     source_files: Optional[Dict[str, str]] = None
@@ -1056,6 +1192,8 @@ def run_sleep_cycle(
                 db_path=db_path,
                 cross_link_tuples=cross_link_tuples,
                 model_fn=model_fn,
+                embedding_client=embedding_client, embedding_model=embedding_model,
+                expected_dimension=expected_dimension, journal_policy=journal_policy,
             )
             dream_pending = True
         else:
@@ -1065,8 +1203,14 @@ def run_sleep_cycle(
     if background_dream:
         orphans = 0  # handled by background dream thread
     else:
-        orphans = _embed_orphans(conn)
+        orphan_stats: dict = {}
+        orphans = _embed_orphans(
+            conn, embedding_client=embedding_client, embedding_model=embedding_model,
+            expected_dimension=expected_dimension, stats=orphan_stats,
+        )
 
+    if background_dream:
+        orphan_stats = {}
     conn.close()
     elapsed = round(time.perf_counter() - t_start, 1)
 
@@ -1074,6 +1218,9 @@ def run_sleep_cycle(
     try:
         audit_conn = sqlite3.connect(db_path)
         audit_conn.execute("PRAGMA busy_timeout = 5000")
+        if journal_policy == "manage":
+            _set_wal(audit_conn)
+        ensure_decay_audit_schema(audit_conn)
         audit_pruned = gc_decay_audit(audit_conn, retention_days=7)
         audit_conn.commit()
         audit_conn.close()
@@ -1094,13 +1241,36 @@ def run_sleep_cycle(
     except Exception as e:
         logger.warning("sleep: vec-index compaction failed: %s", e)
 
+    dream_generation = (
+        "pending" if dream_pending else ("ran" if dream_id else "skipped")
+    )
+    if (model_fn is not None and cross_link_tuples and not background_dream
+            and dream_id is None):
+        dream_generation = "failed"
+    phase_committed = bool(
+        cross_stats.get("created", 0) or cross_stats.get("repaired", 0)
+        or dedup_stats.get("nodes_merged", 0) or gc_count
+        or perm_stats.get("nodes_promoted", 0) or core_stats.get("promoted", 0)
+    )
+    if orphan_stats.get("capability_missing"):
+        result_status = "partial" if phase_committed else "unavailable"
+        result_error = "embedding_capability_unavailable"
+    elif orphan_stats.get("orphan_write_failed"):
+        result_status = "partial" if phase_committed else "failed"
+        result_error = "orphan_write_failed"
+    else:
+        result_status, result_error = "completed", None
     summary = {
+        "status": result_status,
+        "error": result_error,
         "nodes_selected": len(ids),
         "nodes_with_embeddings": len(valid_ids),
         "cross_link_candidates": len(cross_pairs),
         "dedup_candidates": len(dedup_pairs),
         "cross_links_created": cross_stats["created"],
+        "cross_links_repaired": cross_stats.get("repaired", 0),
         "cross_links_skipped": cross_stats["skipped"],
+        "cross_link_directed_rows": cross_stats.get("directed_rows", 0),
         "cross_link_same_source_skipped": cross_stats.get("same_source_skipped", 0),
         "cross_link_capped": cross_stats.get("capped", False),
         "dedup_components": dedup_stats["components"],
@@ -1112,7 +1282,10 @@ def run_sleep_cycle(
         "core_demoted": core_stats.get("demoted", 0),
         "dream_id": dream_id,
         "dream_pending": dream_pending,
+        "dream_generation": dream_generation,
         "orphans_embedded": orphans,
+        "orphan_write_failed": orphan_stats.get("orphan_write_failed", 0),
+        "orphan_vec_unavailable": orphan_stats.get("orphan_vec_unavailable", 0),
         "total_nodes": len(metrics),
         "elapsed_s": elapsed,
     }
@@ -1137,6 +1310,9 @@ def run_sleep_cycle(
             "1" if dream_id else "0", orphans,
         )
 
+    if dream_generation == "failed" and summary["status"] == "completed":
+        summary["status"] = "partial"
+        summary["error"] = "dream_failed"
     return summary
 
 
@@ -1175,7 +1351,9 @@ class SleepProtocol:
     ``run_sleep_cycle()`` delegates to the vectorized pipeline above.
     """
 
-    def __init__(self, db_path: str = None, sleep_log_path: str = None):
+    def __init__(
+        self, db_path: Optional[str] = None, sleep_log_path: Optional[str] = None
+    ):
         if db_path is None:
             db_path = get_db_path()
         if sleep_log_path is None:
@@ -1227,6 +1405,10 @@ class SleepProtocol:
             background_dream=kwargs.get("background_dream", False),
             max_edges=kwargs.get("max_edges", MAX_EDGES_PER_CYCLE),
             cross_source_only=kwargs.get("cross_source_only", False),
+            embedding_client=kwargs.get("embedding_client"),
+            embedding_model=kwargs.get("embedding_model"),
+            expected_dimension=kwargs.get("expected_dimension"),
+            journal_policy=kwargs.get("journal_policy", "manage"),
         )
 
         # Map vectorized result back to old-style summary keys for compat

--- a/core/sleep.py
+++ b/core/sleep.py
@@ -946,6 +946,9 @@ def _embed_orphans(
         write_pair(nid, vec.tobytes(), str(embedding_model))
     for nid, blob, stored_model in repair_rows:
         vec = np.frombuffer(blob, dtype=np.float32)
+        if embedding_model and stored_model and stored_model != embedding_model:
+            stats["orphan_write_failed"] += 1
+            continue
         repair_dim = (
             int(expected_dimension)
             if expected_dimension is not None else len(vec)

--- a/docs/sleep-protocol.md
+++ b/docs/sleep-protocol.md
@@ -1,16 +1,15 @@
 # Sleep protocol integration
 
 `core.sleep.run_sleep_cycle` is the bounded consolidation entry point. Existing
-callers may continue to use the first three positional arguments; new adapter
+callers may continue to use the first six positional arguments; new adapter
 options are keyword-only:
 
 ```python
 run_sleep_cycle(
-    db_path, limit=None, model_fn=None, *,
-    background_dream=False, max_edges=100_000,
-    cross_source_only=False, embedding_client=None,
+    db_path, limit=None, model_fn=None, background_dream=False,
+    max_edges=100_000, cross_source_only=False, *, embedding_client=None,
     embedding_model=None, expected_dimension=None,
-    journal_policy="manage",
+    journal_policy="manage", orphan_limit=None, orphan_batch_size=100,
 )
 ```
 
@@ -20,10 +19,19 @@ must implement `encode(list[str])` and return a NumPy array with exactly one
 finite, non-zero row per input and the requested dimension. Sleep does not
 construct a model, select a device, or call a default embedding service.
 Invalid output is rejected before any node write. Each valid node is written
-to `embeddings` and `vec_embeddings` inside one savepoint. If the vec index is
-present and rejects a write, the ordinary row is rolled back too. If the vec
-index is genuinely absent, ordinary-only repair is reported by
-`orphan_vec_unavailable`.
+to `embeddings` and `vec_embeddings` inside one savepoint, and each batch is
+committed independently. If the vec index is present and rejects a write, the
+ordinary row is rolled back too. If the vec index is genuinely absent,
+ordinary-only repair is reported by `orphan_vec_unavailable`. The default
+repairs all eligible rows in batches of 100 for backward compatibility.
+`orphan_limit` caps rows examined across ordinary and vec-index repair;
+`orphan_batch_size` may reduce the encode/commit batch below 100.
+
+When `limit` caps candidate discovery, sleep persists a private cursor and
+rotates deterministically through `(timestamp, node_id)` pages. Cursor claims
+commit before expensive phases, so a stopped cycle may defer its page until
+the next wrap but cannot keep later pages permanently starved. Node timestamps
+remain untouched.
 
 `journal_policy="manage"` retains the historical direct-call behavior.
 Integrations that own SQLite admission should pass `journal_policy="preserve"`;

--- a/docs/sleep-protocol.md
+++ b/docs/sleep-protocol.md
@@ -31,7 +31,39 @@ When `limit` caps candidate discovery, sleep persists a private cursor and
 rotates deterministically through `(timestamp, node_id)` pages. Cursor claims
 commit before expensive phases, so a stopped cycle may defer its page until
 the next wrap but cannot keep later pages permanently starved. Node timestamps
-remain untouched.
+remain untouched. The private cursor table is checked on every capped run;
+partial or malformed pre-release shapes are rebuilt transactionally, retaining
+a usable cursor when possible.
+
+## Supported work envelope
+
+The public limits bound specific phases; they are not an end-to-end deadline:
+
+- `limit=N` bounds the candidate embedding matrix to at most `N` active nodes.
+  Similarity memory and arithmetic are quadratic in `N`.
+- `max_edges=M` bounds newly completed or repaired unordered cross-link pairs.
+  Existing, same-source, or failed candidates do not consume the budget, so
+  candidate inspection can still visit every pair in the `N`-node matrix.
+- deduplication consumes the same bounded candidate page, but maximal-clique
+  enumeration and edge rewiring do not currently have a separate time or write
+  budget.
+- GC mutates at most 50 sampled nodes and orphan embedding examines at most
+  `orphan_limit` rows when supplied. Metrics, permanence, core-memory ranking,
+  audit cleanup, and vec compaction can still scan graph-wide state.
+- a synchronous `model_fn` has no engine-enforced deadline. Integrations that
+  need a wall-clock bound must own cancellation and SQLite admission outside
+  this function.
+
+Dream generation only receives cross-link pairs completed or repaired and
+committed by the current cycle. Capped, filtered, failed, and already-complete
+pairs are excluded. In particular, `max_edges=0` cannot invoke the dream model.
+
+For reproducible local measurements, `scripts/benchmark_sleep_cycle.py` builds
+an isolated synthetic database and reports wall time plus the public counters.
+It never opens the configured Cashew database. `--hold-writer-ms` adds a
+deterministic competing write transaction before the cycle starts. Results
+characterize the chosen machine and fixture; they do not establish a
+production deadline.
 
 `journal_policy="manage"` retains the historical direct-call behavior.
 Integrations that own SQLite admission should pass `journal_policy="preserve"`;

--- a/docs/sleep-protocol.md
+++ b/docs/sleep-protocol.md
@@ -25,7 +25,9 @@ ordinary row is rolled back too. If the vec index is genuinely absent,
 ordinary-only repair is reported by `orphan_vec_unavailable`. The default
 repairs all eligible rows in batches of 100 for backward compatibility.
 `orphan_limit` caps rows examined across ordinary and vec-index repair;
-`orphan_batch_size` may reduce the encode/commit batch below 100.
+`orphan_batch_size` may reduce the encode/commit batch below 100. A table merely
+named `vec_embeddings` is not a vec capability: it must be a `vec0` virtual
+table that can be loaded and queried on the active connection.
 
 When `limit` caps candidate discovery, sleep persists a private cursor and
 rotates deterministically through `(timestamp, node_id)` pages. Cursor claims
@@ -33,7 +35,11 @@ commit before expensive phases, so a stopped cycle may defer its page until
 the next wrap but cannot keep later pages permanently starved. Node timestamps
 remain untouched. The private cursor table is checked on every capped run;
 partial or malformed pre-release shapes are rebuilt transactionally, retaining
-a usable cursor when possible.
+a single type-valid cursor when possible. Duplicate or invalid legacy cursor
+rows reset to the deterministic origin. Capped orphan work has separate durable
+ordinary and vec-repair cursors and alternates which phase receives the first
+share of the cap. A repeatedly failing oldest batch therefore cannot starve
+later rows or the other repair class forever.
 
 ## Supported work envelope
 
@@ -75,3 +81,7 @@ state (`skipped`, `pending`, `ran`, or `failed`), and explicit pair versus
 directed-row counts. `cross_links_created` counts new unordered pairs only when
 both directions are committed. A half-pair is repaired and counted separately;
 existing complete pairs are skipped without consuming `max_edges`.
+Cross-link counters and dream inputs advance only after each batch commit. A
+known rolled-back suffix reports the exact committed prefix as `partial`; if a
+commit's durability cannot be verified, the stable result instead reports
+`uncertain` without claiming the attempted batch.

--- a/docs/sleep-protocol.md
+++ b/docs/sleep-protocol.md
@@ -1,0 +1,37 @@
+# Sleep protocol integration
+
+`core.sleep.run_sleep_cycle` is the bounded consolidation entry point. Existing
+callers may continue to use the first three positional arguments; new adapter
+options are keyword-only:
+
+```python
+run_sleep_cycle(
+    db_path, limit=None, model_fn=None, *,
+    background_dream=False, max_edges=100_000,
+    cross_source_only=False, embedding_client=None,
+    embedding_model=None, expected_dimension=None,
+    journal_policy="manage",
+)
+```
+
+Orphan repair is caller-owned. When repair is enabled, provide all three of
+`embedding_client`, `embedding_model`, and `expected_dimension`. The client
+must implement `encode(list[str])` and return a NumPy array with exactly one
+finite, non-zero row per input and the requested dimension. Sleep does not
+construct a model, select a device, or call a default embedding service.
+Invalid output is rejected before any node write. Each valid node is written
+to `embeddings` and `vec_embeddings` inside one savepoint. If the vec index is
+present and rejects a write, the ordinary row is rolled back too. If the vec
+index is genuinely absent, ordinary-only repair is reported by
+`orphan_vec_unavailable`.
+
+`journal_policy="manage"` retains the historical direct-call behavior.
+Integrations that own SQLite admission should pass `journal_policy="preserve"`;
+that mode performs no journal-mode assignment. The decay-audit table is created
+idempotently on the cycle connection before any decay audit write.
+
+The result is JSON-safe and includes `status`, bounded phase counters, dream
+state (`skipped`, `pending`, `ran`, or `failed`), and explicit pair versus
+directed-row counts. `cross_links_created` counts new unordered pairs only when
+both directions are committed. A half-pair is repaired and counted separately;
+existing complete pairs are skipped without consuming `max_edges`.

--- a/scripts/benchmark_sleep_cycle.py
+++ b/scripts/benchmark_sleep_cycle.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Opt-in deterministic sleep-cycle measurement on an isolated fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.model_profiles import get_active_profile
+from core.sleep import run_sleep_cycle
+
+
+def _build_fixture(path: Path, nodes: int, dimension: int, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE thought_nodes(
+            id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0,
+            timestamp TEXT DEFAULT '', source_file TEXT,
+            access_count INTEGER DEFAULT 0, permanent INTEGER DEFAULT 0,
+            last_accessed TEXT, domain TEXT, node_type TEXT,
+            confidence REAL, metadata TEXT, mood_state TEXT
+        );
+        CREATE TABLE embeddings(
+            node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT
+        );
+        CREATE TABLE derivation_edges(
+            parent_id TEXT, child_id TEXT, weight REAL, reasoning TEXT,
+            PRIMARY KEY(parent_id, child_id)
+        );
+        """
+    )
+    shared = np.zeros(dimension, dtype=np.float32)
+    shared[0] = 1.0
+    for index in range(nodes):
+        node_id = f"n{index:08d}"
+        residual = rng.normal(size=dimension).astype(np.float32)
+        residual[0] = 0.0
+        residual /= np.linalg.norm(residual)
+        # Pair similarities cluster around 0.92: inside gte-large's
+        # cross-link band while remaining below its 0.94 dedup threshold.
+        vector = np.asarray(
+            np.sqrt(0.92) * shared + np.sqrt(0.08) * residual,
+            dtype=np.float32,
+        )
+        conn.execute(
+            "INSERT INTO thought_nodes(id, content, timestamp, source_file) "
+            "VALUES (?, ?, ?, ?)",
+            (node_id, f"synthetic node {index}", f"2026-01-{index % 28 + 1:02d}",
+             f"source-{index % 7}.md"),
+        )
+        conn.execute(
+            "INSERT INTO embeddings(node_id, vector, model) VALUES (?, ?, ?)",
+            (node_id, vector.tobytes(), get_active_profile().name),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _hold_writer(path: Path, milliseconds: int, acquired: threading.Event) -> None:
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        acquired.set()
+        time.sleep(milliseconds / 1000)
+        conn.rollback()
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--nodes", type=int, default=500)
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--max-edges", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=193)
+    parser.add_argument(
+        "--hold-writer-ms", type=int, default=0,
+        help="hold a competing write transaction for this many milliseconds",
+    )
+    args = parser.parse_args()
+    if (
+        args.nodes < 2 or args.limit < 2 or args.max_edges < 0
+        or args.hold_writer_ms < 0
+    ):
+        parser.error("nodes/limit must be at least 2; limits must be non-negative")
+
+    profile = get_active_profile()
+    with tempfile.TemporaryDirectory(prefix="cashew-sleep-benchmark-") as tmp:
+        path = Path(tmp) / "fixture.db"
+        _build_fixture(path, args.nodes, profile.dim, args.seed)
+        writer = None
+        if args.hold_writer_ms:
+            acquired = threading.Event()
+            writer = threading.Thread(
+                target=_hold_writer,
+                args=(path, args.hold_writer_ms, acquired),
+                daemon=True,
+            )
+            writer.start()
+            if not acquired.wait(timeout=2):
+                raise RuntimeError("competing writer did not acquire its transaction")
+        started = time.perf_counter()
+        result = run_sleep_cycle(
+            str(path), limit=args.limit, max_edges=args.max_edges,
+            journal_policy="preserve",
+        )
+        if writer is not None:
+            writer.join(timeout=max(2.0, args.hold_writer_ms / 1000 + 1.0))
+            if writer.is_alive():
+                raise RuntimeError("competing writer did not exit")
+        report = {
+            "fixture_nodes": args.nodes,
+            "limit": args.limit,
+            "max_edges": args.max_edges,
+            "hold_writer_ms": args.hold_writer_ms,
+            "model": profile.name,
+            "dimension": profile.dim,
+            "wall_seconds": round(time.perf_counter() - started, 6),
+            "result": result,
+        }
+    print(json.dumps(report, sort_keys=True))
+    return 0 if result["status"] in {"completed", "partial"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -170,9 +170,12 @@ def test_embed_orphans_uses_injected_model_and_batch_protocol(tmp_path):
 
     db = str(tmp_path / "orphan.db")
     conn = sqlite3.connect(db)
+    pytest.importorskip("sqlite_vec")
+    from core.embeddings import _load_vec
+    _load_vec(conn)
     conn.execute("CREATE TABLE thought_nodes (id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0)")
     conn.execute("CREATE TABLE embeddings (node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT)")
-    conn.execute("CREATE TABLE vec_embeddings (node_id TEXT PRIMARY KEY, embedding BLOB)")
+    conn.execute("CREATE VIRTUAL TABLE vec_embeddings USING vec0(node_id text primary key, embedding float[3])")
     conn.execute("INSERT INTO thought_nodes (id, content) VALUES ('n1', 'an orphan node')")
     conn.commit()
 
@@ -198,9 +201,12 @@ def test_embed_orphans_writes_vec_index_row(tmp_path):
 
     db = str(tmp_path / "orphan.db")
     conn = sqlite3.connect(db)
+    pytest.importorskip("sqlite_vec")
+    from core.embeddings import _load_vec
+    _load_vec(conn)
     conn.execute("CREATE TABLE thought_nodes (id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0)")
     conn.execute("CREATE TABLE embeddings (node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT)")
-    conn.execute("CREATE TABLE vec_embeddings (node_id TEXT PRIMARY KEY, embedding BLOB)")
+    conn.execute("CREATE VIRTUAL TABLE vec_embeddings USING vec0(node_id text primary key, embedding float[4])")
     conn.execute("INSERT INTO thought_nodes (id, content) VALUES ('n1', 'an orphan node')")
     conn.commit()
 

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -156,79 +156,60 @@ class TestPermanenceIntegrity:
         assert integrity["integrity_ok"] is True
 
 
-def test_embed_orphans_uses_configured_model(monkeypatch, tmp_path):
-    """Regression: _embed_orphans must embed with the CONFIGURED model, not the
-    hardcoded DEFAULT — otherwise a model override embeds orphans at the wrong dim."""
+def test_embed_orphans_uses_injected_model_and_batch_protocol(tmp_path):
+    """Orphan repair uses the caller-owned client and records its model."""
     import sqlite3
     import numpy as np
-    import sentence_transformers
     from core import sleep as S
-    from core import config as C
-
     captured = {}
 
-    class FakeST:
-        def __init__(self, name):
-            captured["name"] = name
-        def encode(self, text, normalize_embeddings=True):
-            return np.array([0.1, 0.2, 0.3], dtype=np.float32)
-
-    monkeypatch.setattr(sentence_transformers, "SentenceTransformer", FakeST)
-    monkeypatch.setattr(C, "get_embedding_model", lambda: "sentinel/custom-model")
+    class FakeClient:
+        def encode(self, texts):
+            captured["texts"] = texts
+            return np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
 
     db = str(tmp_path / "orphan.db")
     conn = sqlite3.connect(db)
     conn.execute("CREATE TABLE thought_nodes (id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0)")
     conn.execute("CREATE TABLE embeddings (node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT)")
+    conn.execute("CREATE TABLE vec_embeddings (node_id TEXT PRIMARY KEY, embedding BLOB)")
     conn.execute("INSERT INTO thought_nodes (id, content) VALUES ('n1', 'an orphan node')")
     conn.commit()
 
-    n = S._embed_orphans(conn)
+    n = S._embed_orphans(conn, embedding_client=FakeClient(),
+                          embedding_model="sentinel/custom-model",
+                          expected_dimension=3)
     assert n == 1
-    # Constructed with the configured model, and stored under that name.
-    assert captured["name"] == "sentinel/custom-model"
+    assert captured["texts"] == ["an orphan node"]
     stored = conn.execute("SELECT model FROM embeddings WHERE node_id='n1'").fetchone()[0]
     assert stored == "sentinel/custom-model"
     conn.close()
 
 
-def test_embed_orphans_writes_vec_index_row(monkeypatch, tmp_path):
-    """Regression: _embed_orphans must write BYTES to vec_embeddings (like
-    embed_nodes), not a Python list. A list raises sqlite3.ProgrammingError,
-    which the OperationalError handler does NOT catch, so the orphan silently
-    ends up with an embeddings row but no vec-index row (invisible to the
-    primary search path, and never retried since it's no longer an orphan)."""
+def test_embed_orphans_writes_vec_index_row(tmp_path):
+    """A valid injected vector is written as bytes to both stores."""
     import sqlite3
     import numpy as np
-    import sentence_transformers
     from core import sleep as S
-    from core import config as C
 
-    class FakeST:
-        def __init__(self, name):
-            pass
-        def encode(self, text, normalize_embeddings=True):
-            return np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
-
-    monkeypatch.setattr(sentence_transformers, "SentenceTransformer", FakeST)
-    monkeypatch.setattr(C, "get_embedding_model", lambda: "test-model")
+    class FakeClient:
+        def encode(self, texts):
+            return np.array([[0.1, 0.2, 0.3, 0.4]], dtype=np.float32)
 
     db = str(tmp_path / "orphan.db")
     conn = sqlite3.connect(db)
     conn.execute("CREATE TABLE thought_nodes (id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0)")
     conn.execute("CREATE TABLE embeddings (node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT)")
-    # Plain BLOB table standing in for the sqlite-vec virtual table: accepts
-    # bytes, rejects a Python list — exactly the bug boundary.
     conn.execute("CREATE TABLE vec_embeddings (node_id TEXT PRIMARY KEY, embedding BLOB)")
     conn.execute("INSERT INTO thought_nodes (id, content) VALUES ('n1', 'an orphan node')")
     conn.commit()
 
-    n = S._embed_orphans(conn)
-    assert n == 1  # pre-fix the ProgrammingError escapes and embedded stays 0
+    n = S._embed_orphans(conn, embedding_client=FakeClient(),
+                          embedding_model="test-model", expected_dimension=4)
+    assert n == 1
     row = conn.execute("SELECT embedding FROM vec_embeddings WHERE node_id='n1'").fetchone()
     assert row is not None and isinstance(row[0], (bytes, bytearray))
     conn.close()
-
 
 def test_promote_core_memories_never_promotes_decayed_node():
     """Regression: a decayed node must never be marked permanent, even if it

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -11,7 +11,10 @@ import pytest
 
 from core.decay_audit import ensure_decay_audit_schema
 import core.sleep as sleep_module
-from core.sleep import _batch_cross_links, _embed_orphans, _vec_write_capability, run_sleep_cycle
+from core.sleep import (
+    _batch_cross_links, _embed_orphans, _empty_sleep_result,
+    _vec_write_capability, run_sleep_cycle,
+)
 
 
 class _CountingConnection(sqlite3.Connection):
@@ -399,6 +402,7 @@ def test_early_orphan_commit_survives_candidate_discovery_failure(tmp_path, monk
     assert result["status"] == "partial"
     assert result["error"] == "sleep_cycle_failed"
     assert result["orphans_embedded"] == 2
+    assert set(result) == set(_empty_sleep_result("partial", "sleep_cycle_failed"))
     check = sqlite3.connect(str(tmp_path / "orphans.db"))
     assert check.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 2
     check.close()

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -14,6 +14,7 @@ import core.sleep as sleep_module
 from core.sleep import (
     _batch_cross_links, _embed_orphans, _empty_sleep_result,
     _ensure_sleep_state_schema,
+    _select_cycle_node_ids,
     _vec_write_capability, run_sleep_cycle,
 )
 
@@ -204,6 +205,160 @@ def test_cross_link_repairs_half_pair_and_counts_one_row(tmp_path):
     conn.close()
 
 
+def test_public_cycle_reports_exact_prefix_when_final_cross_commit_fails(
+    tmp_path, monkeypatch,
+):
+    path = _cycle_db(tmp_path, "cross-prefix.db")
+    conn = sqlite3.connect(str(path))
+    conn.execute("DELETE FROM embeddings")
+    conn.execute("DELETE FROM thought_nodes")
+    vector = np.ones(1024, dtype=np.float32).tobytes()
+    rows = [(f"n{i:04d}", f"node {i}") for i in range(1002)]
+    conn.executemany("INSERT INTO thought_nodes(id, content) VALUES (?, ?)", rows)
+    conn.executemany(
+        "INSERT INTO embeddings(node_id, vector, model) VALUES (?, ?, ?)",
+        [(node_id, vector, "thenlper/gte-large") for node_id, _ in rows],
+    )
+    conn.commit()
+    conn.close()
+
+    pairs = np.asarray([(i, i + 1) for i in range(0, 1002, 2)], dtype=int)
+    monkeypatch.setattr(
+        sleep_module,
+        "_find_pairs",
+        lambda ids, _matrix, **_kwargs: (
+            pairs, np.empty((0, 2), dtype=int), np.ones((len(ids), len(ids))),
+        ),
+    )
+    _neutralize_post_pair_phases(monkeypatch)
+    real_connect = sqlite3.connect
+
+    class FailFinalCommit(sqlite3.Connection):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.commit_calls = 0
+
+        def commit(self):
+            self.commit_calls += 1
+            if self.commit_calls == 2:
+                raise sqlite3.OperationalError("synthetic final commit failure")
+            return super().commit()
+
+    first = True
+
+    def connect(database, *args, **kwargs):
+        nonlocal first
+        if first and str(database) == str(path):
+            first = False
+            kwargs["factory"] = FailFinalCommit
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sleep_module.sqlite3, "connect", connect)
+    dream_inputs = []
+
+    def capture_dream(_conn, tuples, model_fn):
+        dream_inputs.extend(tuples)
+        return None
+
+    monkeypatch.setattr(sleep_module, "_generate_dream", capture_dream)
+    result = run_sleep_cycle(
+        db_path=str(path), model_fn=lambda _prompt: "unused",
+        journal_policy="preserve",
+    )
+
+    assert result["status"] == "partial"
+    assert result["error"] == "cross_link_failed"
+    assert result["cross_links_created"] == 500
+    assert result["cross_link_directed_rows"] == 1000
+    assert len(dream_inputs) == 500
+    assert dream_inputs[-1][:2] == ("n0998", "n0999")
+    assert set(result) == set(_empty_sleep_result("partial", "cross_link_failed"))
+    check = real_connect(str(path))
+    assert check.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 1000
+    check.close()
+
+
+def test_public_cycle_reports_uncertain_when_commit_cannot_be_verified(
+    tmp_path, monkeypatch,
+):
+    path = _cycle_db(tmp_path, "cross-uncertain.db")
+    monkeypatch.setattr(
+        sleep_module,
+        "_find_pairs",
+        lambda *_args, **_kwargs: (
+            np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), np.eye(2),
+        ),
+    )
+    real_connect = sqlite3.connect
+
+    class UnknownCommit(sqlite3.Connection):
+        def commit(self):
+            raise sqlite3.OperationalError("synthetic ambiguous commit")
+
+        def execute(self, sql, *args, **kwargs):
+            if sql.startswith("SELECT count(*) FROM derivation_edges"):
+                raise sqlite3.OperationalError("synthetic verification failure")
+            return super().execute(sql, *args, **kwargs)
+
+    first = True
+
+    def connect(database, *args, **kwargs):
+        nonlocal first
+        if first and str(database) == str(path):
+            first = False
+            kwargs["factory"] = UnknownCommit
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sleep_module.sqlite3, "connect", connect)
+    result = run_sleep_cycle(db_path=str(path), journal_policy="preserve")
+    assert result["status"] == "uncertain"
+    assert result["error"] == "cross_link_commit_uncertain"
+    assert result["cross_links_created"] == 0
+    assert result["cross_link_directed_rows"] == 0
+    assert set(result) == set(
+        _empty_sleep_result("uncertain", "cross_link_commit_uncertain")
+    )
+
+
+def test_public_cycle_counts_commit_that_succeeds_before_wrapper_error(
+    tmp_path, monkeypatch,
+):
+    path = _cycle_db(tmp_path, "cross-post-commit.db")
+    monkeypatch.setattr(
+        sleep_module,
+        "_find_pairs",
+        lambda *_args, **_kwargs: (
+            np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), np.eye(2),
+        ),
+    )
+    _neutralize_post_pair_phases(monkeypatch)
+    real_connect = sqlite3.connect
+
+    class PostCommitError(sqlite3.Connection):
+        def commit(self):
+            super().commit()
+            raise sqlite3.OperationalError("synthetic post-commit wrapper failure")
+
+    first = True
+
+    def connect(database, *args, **kwargs):
+        nonlocal first
+        if first and str(database) == str(path):
+            first = False
+            kwargs["factory"] = PostCommitError
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sleep_module.sqlite3, "connect", connect)
+    result = run_sleep_cycle(db_path=str(path), journal_policy="preserve")
+    assert result["status"] == "partial"
+    assert result["error"] == "cross_link_failed"
+    assert result["cross_links_created"] == 1
+    assert result["cross_link_directed_rows"] == 2
+    check = real_connect(str(path))
+    assert check.execute("SELECT count(*) FROM derivation_edges").fetchone() == (2,)
+    check.close()
+
+
 def test_cross_link_trigger_suppression_is_not_claimed(tmp_path):
     conn = _edge_db(tmp_path)
     conn.execute(
@@ -264,7 +419,7 @@ def test_cross_link_cap_batches_at_five_hundred_pairs(tmp_path, pair_count):
     assert stats["directed_rows"] == pair_count * 2
     assert len(stats["dream_pairs"]) == pair_count
     assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == pair_count * 2
-    assert conn.commit_count - baseline_commit_count <= 2
+    assert conn.commit_count - baseline_commit_count == (pair_count + 499) // 500
     conn.close()
 
 
@@ -341,7 +496,7 @@ class _Client:
         return self.value(len(texts)) if callable(self.value) else self.value
 
 
-def _orphan_db(tmp_path: Path, vec: bool = True):
+def _orphan_db(tmp_path: Path, vec: bool = True, dimension: int = 4):
     conn = sqlite3.connect(str(tmp_path / "orphans.db"))
     conn.execute(
         "CREATE TABLE thought_nodes("
@@ -360,8 +515,14 @@ def _orphan_db(tmp_path: Path, vec: bool = True):
         "PRIMARY KEY(parent_id, child_id))"
     )
     if vec:
+        pytest.importorskip("sqlite_vec")
+        from core.embeddings import _load_vec
+
+        _load_vec(conn)
         conn.execute(
-            "CREATE TABLE vec_embeddings(node_id TEXT PRIMARY KEY, embedding BLOB)"
+            "CREATE VIRTUAL TABLE vec_embeddings USING vec0("
+            f"node_id text primary key, embedding float[{dimension}] "
+            "distance_metric=cosine)"
         )
     conn.execute(
         "INSERT INTO thought_nodes (id, content, decayed) VALUES ('n1','orphan',0)"
@@ -392,7 +553,7 @@ def test_orphan_invalid_batch_writes_nothing(tmp_path):
 def test_orphan_batches_101_rows_with_supervisor_compatible_ceiling(
     tmp_path, monkeypatch
 ):
-    conn = _orphan_db(tmp_path)
+    conn = _orphan_db(tmp_path, dimension=384)
     conn.execute("UPDATE thought_nodes SET id='n000' WHERE id='n1'")
     conn.executemany(
         "INSERT INTO thought_nodes(id, content, timestamp) VALUES (?, ?, ?)",
@@ -435,6 +596,8 @@ def test_orphan_batches_101_rows_with_supervisor_compatible_ceiling(
     assert result["orphan_write_failed"] == 0
     assert set(result) == set(_empty_sleep_result("completed", None))
     check = sqlite3.connect(str(tmp_path / "orphans.db"))
+    from core.embeddings import _load_vec
+    _load_vec(check)
     assert check.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 101
     assert check.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 101
     check.close()
@@ -468,7 +631,7 @@ def test_orphan_encode_runs_before_write_transaction(tmp_path):
 def test_orphan_batch_failure_preserves_committed_prefix_for_restart(
     tmp_path, monkeypatch
 ):
-    conn = _orphan_db(tmp_path)
+    conn = _orphan_db(tmp_path, dimension=384)
     conn.execute("UPDATE thought_nodes SET id='n000' WHERE id='n1'")
     conn.executemany(
         "INSERT INTO thought_nodes(id, content, timestamp) VALUES (?, ?, ?)",
@@ -511,6 +674,8 @@ def test_orphan_batch_failure_preserves_committed_prefix_for_restart(
     assert set(result) == set(_empty_sleep_result("partial", "orphan_write_failed"))
 
     conn = sqlite3.connect(str(tmp_path / "orphans.db"))
+    from core.embeddings import _load_vec
+    _load_vec(conn)
     assert conn.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 100
     assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 100
 
@@ -562,14 +727,100 @@ def test_orphan_limit_caps_ordinary_present_vec_missing_rows(tmp_path):
     conn.close()
 
 
-def test_orphan_vec_failure_rolls_back_ordinary_row(tmp_path):
-    conn = _orphan_db(tmp_path)
-    conn.execute("DROP TABLE vec_embeddings")
-    conn.execute(
-        "CREATE TABLE vec_embeddings("
-        "node_id TEXT PRIMARY KEY, embedding BLOB NOT NULL CHECK(length(embedding)<1))"
+def test_capped_orphan_failures_advance_durable_cursor(tmp_path):
+    conn = _orphan_db(tmp_path, vec=False)
+    conn.execute("UPDATE thought_nodes SET id='one', content='one', timestamp='1'")
+    conn.executemany(
+        "INSERT INTO thought_nodes(id, content, timestamp) VALUES (?, ?, ?)",
+        [("two", "two", "2"), ("three", "three", "3")],
     )
     conn.commit()
+
+    class RejectEveryPage:
+        def __init__(self):
+            self.calls = []
+
+        def encode(self, texts):
+            self.calls.append(list(texts))
+            raise RuntimeError("synthetic worker rejection")
+
+    client = RejectEveryPage()
+    for _ in range(3):
+        stats = {}
+        assert _embed_orphans(
+            conn,
+            embedding_client=client,
+            embedding_model="m",
+            expected_dimension=4,
+            limit=1,
+            batch_size=1,
+            stats=stats,
+        ) == 0
+        assert stats["orphan_examined"] == 1
+        assert stats["orphan_write_failed"] == 1
+    assert client.calls == [["one"], ["two"], ["three"]]
+    check = sqlite3.connect(str(tmp_path / "orphans.db"))
+    assert check.execute(
+        "SELECT epoch FROM _cashew_sleep_state "
+        "WHERE name='orphan_missing_cursor_v1'"
+    ).fetchone() == (3,)
+    check.close()
+    conn.close()
+
+
+def test_capped_orphan_phase_rotation_prevents_repair_starvation(tmp_path):
+    conn = _orphan_db(tmp_path)
+    vector = np.ones(4, dtype=np.float32).tobytes()
+    conn.execute("UPDATE thought_nodes SET id='missing', content='missing'")
+    conn.execute(
+        "INSERT INTO thought_nodes(id, content, timestamp) VALUES ('repair','repair','2')"
+    )
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('repair', ?, 'm', datetime('now'))",
+        (vector,),
+    )
+    conn.commit()
+
+    class RejectOrdinary:
+        def __init__(self):
+            self.calls = []
+
+        def encode(self, texts):
+            self.calls.append(list(texts))
+            raise RuntimeError("synthetic worker rejection")
+
+    client = RejectOrdinary()
+    first_stats = {}
+    assert _embed_orphans(
+        conn, embedding_client=client, embedding_model="m", expected_dimension=4,
+        limit=1, batch_size=1, stats=first_stats,
+    ) == 0
+    assert first_stats["orphan_write_failed"] == 1
+    second_stats = {}
+    assert _embed_orphans(
+        conn, embedding_client=client, embedding_model="m", expected_dimension=4,
+        limit=1, batch_size=1, stats=second_stats,
+    ) == 1
+    assert client.calls == [["missing"]]
+    assert conn.execute(
+        "SELECT count(*) FROM vec_embeddings WHERE node_id='repair'"
+    ).fetchone() == (1,)
+    conn.close()
+
+
+def test_orphan_vec_failure_rolls_back_ordinary_row(tmp_path):
+    conn = _orphan_db(tmp_path)
+    conn.close()
+
+    class BrokenVecWrite(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):
+            if sql.startswith("INSERT OR REPLACE INTO vec_embeddings"):
+                raise sqlite3.OperationalError("synthetic vec write failure")
+            return super().execute(sql, *args, **kwargs)
+
+    conn = sqlite3.connect(
+        str(tmp_path / "orphans.db"), factory=BrokenVecWrite,
+    )
     client = _Client(lambda n: np.ones((n, 4), dtype=np.float32))
     stats = {}
     assert (
@@ -638,30 +889,15 @@ def test_malformed_existing_embedding_is_contained(tmp_path):
 
 def test_real_sqlite_vec0_dual_write_when_extension_is_available(tmp_path):
     pytest.importorskip("sqlite_vec")
-    from core.embeddings import _load_vec
 
     conn = _orphan_db(tmp_path)
-    conn.execute("DROP TABLE vec_embeddings")
-    _load_vec(conn)
-    conn.execute(
-        "CREATE VIRTUAL TABLE vec_embeddings USING vec0("
-        "node_id text primary key, embedding float[4] distance_metric=cosine)"
-    )
-    conn.commit()
+    assert _vec_write_capability(conn) is True
     conn.close()
 
 
 def _real_vec_db(tmp_path: Path, name: str):
     pytest.importorskip("sqlite_vec")
-    from core.embeddings import _load_vec
     conn = _orphan_db(tmp_path)
-    conn.execute("DROP TABLE vec_embeddings")
-    _load_vec(conn)
-    conn.execute(
-        "CREATE VIRTUAL TABLE vec_embeddings USING vec0("
-        "node_id text primary key, embedding float[4] distance_metric=cosine)"
-    )
-    conn.commit()
     conn.close()
     return sqlite3.connect(str(tmp_path / "orphans.db"))
 
@@ -677,6 +913,29 @@ def test_vec_enable_failure_is_unavailable(tmp_path):
     disabled = sqlite3.connect(str(tmp_path / "orphans.db"), factory=Disabled)
     assert _vec_write_capability(disabled) is False
     disabled.close()
+
+
+def test_plain_table_named_vec_embeddings_is_not_vec_capability(tmp_path):
+    conn = _orphan_db(tmp_path, vec=False)
+    conn.execute(
+        "CREATE TABLE vec_embeddings(node_id TEXT PRIMARY KEY, embedding BLOB)"
+    )
+    conn.commit()
+    assert _vec_write_capability(conn) is False
+    stats = {}
+    assert _embed_orphans(
+        conn,
+        embedding_client=_Client(
+            lambda n: np.ones((n, 4), dtype=np.float32)
+        ),
+        embedding_model="m",
+        expected_dimension=4,
+        stats=stats,
+    ) == 0
+    assert stats["orphan_vec_unavailable"] == 1
+    assert conn.execute("SELECT count(*) FROM embeddings").fetchone() == (1,)
+    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone() == (0,)
+    conn.close()
 
 
 def test_vec_post_load_query_failure_is_hard(tmp_path):
@@ -725,7 +984,7 @@ def test_public_cycle_reports_committed_prefix_when_later_phase_fails(tmp_path, 
 
 
 def test_early_orphan_commit_survives_candidate_discovery_failure(tmp_path, monkeypatch):
-    conn = _orphan_db(tmp_path)
+    conn = _orphan_db(tmp_path, dimension=384)
     vector = np.ones(384, dtype=np.float32).tobytes()
     conn.execute(
         "INSERT INTO embeddings VALUES ('anchor', ?, 'all-MiniLM-L6-v2', datetime('now'))",
@@ -953,6 +1212,73 @@ def test_sleep_state_malformed_schema_rebuilds_idempotently(tmp_path):
     conn.close()
 
 
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [
+            ("candidate_cursor_v1", "2026-01-01", "a", 1),
+            ("candidate_cursor_v1", "2026-01-02", "b", 2),
+        ],
+        [("candidate_cursor_v1", b"bad", "a", 1)],
+        [("candidate_cursor_v1", "2026-01-01", "a", -1)],
+    ],
+)
+def test_sleep_state_ambiguous_or_invalid_cursor_resets_to_origin(tmp_path, rows):
+    conn = sqlite3.connect(str(tmp_path / "state-reset.db"))
+    conn.execute(
+        "CREATE TABLE _cashew_sleep_state("
+        "name TEXT, cursor_timestamp TEXT, cursor_node_id TEXT, epoch)"
+    )
+    conn.executemany("INSERT INTO _cashew_sleep_state VALUES (?, ?, ?, ?)", rows)
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    _ensure_sleep_state_schema(conn)
+    conn.commit()
+    assert conn.execute(
+        "SELECT * FROM _cashew_sleep_state WHERE name='candidate_cursor_v1'"
+    ).fetchall() == []
+    conn.close()
+
+
+def test_sleep_state_exact_schema_drops_type_invalid_cursor(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "state-invalid.db"))
+    conn.execute(
+        "CREATE TABLE _cashew_sleep_state("
+        "name TEXT PRIMARY KEY, cursor_timestamp TEXT NOT NULL, "
+        "cursor_node_id TEXT NOT NULL, epoch INTEGER NOT NULL)"
+    )
+    conn.execute(
+        "INSERT INTO _cashew_sleep_state VALUES (?, ?, ?, ?)",
+        ("candidate_cursor_v1", sqlite3.Binary(b"bad"), "a", 1),
+    )
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    _ensure_sleep_state_schema(conn)
+    conn.commit()
+    assert conn.execute("SELECT * FROM _cashew_sleep_state").fetchall() == []
+    conn.close()
+
+
+def test_sleep_cursor_migration_is_atomic_under_writer_contention(tmp_path):
+    path = _cycle_db(tmp_path, "cursor-contention.db")
+    _add_four_fairness_nodes(path)
+    owner = sqlite3.connect(str(path))
+    contender = sqlite3.connect(str(path), timeout=0.0)
+    owner.execute("BEGIN IMMEDIATE")
+    with pytest.raises(sqlite3.OperationalError, match="locked"):
+        _select_cycle_node_ids(contender, 2)
+    assert owner.execute(
+        "SELECT name FROM sqlite_master WHERE name='_cashew_sleep_state'"
+    ).fetchone() is None
+    owner.rollback()
+    assert _select_cycle_node_ids(contender, 2) == ["a", "b"]
+    assert contender.execute(
+        "SELECT name, epoch FROM _cashew_sleep_state"
+    ).fetchall() == [("candidate_cursor_v1", 1)]
+    contender.close()
+    owner.close()
+
+
 def test_synchronous_dream_reports_ran(tmp_path, monkeypatch):
     path = _cycle_db(tmp_path, "dream.db")
     conn = sqlite3.connect(str(path))
@@ -1015,7 +1341,7 @@ def test_repaired_half_pair_can_drive_dream(tmp_path, monkeypatch):
 
 
 def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
-    conn = _orphan_db(tmp_path)
+    conn = _orphan_db(tmp_path, dimension=384)
     dimension = 384
     anchor = np.ones(dimension, dtype=np.float32).tobytes()
     conn.execute(
@@ -1041,6 +1367,8 @@ def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
     assert result["nodes_selected"] == 2
     assert result["dedup_nodes_merged"] == 1
     check = sqlite3.connect(str(tmp_path / "orphans.db"))
+    from core.embeddings import _load_vec
+    _load_vec(check)
     assert check.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 1
     check.close()
 

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -11,7 +11,7 @@ import pytest
 
 from core.decay_audit import ensure_decay_audit_schema
 import core.sleep as sleep_module
-from core.sleep import _batch_cross_links, _embed_orphans, run_sleep_cycle
+from core.sleep import _batch_cross_links, _embed_orphans, _vec_write_capability, run_sleep_cycle
 
 
 class _CountingConnection(sqlite3.Connection):
@@ -40,7 +40,7 @@ def _cycle_db(tmp_path: Path, name: str = "cycle.db") -> Path:
             id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0,
             timestamp TEXT DEFAULT '', source_file TEXT, access_count INTEGER DEFAULT 0,
             permanent INTEGER DEFAULT 0, last_accessed TEXT, domain TEXT, node_type TEXT,
-            confidence REAL, metadata TEXT
+            confidence REAL, metadata TEXT, mood_state TEXT
         );
         CREATE TABLE embeddings(
             node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT
@@ -147,6 +147,14 @@ def test_embedding_profile_dimension_is_rejected_before_database_open(monkeypatc
     assert result["error"] == "embedding_dimension_mismatch"
 
 
+def test_active_profile_failure_without_explicit_model_is_pre_db(monkeypatch):
+    monkeypatch.setattr(sleep_module, "_get_active_profile", lambda *_args: (_ for _ in ()).throw(RuntimeError("profile")))
+    monkeypatch.setattr(sqlite3, "connect", lambda *_args, **_kwargs: pytest.fail("database must not open"))
+    result = run_sleep_cycle(db_path="/tmp/does-not-exist.db")
+    assert result["status"] in {"rejected", "unavailable"}
+    assert result["error"] == "uncalibrated_embedding_model"
+
+
 class _Client:
     def __init__(self, value):
         self.value = value
@@ -162,11 +170,18 @@ def _orphan_db(tmp_path: Path, vec: bool = True):
     conn.execute(
         "CREATE TABLE thought_nodes("
         "id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0, "
-        "timestamp TEXT DEFAULT '')"
+        "timestamp TEXT DEFAULT '', source_file TEXT, access_count INTEGER DEFAULT 0, "
+        "permanent INTEGER DEFAULT 0, node_type TEXT DEFAULT 'observation', "
+        "last_accessed TEXT, domain TEXT)"
     )
     conn.execute(
         "CREATE TABLE embeddings("
         "node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE derivation_edges("
+        "parent_id TEXT, child_id TEXT, weight REAL, reasoning TEXT, "
+        "PRIMARY KEY(parent_id, child_id))"
     )
     if vec:
         conn.execute(
@@ -285,6 +300,49 @@ def test_real_sqlite_vec0_dual_write_when_extension_is_available(tmp_path):
     )
     conn.commit()
     conn.close()
+
+
+def _real_vec_db(tmp_path: Path, name: str):
+    pytest.importorskip("sqlite_vec")
+    from core.embeddings import _load_vec
+    conn = _orphan_db(tmp_path)
+    conn.execute("DROP TABLE vec_embeddings")
+    _load_vec(conn)
+    conn.execute(
+        "CREATE VIRTUAL TABLE vec_embeddings USING vec0("
+        "node_id text primary key, embedding float[4] distance_metric=cosine)"
+    )
+    conn.commit()
+    conn.close()
+    return sqlite3.connect(str(tmp_path / "orphans.db"))
+
+
+def test_vec_enable_failure_is_unavailable(tmp_path):
+    conn = _real_vec_db(tmp_path, "enable-failure")
+
+    class Disabled(sqlite3.Connection):
+        def enable_load_extension(self, _enabled):
+            raise sqlite3.OperationalError("extension disabled")
+
+    conn.close()
+    disabled = sqlite3.connect(str(tmp_path / "orphans.db"), factory=Disabled)
+    assert _vec_write_capability(disabled) is False
+    disabled.close()
+
+
+def test_vec_post_load_query_failure_is_hard(tmp_path):
+    _real_vec_db(tmp_path, "query-failure").close()
+
+    class BrokenQuery(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):
+            if sql == "SELECT count(*) FROM vec_embeddings":
+                raise sqlite3.OperationalError("corrupt vec schema")
+            return super().execute(sql, *args, **kwargs)
+
+    conn = sqlite3.connect(str(tmp_path / "orphans.db"), factory=BrokenQuery)
+    with pytest.raises(sqlite3.OperationalError, match="corrupt vec schema"):
+        _vec_write_capability(conn)
+    conn.close()
     conn = sqlite3.connect(str(tmp_path / "orphans.db"))
     client = _Client(lambda n: np.ones((n, 4), dtype=np.float32))
     assert (
@@ -335,20 +393,63 @@ def test_public_cycle_exposes_cross_link_failure(tmp_path, monkeypatch):
     assert result["error"] == "cross_link_failed"
 
 
-def test_synchronous_dream_reports_ran(tmp_path, monkeypatch):
-    path = _cycle_db(tmp_path, "dream.db")
+def test_zero_prefix_dream_failure_is_failed(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "zero-dream.db")
+    conn = sqlite3.connect(str(path))
+    conn.execute("UPDATE thought_nodes SET source_file='one.md' WHERE id='a'")
+    conn.execute("UPDATE thought_nodes SET source_file='two.md' WHERE id='b'")
+    conn.commit()
+    conn.close()
     monkeypatch.setattr(
         sleep_module, "_find_pairs",
         lambda *_args, **_kwargs: (
             np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), np.eye(2)
         ),
     )
-    monkeypatch.setattr(sleep_module, "_generate_dream", lambda *_args, **_kwargs: "dream-id")
+    monkeypatch.setattr(
+        sleep_module, "_batch_cross_links",
+        lambda *_args, **_kwargs: {"created": 0, "repaired": 0, "skipped": 0,
+                                   "failed": 0, "directed_rows": 0},
+    )
+    monkeypatch.setattr(sleep_module, "_evaluate_permanence", lambda *_args: {"nodes_promoted": 0})
+    monkeypatch.setattr(sleep_module, "_promote_core_memories", lambda *_args: {"promoted": 0, "demoted": 0})
     result = run_sleep_cycle(
-        db_path=str(path), model_fn=lambda _prompt: "unused", journal_policy="preserve"
+        db_path=str(path), model_fn=lambda _prompt: "too short", journal_policy="preserve"
+    )
+    assert result["dream_generation"] == "failed"
+    assert result["status"] == "failed"
+    assert result["error"] == "dream_failed"
+
+
+def test_synchronous_dream_reports_ran(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "dream.db")
+    conn = sqlite3.connect(str(path))
+    v1 = np.zeros(1024, dtype=np.float32)
+    v1[0] = 1.0
+    v2 = np.zeros(1024, dtype=np.float32)
+    v2[0] = 0.92
+    v2[1] = np.sqrt(1.0 - 0.92 ** 2)
+    conn.execute("UPDATE thought_nodes SET source_file='one.md' WHERE id='a'")
+    conn.execute("UPDATE thought_nodes SET source_file='two.md' WHERE id='b'")
+    conn.execute("UPDATE embeddings SET vector=? WHERE node_id='a'", (v1.tobytes(),))
+    conn.execute("UPDATE embeddings SET vector=? WHERE node_id='b'", (v2.tobytes(),))
+    conn.commit()
+    conn.close()
+    result = run_sleep_cycle(
+        db_path=str(path),
+        model_fn=lambda _prompt: "A durable relationship connects these two observations.",
+        journal_policy="preserve",
     )
     assert result["dream_generation"] == "ran"
-    assert result["status"] != "failed"
+    assert result["dream_id"]
+    check = sqlite3.connect(str(path))
+    assert check.execute(
+        "SELECT count(*) FROM thought_nodes WHERE id=?", (result["dream_id"],)
+    ).fetchone()[0] == 1
+    assert check.execute(
+        "SELECT count(*) FROM derivation_edges WHERE child_id=?", (result["dream_id"],)
+    ).fetchone()[0] == 2
+    check.close()
 
 
 def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
@@ -364,6 +465,7 @@ def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
         "INSERT INTO thought_nodes (id, content, decayed) VALUES ('anchor','anchor',0)"
     )
     conn.commit()
+    conn.close()
     client = _Client(lambda n: np.ones((n, dimension), dtype=np.float32))
     result = run_sleep_cycle(
         db_path=str(tmp_path / "orphans.db"),
@@ -374,8 +476,29 @@ def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
     )
     assert client.calls == [["orphan"]]
     assert result["orphans_embedded"] == 2
-    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 2
+    assert result["nodes_selected"] == 2
+    assert result["dedup_nodes_merged"] == 1
+    check = sqlite3.connect(str(tmp_path / "orphans.db"))
+    assert check.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 1
+    check.close()
+
+
+def test_public_cycle_reports_ordinary_only_orphan_write(tmp_path):
+    conn = _orphan_db(tmp_path, vec=False)
     conn.close()
+    client = _Client(lambda n: np.ones((n, 384), dtype=np.float32))
+    result = run_sleep_cycle(
+        db_path=str(tmp_path / "orphans.db"),
+        embedding_client=client,
+        embedding_model="all-MiniLM-L6-v2",
+        expected_dimension=384,
+        journal_policy="preserve",
+    )
+    assert result["orphan_ordinary_written"] == 1
+    assert result["orphan_vec_unavailable"] == 1
+    check = sqlite3.connect(str(tmp_path / "orphans.db"))
+    assert check.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 1
+    check.close()
 
 
 def test_decay_audit_schema_is_idempotent_and_preserves_graph(tmp_path):

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -375,6 +375,71 @@ def test_public_cycle_reports_committed_prefix_when_later_phase_fails(tmp_path, 
     check.close()
 
 
+def _force_late_dream_failure(monkeypatch):
+    monkeypatch.setattr(
+        sleep_module, "_find_pairs",
+        lambda *_args, **_kwargs: (
+            np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), np.eye(2)
+        ),
+    )
+    monkeypatch.setattr(
+        sleep_module, "_generate_dream",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("late")),
+    )
+
+
+def test_late_failure_preserves_permanence_promotion(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "permanence-late.db")
+
+    def promote(conn, **_kwargs):
+        conn.execute("UPDATE thought_nodes SET permanent=1 WHERE id='a'")
+        conn.commit()
+        return {"nodes_promoted": 1}
+
+    monkeypatch.setattr(sleep_module, "_evaluate_permanence", promote)
+    monkeypatch.setattr(sleep_module, "_promote_core_memories", lambda *_args: {"promoted": 0, "demoted": 0})
+    _force_late_dream_failure(monkeypatch)
+    result = run_sleep_cycle(db_path=str(path), model_fn=lambda _prompt: "unused", journal_policy="preserve")
+    assert result["status"] == "partial"
+    assert result["nodes_made_permanent"] == 1
+
+
+def test_late_failure_preserves_core_promotion(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "core-promotion-late.db")
+
+    def promote_core(conn, _metrics):
+        conn.execute("UPDATE thought_nodes SET node_type='core_memory' WHERE id='a'")
+        conn.commit()
+        return {"promoted": 1, "demoted": 0}
+
+    monkeypatch.setattr(sleep_module, "_evaluate_permanence", lambda *_args: {"nodes_promoted": 0})
+    monkeypatch.setattr(sleep_module, "_promote_core_memories", promote_core)
+    _force_late_dream_failure(monkeypatch)
+    result = run_sleep_cycle(db_path=str(path), model_fn=lambda _prompt: "unused", journal_policy="preserve")
+    assert result["status"] == "partial"
+    assert result["core_promoted"] == 1
+
+
+def test_late_failure_preserves_core_demotion(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "core-demotion-late.db")
+    conn = sqlite3.connect(str(path))
+    conn.execute("UPDATE thought_nodes SET node_type='core_memory' WHERE id='a'")
+    conn.commit()
+    conn.close()
+
+    def demote_core(conn, _metrics):
+        conn.execute("UPDATE thought_nodes SET node_type='derived' WHERE id='a'")
+        conn.commit()
+        return {"promoted": 0, "demoted": 1}
+
+    monkeypatch.setattr(sleep_module, "_evaluate_permanence", lambda *_args: {"nodes_promoted": 0})
+    monkeypatch.setattr(sleep_module, "_promote_core_memories", demote_core)
+    _force_late_dream_failure(monkeypatch)
+    result = run_sleep_cycle(db_path=str(path), model_fn=lambda _prompt: "unused", journal_policy="preserve")
+    assert result["status"] == "partial"
+    assert result["core_demoted"] == 1
+
+
 def test_public_cycle_exposes_cross_link_failure(tmp_path, monkeypatch):
     path = _cycle_db(tmp_path)
     monkeypatch.setattr(

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -1,0 +1,202 @@
+"""Production-boundary contracts for the upstream sleep adapter."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+
+from core.decay_audit import ensure_decay_audit_schema
+from core.sleep import _batch_cross_links, _embed_orphans, run_sleep_cycle
+
+
+def _edge_db(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(tmp_path / "edges.db"))
+    conn.executescript("""
+        CREATE TABLE derivation_edges(parent_id TEXT, child_id TEXT,
+            weight REAL, reasoning TEXT, PRIMARY KEY(parent_id, child_id));
+    """)
+    return conn
+
+
+def test_cross_link_cap_flushes_two_directed_rows(tmp_path):
+    conn = _edge_db(tmp_path)
+    stats = _batch_cross_links(
+        conn, ["a", "b"], np.array([[0, 1]]), np.eye(2), max_edges=1
+    )
+    assert stats["created"] == 1
+    assert stats["directed_rows"] == 2
+    assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 2
+    conn.close()
+
+
+def test_cross_link_repairs_half_pair_and_counts_one_row(tmp_path):
+    conn = _edge_db(tmp_path)
+    conn.execute("INSERT INTO derivation_edges VALUES ('a','b',.9,'old')")
+    conn.commit()
+    stats = _batch_cross_links(
+        conn, ["a", "b"], np.array([[0, 1]]), np.eye(2), max_edges=1
+    )
+    assert stats["created"] == 0 and stats["repaired"] == 1
+    assert stats["directed_rows"] == 1
+    assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 2
+    conn.close()
+
+
+class _Client:
+    def __init__(self, value):
+        self.value = value
+        self.calls = []
+
+    def encode(self, texts):
+        self.calls.append(texts)
+        return self.value(len(texts)) if callable(self.value) else self.value
+
+
+def _orphan_db(tmp_path: Path, vec: bool = True):
+    conn = sqlite3.connect(str(tmp_path / "orphans.db"))
+    conn.execute(
+        "CREATE TABLE thought_nodes("
+        "id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "CREATE TABLE embeddings("
+        "node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT)"
+    )
+    if vec:
+        conn.execute(
+            "CREATE TABLE vec_embeddings(node_id TEXT PRIMARY KEY, embedding BLOB)"
+        )
+    conn.execute("INSERT INTO thought_nodes VALUES ('n1','orphan',0)")
+    conn.commit()
+    return conn
+
+
+def test_orphan_invalid_batch_writes_nothing(tmp_path):
+    conn = _orphan_db(tmp_path)
+    client = _Client(lambda n: np.array([[np.nan, 1, 1, 1]], dtype=np.float32))
+    stats = {}
+    assert (
+        _embed_orphans(
+            conn,
+            embedding_client=client,
+            embedding_model="m",
+            expected_dimension=4,
+            stats=stats,
+        )
+        == 0
+    )
+    assert conn.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 0
+    assert stats["orphan_write_failed"] == 1
+    conn.close()
+
+
+def test_orphan_vec_failure_rolls_back_ordinary_row(tmp_path):
+    conn = _orphan_db(tmp_path)
+    conn.execute("DROP TABLE vec_embeddings")
+    conn.execute(
+        "CREATE TABLE vec_embeddings("
+        "node_id TEXT PRIMARY KEY, embedding BLOB NOT NULL CHECK(length(embedding)<1))"
+    )
+    conn.commit()
+    client = _Client(lambda n: np.ones((n, 4), dtype=np.float32))
+    stats = {}
+    assert (
+        _embed_orphans(
+            conn,
+            embedding_client=client,
+            embedding_model="m",
+            expected_dimension=4,
+            stats=stats,
+        )
+        == 0
+    )
+    assert conn.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 0
+    assert stats["orphan_write_failed"] == 1
+    conn.close()
+
+
+def test_orphan_repair_works_without_two_anchors(tmp_path):
+    conn = _orphan_db(tmp_path)
+    vec = np.ones(4, dtype=np.float32).tobytes()
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('n1', ?, 'm', datetime('now'))", (vec,)
+    )
+    conn.commit()
+    assert _embed_orphans(conn, expected_dimension=4) == 1
+    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 1
+    conn.close()
+
+
+def test_orphan_without_vec_is_explicit_ordinary_only(tmp_path):
+    conn = _orphan_db(tmp_path, vec=False)
+    client = _Client(lambda n: np.ones((n, 4), dtype=np.float32))
+    stats = {}
+    assert (
+        _embed_orphans(
+            conn,
+            embedding_client=client,
+            embedding_model="m",
+            expected_dimension=4,
+            stats=stats,
+        )
+        == 0
+    )
+    assert stats["orphan_vec_unavailable"] == 1
+    conn.close()
+
+
+def test_decay_audit_schema_is_idempotent_and_preserves_graph(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "audit.db"))
+    conn.execute(
+        "CREATE TABLE thought_nodes("
+        "id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0, "
+        "timestamp TEXT DEFAULT '')"
+    )
+    conn.execute("INSERT INTO thought_nodes (id, content) VALUES ('n','keep')")
+    ensure_decay_audit_schema(conn)
+    ensure_decay_audit_schema(conn)
+    assert conn.execute("SELECT content FROM thought_nodes").fetchone()[0] == "keep"
+    assert conn.execute(
+        "SELECT name FROM sqlite_master WHERE name='decay_audit'"
+    ).fetchone()
+    conn.close()
+
+
+def test_preserve_journal_policy_does_not_change_mode(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "empty.db"))
+    conn.execute(
+        "CREATE TABLE thought_nodes("
+        "id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0, "
+        "timestamp TEXT DEFAULT '')"
+    )
+    conn.commit()
+    conn.close()
+    result = run_sleep_cycle(
+        db_path=str(tmp_path / "empty.db"), journal_policy="preserve"
+    )
+    assert result["status"] == "unavailable"
+    check = sqlite3.connect(str(tmp_path / "empty.db"))
+    assert check.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
+    check.close()
+
+
+def test_result_contract_no_llm_has_skipped_dream(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "noemb.db"))
+    conn.execute(
+        "CREATE TABLE thought_nodes("
+        "id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0, "
+        "timestamp TEXT DEFAULT '')"
+    )
+    conn.execute(
+        "CREATE TABLE embeddings("
+        "node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    result = run_sleep_cycle(
+        db_path=str(tmp_path / "noemb.db"), journal_policy="preserve"
+    )
+    assert result["status"] == "unavailable"
+    assert result["error"] == "too_few_embeddings"

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -13,6 +13,7 @@ from core.decay_audit import ensure_decay_audit_schema
 import core.sleep as sleep_module
 from core.sleep import (
     _batch_cross_links, _embed_orphans, _empty_sleep_result,
+    _ensure_sleep_state_schema,
     _vec_write_capability, run_sleep_cycle,
 )
 
@@ -104,6 +105,7 @@ def test_cross_link_cap_flushes_two_directed_rows(tmp_path):
     )
     assert stats["created"] == 1
     assert stats["directed_rows"] == 2
+    assert stats["dream_pairs"] == [("a", "b", 0.0)]
     assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 2
     conn.close()
 
@@ -197,6 +199,7 @@ def test_cross_link_repairs_half_pair_and_counts_one_row(tmp_path):
     )
     assert stats["created"] == 0 and stats["repaired"] == 1
     assert stats["directed_rows"] == 1
+    assert stats["dream_pairs"] == [("a", "b", 0.0)]
     assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 2
     conn.close()
 
@@ -214,7 +217,38 @@ def test_cross_link_trigger_suppression_is_not_claimed(tmp_path):
     )
     assert stats["created"] == 0
     assert stats["failed"] == 1
+    assert stats["dream_pairs"] == []
     assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 0
+    conn.close()
+
+
+def test_existing_complete_pair_is_not_reused_for_dream(tmp_path):
+    conn = _edge_db(tmp_path)
+    conn.executemany(
+        "INSERT INTO derivation_edges VALUES (?, ?, .9, 'old')",
+        [("a", "b"), ("b", "a")],
+    )
+    conn.commit()
+    stats = _batch_cross_links(
+        conn, ["a", "b"], np.array([[0, 1]]), np.eye(2), max_edges=1
+    )
+    assert stats["skipped"] == 1
+    assert stats["dream_pairs"] == []
+    conn.close()
+
+
+def test_dream_pairs_stop_at_successful_pair_cap(tmp_path):
+    conn = _edge_db(tmp_path)
+    stats = _batch_cross_links(
+        conn,
+        ["a", "b", "c", "d"],
+        np.array([[0, 1], [2, 3]]),
+        np.eye(4),
+        max_edges=1,
+    )
+    assert stats["capped"] is True
+    assert stats["dream_pairs"] == [("a", "b", 0.0)]
+    assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 2
     conn.close()
 
 
@@ -228,6 +262,7 @@ def test_cross_link_cap_batches_at_five_hundred_pairs(tmp_path, pair_count):
     stats = _batch_cross_links(conn, ids, pairs, sim, max_edges=pair_count)
     assert stats["created"] == pair_count
     assert stats["directed_rows"] == pair_count * 2
+    assert len(stats["dream_pairs"]) == pair_count
     assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == pair_count * 2
     assert conn.commit_count - baseline_commit_count <= 2
     conn.close()
@@ -831,32 +866,91 @@ def test_public_cycle_exposes_cross_link_failure(tmp_path, monkeypatch):
     assert result["error"] == "cross_link_failed"
 
 
-def test_zero_prefix_dream_failure_is_failed(tmp_path, monkeypatch):
+def test_max_edges_zero_never_dreams_from_uncommitted_candidates(tmp_path, monkeypatch):
     path = _cycle_db(tmp_path, "zero-dream.db")
     conn = sqlite3.connect(str(path))
+    first = np.zeros(1024, dtype=np.float32)
+    first[0] = 1.0
+    second = np.zeros(1024, dtype=np.float32)
+    second[0] = 0.92
+    second[1] = np.sqrt(1.0 - 0.92 ** 2)
     conn.execute("UPDATE thought_nodes SET source_file='one.md' WHERE id='a'")
     conn.execute("UPDATE thought_nodes SET source_file='two.md' WHERE id='b'")
+    conn.execute("UPDATE embeddings SET vector=? WHERE node_id='a'", (first.tobytes(),))
+    conn.execute("UPDATE embeddings SET vector=? WHERE node_id='b'", (second.tobytes(),))
     conn.commit()
     conn.close()
-    monkeypatch.setattr(
-        sleep_module, "_find_pairs",
-        lambda *_args, **_kwargs: (
-            np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), np.eye(2)
-        ),
-    )
-    monkeypatch.setattr(
-        sleep_module, "_batch_cross_links",
-        lambda *_args, **_kwargs: {"created": 0, "repaired": 0, "skipped": 0,
-                                   "failed": 0, "directed_rows": 0},
-    )
-    monkeypatch.setattr(sleep_module, "_evaluate_permanence", lambda *_args: {"nodes_promoted": 0})
-    monkeypatch.setattr(sleep_module, "_promote_core_memories", lambda *_args: {"promoted": 0, "demoted": 0})
+    _neutralize_post_pair_phases(monkeypatch)
+    prompts = []
     result = run_sleep_cycle(
-        db_path=str(path), model_fn=lambda _prompt: "too short", journal_policy="preserve"
+        db_path=str(path), model_fn=prompts.append, max_edges=0,
+        journal_policy="preserve",
     )
-    assert result["dream_generation"] == "failed"
-    assert result["status"] == "failed"
-    assert result["error"] == "dream_failed"
+    assert result["cross_link_candidates"] == 1
+    assert result["cross_link_capped"] is True
+    assert result["cross_links_created"] == 0
+    assert result["dream_generation"] == "skipped"
+    assert result["status"] == "completed"
+    assert prompts == []
+    check = sqlite3.connect(str(path))
+    assert check.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 0
+    assert check.execute("SELECT count(*) FROM thought_nodes WHERE node_type='dream'").fetchone()[0] == 0
+    check.close()
+
+
+def test_sleep_state_partial_schema_migrates_and_keeps_cursor(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "partial-state.db")
+    _add_four_fairness_nodes(path)
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE _cashew_sleep_state("
+        "name TEXT, cursor_timestamp TEXT, cursor_node_id TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO _cashew_sleep_state VALUES (?, ?, ?)",
+        ("candidate_cursor_v1", "2026-01-02T00:00:00+00:00", "b"),
+    )
+    conn.commit()
+    conn.close()
+    selected = []
+
+    def capture(ids, _matrix, **_kwargs):
+        selected.append(list(ids))
+        empty = np.empty((0, 2), dtype=int)
+        return empty, empty, np.eye(len(ids))
+
+    monkeypatch.setattr(sleep_module, "_find_pairs", capture)
+    _neutralize_post_pair_phases(monkeypatch)
+    result = run_sleep_cycle(db_path=str(path), limit=2, journal_policy="preserve")
+    assert result["status"] == "completed"
+    assert selected == [["c", "d"]]
+    check = sqlite3.connect(str(path))
+    columns = [row[1] for row in check.execute("PRAGMA table_info(_cashew_sleep_state)")]
+    assert columns == ["name", "cursor_timestamp", "cursor_node_id", "epoch"]
+    assert check.execute(
+        "SELECT epoch FROM _cashew_sleep_state WHERE name='candidate_cursor_v1'"
+    ).fetchone() == (1,)
+    check.close()
+
+
+def test_sleep_state_malformed_schema_rebuilds_idempotently(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "state.db"))
+    conn.execute("CREATE TABLE _cashew_sleep_state(unrelated TEXT)")
+    conn.execute("BEGIN IMMEDIATE")
+    _ensure_sleep_state_schema(conn)
+    _ensure_sleep_state_schema(conn)
+    conn.commit()
+    shape = [
+        (row[1], (row[2] or "").upper(), row[3], row[5])
+        for row in conn.execute("PRAGMA table_info(_cashew_sleep_state)")
+    ]
+    assert shape == [
+        ("name", "TEXT", 0, 1),
+        ("cursor_timestamp", "TEXT", 1, 0),
+        ("cursor_node_id", "TEXT", 1, 0),
+        ("epoch", "INTEGER", 1, 0),
+    ]
+    conn.close()
 
 
 def test_synchronous_dream_reports_ran(tmp_path, monkeypatch):
@@ -878,6 +972,7 @@ def test_synchronous_dream_reports_ran(tmp_path, monkeypatch):
         model_fn=lambda _prompt: "A durable relationship connects these two observations.",
         journal_policy="preserve",
     )
+    assert result["cross_links_created"] == 1
     assert result["dream_generation"] == "ran"
     assert result["dream_id"]
     check = sqlite3.connect(str(path))
@@ -888,6 +983,35 @@ def test_synchronous_dream_reports_ran(tmp_path, monkeypatch):
         "SELECT count(*) FROM derivation_edges WHERE child_id=?", (result["dream_id"],)
     ).fetchone()[0] == 2
     check.close()
+
+
+def test_repaired_half_pair_can_drive_dream(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "repair-dream.db")
+    conn = sqlite3.connect(str(path))
+    first = np.zeros(1024, dtype=np.float32)
+    first[0] = 1.0
+    second = np.zeros(1024, dtype=np.float32)
+    second[0] = 0.92
+    second[1] = np.sqrt(1.0 - 0.92 ** 2)
+    conn.execute("UPDATE thought_nodes SET source_file='one.md' WHERE id='a'")
+    conn.execute("UPDATE thought_nodes SET source_file='two.md' WHERE id='b'")
+    conn.execute("UPDATE embeddings SET vector=? WHERE node_id='a'", (first.tobytes(),))
+    conn.execute("UPDATE embeddings SET vector=? WHERE node_id='b'", (second.tobytes(),))
+    conn.execute(
+        "INSERT INTO derivation_edges VALUES "
+        "('a', 'b', .92, 'existing half')"
+    )
+    conn.commit()
+    conn.close()
+    result = run_sleep_cycle(
+        db_path=str(path),
+        model_fn=lambda _prompt: "A durable relationship connects these observations.",
+        journal_policy="preserve",
+    )
+    assert result["cross_links_created"] == 0
+    assert result["cross_links_repaired"] == 1
+    assert result["dream_generation"] == "ran"
+    assert result["dream_id"]
 
 
 def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import sqlite3
+import inspect
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from core.decay_audit import ensure_decay_audit_schema
 from core.sleep import _batch_cross_links, _embed_orphans, run_sleep_cycle
@@ -44,6 +46,38 @@ def test_cross_link_repairs_half_pair_and_counts_one_row(tmp_path):
     conn.close()
 
 
+def test_cross_link_trigger_suppression_is_not_claimed(tmp_path):
+    conn = _edge_db(tmp_path)
+    conn.execute(
+        """CREATE TRIGGER suppress_reverse BEFORE INSERT ON derivation_edges
+           WHEN NEW.parent_id='b' AND NEW.child_id='a'
+           BEGIN SELECT RAISE(IGNORE); END"""
+    )
+    conn.commit()
+    stats = _batch_cross_links(
+        conn, ["a", "b"], np.array([[0, 1]]), np.eye(2), max_edges=1
+    )
+    assert stats["created"] == 0
+    assert stats["failed"] == 1
+    assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 0
+    conn.close()
+
+
+def test_run_sleep_cycle_preserves_six_positional_arguments():
+    signature = inspect.signature(run_sleep_cycle)
+    signature.bind("/tmp/example.db", None, None, False, 1, True)
+
+
+def test_partial_embedding_triad_is_rejected_before_database_open(monkeypatch):
+    def fail_connect(*_args, **_kwargs):
+        raise AssertionError("database must not open during argument rejection")
+
+    monkeypatch.setattr(sqlite3, "connect", fail_connect)
+    result = run_sleep_cycle(db_path="/tmp/does-not-exist.db", embedding_model="m")
+    assert result["status"] == "rejected"
+    assert result["error"] == "invalid_embedding_contract"
+
+
 class _Client:
     def __init__(self, value):
         self.value = value
@@ -58,7 +92,8 @@ def _orphan_db(tmp_path: Path, vec: bool = True):
     conn = sqlite3.connect(str(tmp_path / "orphans.db"))
     conn.execute(
         "CREATE TABLE thought_nodes("
-        "id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0)"
+        "id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0, "
+        "timestamp TEXT DEFAULT '')"
     )
     conn.execute(
         "CREATE TABLE embeddings("
@@ -68,7 +103,9 @@ def _orphan_db(tmp_path: Path, vec: bool = True):
         conn.execute(
             "CREATE TABLE vec_embeddings(node_id TEXT PRIMARY KEY, embedding BLOB)"
         )
-    conn.execute("INSERT INTO thought_nodes VALUES ('n1','orphan',0)")
+    conn.execute(
+        "INSERT INTO thought_nodes (id, content, decayed) VALUES ('n1','orphan',0)"
+    )
     conn.commit()
     return conn
 
@@ -144,6 +181,56 @@ def test_orphan_without_vec_is_explicit_ordinary_only(tmp_path):
         == 0
     )
     assert stats["orphan_vec_unavailable"] == 1
+    conn.close()
+
+
+def test_real_sqlite_vec0_dual_write_when_extension_is_available(tmp_path):
+    sqlite_vec = pytest.importorskip("sqlite_vec")
+    from core.embeddings import _load_vec
+
+    conn = _orphan_db(tmp_path)
+    conn.execute("DROP TABLE vec_embeddings")
+    _load_vec(conn)
+    conn.execute(
+        "CREATE VIRTUAL TABLE vec_embeddings USING vec0("
+        "node_id text primary key, embedding float[4] distance_metric=cosine)"
+    )
+    conn.commit()
+    client = _Client(lambda n: np.ones((n, 4), dtype=np.float32))
+    assert (
+        _embed_orphans(
+            conn,
+            embedding_client=client,
+            embedding_model="m",
+            expected_dimension=4,
+        )
+        == 1
+    )
+    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 1
+    conn.close()
+
+
+def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
+    conn = _orphan_db(tmp_path)
+    anchor = np.ones(4, dtype=np.float32).tobytes()
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('anchor', ?, 'm', datetime('now'))", (anchor,)
+    )
+    conn.execute(
+        "INSERT INTO thought_nodes (id, content, decayed) VALUES ('anchor','anchor',0)"
+    )
+    conn.commit()
+    client = _Client(lambda n: np.ones((n, 4), dtype=np.float32))
+    result = run_sleep_cycle(
+        db_path=str(tmp_path / "orphans.db"),
+        embedding_client=client,
+        embedding_model="all-MiniLM-L6-v2",
+        expected_dimension=4,
+        journal_policy="preserve",
+    )
+    assert client.calls == [["orphan"]]
+    assert result["orphans_embedded"] == 2
+    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 2
     conn.close()
 
 

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -112,11 +112,12 @@ def test_cross_link_cap_batches_at_five_hundred_pairs(tmp_path, pair_count):
     pairs = np.asarray([[2 * i, 2 * i + 1] for i in range(pair_count)])
     sim = np.eye(len(ids), dtype=np.float32)
     conn = _edge_db(tmp_path, name=f"edges-{pair_count}.db", factory=_CountingConnection)
+    baseline_commit_count = conn.commit_count
     stats = _batch_cross_links(conn, ids, pairs, sim, max_edges=pair_count)
     assert stats["created"] == pair_count
     assert stats["directed_rows"] == pair_count * 2
     assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == pair_count * 2
-    assert conn.commit_count <= 2
+    assert conn.commit_count - baseline_commit_count <= 2
     conn.close()
 
 

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -65,6 +65,38 @@ def _cycle_db(tmp_path: Path, name: str = "cycle.db") -> Path:
     return path
 
 
+def _add_four_fairness_nodes(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute("DELETE FROM embeddings")
+    conn.execute("DELETE FROM thought_nodes")
+    for index, node_id in enumerate(("a", "b", "c", "d"), start=1):
+        vector = np.zeros(1024, dtype=np.float32)
+        vector[index - 1] = 1.0
+        conn.execute(
+            "INSERT INTO thought_nodes(id, content, timestamp) VALUES (?, ?, ?)",
+            (node_id, node_id, f"2026-01-0{index}T00:00:00+00:00"),
+        )
+        conn.execute(
+            "INSERT INTO embeddings(node_id, vector, model) VALUES (?, ?, ?)",
+            (node_id, vector.tobytes(), "thenlper/gte-large"),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _neutralize_post_pair_phases(monkeypatch) -> None:
+    monkeypatch.setattr(sleep_module, "_compute_metrics", lambda _conn: {})
+    monkeypatch.setattr(sleep_module, "_garbage_collect", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        sleep_module, "_evaluate_permanence", lambda _conn: {"nodes_promoted": 0}
+    )
+    monkeypatch.setattr(
+        sleep_module,
+        "_promote_core_memories",
+        lambda _conn, _metrics: {"promoted": 0, "demoted": 0},
+    )
+
+
 def test_cross_link_cap_flushes_two_directed_rows(tmp_path):
     conn = _edge_db(tmp_path)
     stats = _batch_cross_links(
@@ -74,6 +106,86 @@ def test_cross_link_cap_flushes_two_directed_rows(tmp_path):
     assert stats["directed_rows"] == 2
     assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 2
     conn.close()
+
+
+def test_capped_candidate_pages_rotate_across_four_nodes(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "fair-pages.db")
+    _add_four_fairness_nodes(path)
+    selected = []
+
+    def capture(ids, _matrix, **_kwargs):
+        selected.append(list(ids))
+        empty = np.empty((0, 2), dtype=int)
+        return empty, empty, np.eye(len(ids))
+
+    monkeypatch.setattr(sleep_module, "_find_pairs", capture)
+    _neutralize_post_pair_phases(monkeypatch)
+    before_conn = sqlite3.connect(str(path))
+    before = before_conn.execute(
+        "SELECT id, timestamp FROM thought_nodes ORDER BY id"
+    ).fetchall()
+    before_conn.close()
+
+    for _ in range(2):
+        result = run_sleep_cycle(db_path=str(path), limit=2, journal_policy="preserve")
+        assert result["status"] == "completed"
+
+    assert selected == [["a", "b"], ["c", "d"]]
+    check = sqlite3.connect(str(path))
+    assert check.execute(
+        "SELECT epoch FROM _cashew_sleep_state WHERE name='candidate_cursor_v1'"
+    ).fetchone()[0] == 2
+    assert check.execute(
+        "SELECT id, timestamp FROM thought_nodes ORDER BY id"
+    ).fetchall() == before
+    check.close()
+
+
+def test_cursor_survives_interruption_then_wrap_repairs_half_pair(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "fair-restart.db")
+    _add_four_fairness_nodes(path)
+    conn = sqlite3.connect(str(path))
+    conn.execute("INSERT INTO derivation_edges VALUES ('a','b',.92,'existing half')")
+    conn.commit()
+    before = conn.execute(
+        "SELECT id, timestamp FROM thought_nodes ORDER BY id"
+    ).fetchall()
+    conn.close()
+    calls = []
+
+    def interrupt_once(ids, _matrix, **_kwargs):
+        calls.append(list(ids))
+        if len(calls) == 1:
+            raise RuntimeError("interrupted after durable page claim")
+        sim = np.eye(2, dtype=np.float64)
+        sim[0, 1] = sim[1, 0] = 0.92
+        return np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), sim
+
+    monkeypatch.setattr(sleep_module, "_find_pairs", interrupt_once)
+    _neutralize_post_pair_phases(monkeypatch)
+    failed = run_sleep_cycle(db_path=str(path), limit=2, journal_policy="preserve")
+    assert failed["status"] == "failed"
+    assert failed["error"] == "sleep_cycle_failed"
+
+    next_page = run_sleep_cycle(db_path=str(path), limit=2, journal_policy="preserve")
+    wrapped = run_sleep_cycle(db_path=str(path), limit=2, journal_policy="preserve")
+    assert calls == [["a", "b"], ["c", "d"], ["a", "b"]]
+    assert next_page["cross_links_created"] == 1
+    assert wrapped["cross_links_created"] == 0
+    assert wrapped["cross_links_repaired"] == 1
+
+    check = sqlite3.connect(str(path))
+    assert check.execute(
+        "SELECT count(*) FROM derivation_edges WHERE "
+        "(parent_id='a' AND child_id='b') OR (parent_id='b' AND child_id='a')"
+    ).fetchone()[0] == 2
+    assert check.execute(
+        "SELECT epoch FROM _cashew_sleep_state WHERE name='candidate_cursor_v1'"
+    ).fetchone()[0] == 3
+    assert check.execute(
+        "SELECT id, timestamp FROM thought_nodes ORDER BY id"
+    ).fetchall() == before
+    check.close()
 
 
 def test_cross_link_repairs_half_pair_and_counts_one_row(tmp_path):
@@ -124,6 +236,31 @@ def test_cross_link_cap_batches_at_five_hundred_pairs(tmp_path, pair_count):
 def test_run_sleep_cycle_preserves_six_positional_arguments():
     signature = inspect.signature(run_sleep_cycle)
     signature.bind("/tmp/example.db", None, None, False, 1, True)
+    assert signature.parameters["orphan_limit"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert (
+        signature.parameters["orphan_batch_size"].kind
+        is inspect.Parameter.KEYWORD_ONLY
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"orphan_limit": -1}, "invalid_orphan_limit"),
+        ({"orphan_limit": True}, "invalid_orphan_limit"),
+        ({"orphan_batch_size": 0}, "invalid_orphan_batch_size"),
+        ({"orphan_batch_size": 101}, "invalid_orphan_batch_size"),
+    ],
+)
+def test_orphan_bounds_are_rejected_before_database_open(monkeypatch, kwargs, error):
+    monkeypatch.setattr(
+        sqlite3,
+        "connect",
+        lambda *_args, **_kwargs: pytest.fail("database must not open"),
+    )
+    result = run_sleep_cycle(db_path="/tmp/does-not-exist.db", **kwargs)
+    assert result["status"] == "rejected"
+    assert result["error"] == error
 
 
 def test_partial_embedding_triad_is_rejected_before_database_open(monkeypatch):
@@ -214,6 +351,179 @@ def test_orphan_invalid_batch_writes_nothing(tmp_path):
     )
     assert conn.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 0
     assert stats["orphan_write_failed"] == 1
+    conn.close()
+
+
+def test_orphan_batches_101_rows_with_supervisor_compatible_ceiling(
+    tmp_path, monkeypatch
+):
+    conn = _orphan_db(tmp_path)
+    conn.execute("UPDATE thought_nodes SET id='n000' WHERE id='n1'")
+    conn.executemany(
+        "INSERT INTO thought_nodes(id, content, timestamp) VALUES (?, ?, ?)",
+        [(f"n{i:03d}", f"orphan {i}", "2026-01-01T00:00:00+00:00")
+         for i in range(1, 101)],
+    )
+    conn.commit()
+
+    class BoundedClient:
+        def __init__(self):
+            self.calls = []
+            self.offset = 0
+
+        def encode(self, texts):
+            assert len(texts) <= 100
+            self.calls.append(list(texts))
+            result = np.zeros((len(texts), 384), dtype=np.float32)
+            for row in range(len(texts)):
+                result[row, self.offset + row] = 1.0
+            self.offset += len(texts)
+            return result
+
+    client = BoundedClient()
+    conn.close()
+    _neutralize_post_pair_phases(monkeypatch)
+    result = run_sleep_cycle(
+        db_path=str(tmp_path / "orphans.db"),
+        limit=2,
+        embedding_client=client,
+        embedding_model="all-MiniLM-L6-v2",
+        expected_dimension=384,
+        journal_policy="preserve",
+        orphan_limit=101,
+        orphan_batch_size=100,
+    )
+    assert [len(call) for call in client.calls] == [100, 1]
+    assert client.calls[0][:2] == ["orphan", "orphan 1"]
+    assert client.calls[1] == ["orphan 100"]
+    assert result["orphans_embedded"] == 101
+    assert result["orphan_write_failed"] == 0
+    assert set(result) == set(_empty_sleep_result("completed", None))
+    check = sqlite3.connect(str(tmp_path / "orphans.db"))
+    assert check.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 101
+    assert check.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 101
+    check.close()
+
+
+def test_orphan_encode_runs_before_write_transaction(tmp_path):
+    conn = _orphan_db(tmp_path)
+    conn.execute("CREATE TABLE writer_probe(value TEXT)")
+    conn.commit()
+
+    class ConcurrentWriterClient:
+        def encode(self, texts):
+            assert conn.in_transaction is False
+            writer = sqlite3.connect(str(tmp_path / "orphans.db"), timeout=0.1)
+            writer.execute("INSERT INTO writer_probe VALUES ('during encode')")
+            writer.commit()
+            writer.close()
+            return np.ones((len(texts), 4), dtype=np.float32)
+
+    assert _embed_orphans(
+        conn,
+        embedding_client=ConcurrentWriterClient(),
+        embedding_model="m",
+        expected_dimension=4,
+        batch_size=1,
+    ) == 1
+    assert conn.execute("SELECT value FROM writer_probe").fetchone()[0] == "during encode"
+    conn.close()
+
+
+def test_orphan_batch_failure_preserves_committed_prefix_for_restart(
+    tmp_path, monkeypatch
+):
+    conn = _orphan_db(tmp_path)
+    conn.execute("UPDATE thought_nodes SET id='n000' WHERE id='n1'")
+    conn.executemany(
+        "INSERT INTO thought_nodes(id, content, timestamp) VALUES (?, ?, ?)",
+        [(f"n{i:03d}", f"orphan {i}", f"{i:03d}") for i in range(1, 101)],
+    )
+    conn.commit()
+
+    class InterruptedClient:
+        def __init__(self):
+            self.calls = 0
+
+        def encode(self, texts):
+            self.calls += 1
+            if self.calls == 2:
+                raise RuntimeError("worker exited")
+            return np.ones((len(texts), 384), dtype=np.float32)
+
+    conn.close()
+    empty = np.empty((0, 2), dtype=int)
+    monkeypatch.setattr(
+        sleep_module,
+        "_find_pairs",
+        lambda ids, _matrix, **_kwargs: (empty, empty, np.eye(len(ids))),
+    )
+    _neutralize_post_pair_phases(monkeypatch)
+    result = run_sleep_cycle(
+        db_path=str(tmp_path / "orphans.db"),
+        limit=2,
+        embedding_client=InterruptedClient(),
+        embedding_model="all-MiniLM-L6-v2",
+        expected_dimension=384,
+        journal_policy="preserve",
+        orphan_limit=101,
+        orphan_batch_size=100,
+    )
+    assert result["status"] == "partial"
+    assert result["error"] == "orphan_write_failed"
+    assert result["orphans_embedded"] == 100
+    assert result["orphan_write_failed"] == 1
+    assert set(result) == set(_empty_sleep_result("partial", "orphan_write_failed"))
+
+    conn = sqlite3.connect(str(tmp_path / "orphans.db"))
+    assert conn.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 100
+    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 100
+
+    restart = _Client(lambda n: np.ones((n, 384), dtype=np.float32))
+    assert _embed_orphans(
+        conn,
+        embedding_client=restart,
+        embedding_model="all-MiniLM-L6-v2",
+        expected_dimension=384,
+        limit=1,
+        batch_size=1,
+    ) == 1
+    assert conn.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 101
+    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 101
+    conn.close()
+
+
+def test_orphan_limit_caps_ordinary_present_vec_missing_rows(tmp_path):
+    conn = _orphan_db(tmp_path)
+    vec = np.ones(4, dtype=np.float32).tobytes()
+    conn.executemany(
+        "INSERT INTO thought_nodes(id, content, timestamp) VALUES (?, ?, ?)",
+        [("n2", "two", "2"), ("n3", "three", "3")],
+    )
+    conn.executemany(
+        "INSERT INTO embeddings(node_id, vector, model) VALUES (?, ?, 'm')",
+        [("n1", vec), ("n2", vec), ("n3", vec)],
+    )
+    conn.commit()
+
+    class MustNotEncode:
+        def encode(self, _texts):
+            raise AssertionError("existing vectors must be reused")
+
+    stats = {}
+    assert _embed_orphans(
+        conn,
+        embedding_client=MustNotEncode(),
+        embedding_model="m",
+        expected_dimension=4,
+        limit=2,
+        batch_size=1,
+        stats=stats,
+    ) == 2
+    assert stats["orphan_examined"] == 2
+    assert [row[0] for row in conn.execute(
+        "SELECT node_id FROM vec_embeddings ORDER BY node_id"
+    )] == ["n1", "n2"]
     conn.close()
 
 

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -214,7 +214,8 @@ def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
     conn = _orphan_db(tmp_path)
     anchor = np.ones(4, dtype=np.float32).tobytes()
     conn.execute(
-        "INSERT INTO embeddings VALUES ('anchor', ?, 'm', datetime('now'))", (anchor,)
+        "INSERT INTO embeddings VALUES ('anchor', ?, 'all-MiniLM-L6-v2', datetime('now'))",
+        (anchor,),
     )
     conn.execute(
         "INSERT INTO thought_nodes (id, content, decayed) VALUES ('anchor','anchor',0)"

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -235,7 +235,6 @@ def test_orphan_vec_failure_rolls_back_ordinary_row(tmp_path):
     )
     assert conn.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 0
     assert stats["orphan_write_failed"] == 1
-    assert stats.get("orphan_ordinary_written", 0) == 0
     conn.close()
 
 
@@ -400,7 +399,9 @@ def test_early_orphan_commit_survives_candidate_discovery_failure(tmp_path, monk
     assert result["status"] == "partial"
     assert result["error"] == "sleep_cycle_failed"
     assert result["orphans_embedded"] == 2
-    assert result["orphan_ordinary_written"] == 2
+    check = sqlite3.connect(str(tmp_path / "orphans.db"))
+    assert check.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 2
+    check.close()
 
 
 def test_late_orphan_failure_retains_committed_dream_fields(tmp_path, monkeypatch):
@@ -618,7 +619,6 @@ def test_public_cycle_reports_ordinary_only_orphan_write(tmp_path):
     )
     assert result["status"] == "partial"
     assert result["error"] == "vec_capability_unavailable"
-    assert result["orphan_ordinary_written"] == 1
     assert result["orphan_vec_unavailable"] == 1
     check = sqlite3.connect(str(tmp_path / "orphans.db"))
     assert check.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 1

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -10,16 +10,56 @@ import numpy as np
 import pytest
 
 from core.decay_audit import ensure_decay_audit_schema
+import core.sleep as sleep_module
 from core.sleep import _batch_cross_links, _embed_orphans, run_sleep_cycle
 
 
-def _edge_db(tmp_path: Path) -> sqlite3.Connection:
-    conn = sqlite3.connect(str(tmp_path / "edges.db"))
+class _CountingConnection(sqlite3.Connection):
+    commit_count = 0
+
+    def commit(self):
+        self.commit_count += 1
+        return super().commit()
+
+
+def _edge_db(tmp_path: Path, name: str = "edges.db", factory=None) -> sqlite3.Connection:
+    kwargs = {"factory": factory} if factory is not None else {}
+    conn = sqlite3.connect(str(tmp_path / name), **kwargs)
     conn.executescript("""
         CREATE TABLE derivation_edges(parent_id TEXT, child_id TEXT,
             weight REAL, reasoning TEXT, PRIMARY KEY(parent_id, child_id));
     """)
     return conn
+
+
+def _cycle_db(tmp_path: Path, name: str = "cycle.db") -> Path:
+    path = tmp_path / name
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE thought_nodes(
+            id TEXT PRIMARY KEY, content TEXT, decayed INTEGER DEFAULT 0,
+            timestamp TEXT DEFAULT '', source_file TEXT, access_count INTEGER DEFAULT 0,
+            permanent INTEGER DEFAULT 0, last_accessed TEXT, domain TEXT, node_type TEXT,
+            confidence REAL, metadata TEXT
+        );
+        CREATE TABLE embeddings(
+            node_id TEXT PRIMARY KEY, vector BLOB, model TEXT, updated_at TEXT
+        );
+        CREATE TABLE derivation_edges(
+            parent_id TEXT, child_id TEXT, weight REAL, reasoning TEXT,
+            PRIMARY KEY(parent_id, child_id)
+        );
+    """)
+    vector = np.ones(1024, dtype=np.float32).tobytes()
+    for nid in ("a", "b"):
+        conn.execute("INSERT INTO thought_nodes(id, content) VALUES (?, ?)", (nid, nid))
+        conn.execute(
+            "INSERT INTO embeddings(node_id, vector, model) VALUES (?, ?, ?)",
+            (nid, vector, "thenlper/gte-large"),
+        )
+    conn.commit()
+    conn.close()
+    return path
 
 
 def test_cross_link_cap_flushes_two_directed_rows(tmp_path):
@@ -63,6 +103,20 @@ def test_cross_link_trigger_suppression_is_not_claimed(tmp_path):
     conn.close()
 
 
+@pytest.mark.parametrize("pair_count", [500, 501])
+def test_cross_link_cap_batches_at_five_hundred_pairs(tmp_path, pair_count):
+    ids = [f"n{i}" for i in range(pair_count * 2)]
+    pairs = np.asarray([[2 * i, 2 * i + 1] for i in range(pair_count)])
+    sim = np.eye(len(ids), dtype=np.float32)
+    conn = _edge_db(tmp_path, name=f"edges-{pair_count}.db", factory=_CountingConnection)
+    stats = _batch_cross_links(conn, ids, pairs, sim, max_edges=pair_count)
+    assert stats["created"] == pair_count
+    assert stats["directed_rows"] == pair_count * 2
+    assert conn.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == pair_count * 2
+    assert conn.commit_count <= 2
+    conn.close()
+
+
 def test_run_sleep_cycle_preserves_six_positional_arguments():
     signature = inspect.signature(run_sleep_cycle)
     signature.bind("/tmp/example.db", None, None, False, 1, True)
@@ -76,6 +130,21 @@ def test_partial_embedding_triad_is_rejected_before_database_open(monkeypatch):
     result = run_sleep_cycle(db_path="/tmp/does-not-exist.db", embedding_model="m")
     assert result["status"] == "rejected"
     assert result["error"] == "invalid_embedding_contract"
+
+
+def test_embedding_profile_dimension_is_rejected_before_database_open(monkeypatch):
+    def fail_connect(*_args, **_kwargs):
+        raise AssertionError("database must not open for profile mismatch")
+
+    monkeypatch.setattr(sqlite3, "connect", fail_connect)
+    result = run_sleep_cycle(
+        db_path="/tmp/does-not-exist.db",
+        embedding_client=_Client(lambda n: np.ones((n, 4), dtype=np.float32)),
+        embedding_model="all-MiniLM-L6-v2",
+        expected_dimension=4,
+    )
+    assert result["status"] == "rejected"
+    assert result["error"] == "embedding_dimension_mismatch"
 
 
 class _Client:
@@ -161,8 +230,12 @@ def test_orphan_repair_works_without_two_anchors(tmp_path):
         "INSERT INTO embeddings VALUES ('n1', ?, 'm', datetime('now'))", (vec,)
     )
     conn.commit()
-    assert _embed_orphans(conn, expected_dimension=4) == 1
-    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 1
+    # Repair is deliberately skipped without the explicit client/model/dim
+    # triad; sleep must not borrow a configured model by accident.
+    stats = {}
+    assert _embed_orphans(conn, expected_dimension=4, stats=stats) == 0
+    assert stats["capability_missing"] is True
+    assert conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()[0] == 0
     conn.close()
 
 
@@ -184,6 +257,21 @@ def test_orphan_without_vec_is_explicit_ordinary_only(tmp_path):
     conn.close()
 
 
+def test_malformed_existing_embedding_is_contained(tmp_path):
+    conn = _orphan_db(tmp_path)
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('n1', ?, 'm', datetime('now'))", (b"bad",)
+    )
+    conn.commit()
+    stats = {}
+    assert _embed_orphans(
+        conn, embedding_client=_Client(lambda n: np.ones((n, 4), dtype=np.float32)),
+        embedding_model="m", expected_dimension=4, stats=stats,
+    ) == 0
+    assert stats["orphan_write_failed"] == 1
+    conn.close()
+
+
 def test_real_sqlite_vec0_dual_write_when_extension_is_available(tmp_path):
     pytest.importorskip("sqlite_vec")
     from core.embeddings import _load_vec
@@ -196,6 +284,8 @@ def test_real_sqlite_vec0_dual_write_when_extension_is_available(tmp_path):
         "node_id text primary key, embedding float[4] distance_metric=cosine)"
     )
     conn.commit()
+    conn.close()
+    conn = sqlite3.connect(str(tmp_path / "orphans.db"))
     client = _Client(lambda n: np.ones((n, 4), dtype=np.float32))
     assert (
         _embed_orphans(
@@ -210,9 +300,61 @@ def test_real_sqlite_vec0_dual_write_when_extension_is_available(tmp_path):
     conn.close()
 
 
+def test_public_cycle_reports_committed_prefix_when_later_phase_fails(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path)
+    monkeypatch.setattr(
+        sleep_module, "_find_pairs",
+        lambda *_args, **_kwargs: (
+            np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), np.eye(2)
+        ),
+    )
+    monkeypatch.setattr(sleep_module, "_compute_metrics", lambda *_args: (_ for _ in ()).throw(RuntimeError("later")))
+    result = run_sleep_cycle(db_path=str(path), journal_policy="preserve")
+    assert result["status"] == "partial"
+    assert result["cross_links_created"] == 1
+    check = sqlite3.connect(str(path))
+    assert check.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 2
+    check.close()
+
+
+def test_public_cycle_exposes_cross_link_failure(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path)
+    monkeypatch.setattr(
+        sleep_module, "_find_pairs",
+        lambda *_args, **_kwargs: (
+            np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), np.eye(2)
+        ),
+    )
+    monkeypatch.setattr(
+        sleep_module, "_batch_cross_links",
+        lambda *_args, **_kwargs: {"created": 0, "repaired": 0, "skipped": 0,
+                                   "failed": 1, "directed_rows": 0},
+    )
+    result = run_sleep_cycle(db_path=str(path), journal_policy="preserve")
+    assert result["status"] in {"failed", "partial"}
+    assert result["error"] == "cross_link_failed"
+
+
+def test_synchronous_dream_reports_ran(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "dream.db")
+    monkeypatch.setattr(
+        sleep_module, "_find_pairs",
+        lambda *_args, **_kwargs: (
+            np.asarray([[0, 1]]), np.empty((0, 2), dtype=int), np.eye(2)
+        ),
+    )
+    monkeypatch.setattr(sleep_module, "_generate_dream", lambda *_args, **_kwargs: "dream-id")
+    result = run_sleep_cycle(
+        db_path=str(path), model_fn=lambda _prompt: "unused", journal_policy="preserve"
+    )
+    assert result["dream_generation"] == "ran"
+    assert result["status"] != "failed"
+
+
 def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
     conn = _orphan_db(tmp_path)
-    anchor = np.ones(4, dtype=np.float32).tobytes()
+    dimension = 384
+    anchor = np.ones(dimension, dtype=np.float32).tobytes()
     conn.execute(
         "INSERT INTO embeddings VALUES "
         "('anchor', ?, 'all-MiniLM-L6-v2', datetime('now'))",
@@ -222,12 +364,12 @@ def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
         "INSERT INTO thought_nodes (id, content, decayed) VALUES ('anchor','anchor',0)"
     )
     conn.commit()
-    client = _Client(lambda n: np.ones((n, 4), dtype=np.float32))
+    client = _Client(lambda n: np.ones((n, dimension), dtype=np.float32))
     result = run_sleep_cycle(
         db_path=str(tmp_path / "orphans.db"),
         embedding_client=client,
         embedding_model="all-MiniLM-L6-v2",
-        expected_dimension=4,
+        expected_dimension=dimension,
         journal_policy="preserve",
     )
     assert client.calls == [["orphan"]]
@@ -250,6 +392,18 @@ def test_decay_audit_schema_is_idempotent_and_preserves_graph(tmp_path):
     assert conn.execute(
         "SELECT name FROM sqlite_master WHERE name='decay_audit'"
     ).fetchone()
+    conn.close()
+
+
+def test_decay_audit_partial_schema_migrates_and_keeps_history(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "partial-audit.db"))
+    conn.execute("CREATE TABLE decay_audit(node_id TEXT, decay_reason TEXT)")
+    conn.execute("INSERT INTO decay_audit VALUES ('old', 'dedup_loser')")
+    conn.commit()
+    ensure_decay_audit_schema(conn)
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(decay_audit)")}
+    assert {"id", "content_summary", "decay_timestamp", "metadata"} <= columns
+    assert conn.execute("SELECT node_id FROM decay_audit").fetchone()[0] == "old"
     conn.close()
 
 

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -235,6 +235,7 @@ def test_orphan_vec_failure_rolls_back_ordinary_row(tmp_path):
     )
     assert conn.execute("SELECT count(*) FROM embeddings").fetchone()[0] == 0
     assert stats["orphan_write_failed"] == 1
+    assert stats.get("orphan_ordinary_written", 0) == 0
     conn.close()
 
 
@@ -373,6 +374,62 @@ def test_public_cycle_reports_committed_prefix_when_later_phase_fails(tmp_path, 
     check = sqlite3.connect(str(path))
     assert check.execute("SELECT count(*) FROM derivation_edges").fetchone()[0] == 2
     check.close()
+
+
+def test_early_orphan_commit_survives_candidate_discovery_failure(tmp_path, monkeypatch):
+    conn = _orphan_db(tmp_path)
+    vector = np.ones(384, dtype=np.float32).tobytes()
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('anchor', ?, 'all-MiniLM-L6-v2', datetime('now'))",
+        (vector,),
+    )
+    conn.execute("INSERT INTO thought_nodes(id, content) VALUES ('anchor', 'anchor')")
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(
+        sleep_module, "_find_pairs",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("discovery")),
+    )
+    result = run_sleep_cycle(
+        db_path=str(tmp_path / "orphans.db"),
+        embedding_client=_Client(lambda n: np.ones((n, 384), dtype=np.float32)),
+        embedding_model="all-MiniLM-L6-v2",
+        expected_dimension=384,
+        journal_policy="preserve",
+    )
+    assert result["status"] == "partial"
+    assert result["error"] == "sleep_cycle_failed"
+    assert result["orphans_embedded"] == 2
+    assert result["orphan_ordinary_written"] == 2
+
+
+def test_late_orphan_failure_retains_committed_dream_fields(tmp_path, monkeypatch):
+    path = _cycle_db(tmp_path, "dream-orphan-failure.db")
+    conn = sqlite3.connect(str(path))
+    v1 = np.zeros(1024, dtype=np.float32)
+    v1[0] = 1.0
+    v2 = np.zeros(1024, dtype=np.float32)
+    v2[0] = 0.92
+    v2[1] = np.sqrt(1.0 - 0.92 ** 2)
+    conn.execute("UPDATE thought_nodes SET source_file='one.md' WHERE id='a'")
+    conn.execute("UPDATE thought_nodes SET source_file='two.md' WHERE id='b'")
+    conn.execute("INSERT INTO thought_nodes(id, content) VALUES ('orphan', 'late orphan')")
+    conn.execute("UPDATE embeddings SET vector=? WHERE node_id='a'", (v1.tobytes(),))
+    conn.execute("UPDATE embeddings SET vector=? WHERE node_id='b'", (v2.tobytes(),))
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(
+        sleep_module, "_embed_orphans",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("orphan")),
+    )
+    result = run_sleep_cycle(
+        db_path=str(path),
+        model_fn=lambda _prompt: "A durable relationship connects these observations.",
+        journal_policy="preserve",
+    )
+    assert result["status"] == "partial"
+    assert result["dream_generation"] == "ran"
+    assert result["dream_id"]
 
 
 def _force_late_dream_failure(monkeypatch):
@@ -559,6 +616,8 @@ def test_public_cycle_reports_ordinary_only_orphan_write(tmp_path):
         expected_dimension=384,
         journal_policy="preserve",
     )
+    assert result["status"] == "partial"
+    assert result["error"] == "vec_capability_unavailable"
     assert result["orphan_ordinary_written"] == 1
     assert result["orphan_vec_unavailable"] == 1
     check = sqlite3.connect(str(tmp_path / "orphans.db"))

--- a/tests/test_sleep_contract_193.py
+++ b/tests/test_sleep_contract_193.py
@@ -185,7 +185,7 @@ def test_orphan_without_vec_is_explicit_ordinary_only(tmp_path):
 
 
 def test_real_sqlite_vec0_dual_write_when_extension_is_available(tmp_path):
-    sqlite_vec = pytest.importorskip("sqlite_vec")
+    pytest.importorskip("sqlite_vec")
     from core.embeddings import _load_vec
 
     conn = _orphan_db(tmp_path)
@@ -214,7 +214,8 @@ def test_public_cycle_repairs_orphan_before_anchor_requirement(tmp_path):
     conn = _orphan_db(tmp_path)
     anchor = np.ones(4, dtype=np.float32).tobytes()
     conn.execute(
-        "INSERT INTO embeddings VALUES ('anchor', ?, 'all-MiniLM-L6-v2', datetime('now'))",
+        "INSERT INTO embeddings VALUES "
+        "('anchor', ?, 'all-MiniLM-L6-v2', datetime('now'))",
         (anchor,),
     )
     conn.execute(

--- a/tests/test_sleep_refactor.py
+++ b/tests/test_sleep_refactor.py
@@ -216,7 +216,8 @@ def test_run_sleep_cycle_no_embeddings_table():
 
         result = run_sleep_cycle(db_path=path)
         assert "error" in result
-        assert "no embeddings table" in result["error"]
+        assert result["status"] == "unavailable"
+        assert result["error"] == "no_embeddings_table"
     finally:
         os.unlink(path)
 
@@ -658,7 +659,10 @@ def test_run_sleep_cycle_vectorized(db_with_embeddings):
             cross_source_only=True,
         )
 
-    assert "error" not in result
+    assert result["status"] == "completed"
+    assert result["error"] is None
+    assert result["dream_generation"] == "skipped"
+    assert result["cross_link_directed_rows"] >= result["cross_links_created"]
     assert result["nodes_selected"] > 0
     assert result["total_nodes"] > 0
     assert result["cross_link_candidates"] >= 0
@@ -693,11 +697,30 @@ def test_run_sleep_cycle_background_dream(db_with_embeddings):
             cross_source_only=False,
         )
 
-    assert "error" not in result
+    assert result["status"] == "completed"
+    assert result["error"] is None
     assert result["cross_link_candidates"] > 0, (
         "Need cross-link candidates for dream_pending, check similarity setup"
     )
     assert result["dream_pending"] is True
+    assert result["dream_generation"] == "pending"
+
+
+def test_run_sleep_cycle_reports_contained_dream_failure(db_with_embeddings, monkeypatch):
+    """An eligible synchronous dream that produces no node is failed, not skipped."""
+    monkeypatch.setattr("core.sleep._generate_dream", lambda *args, **kwargs: None)
+    with patch("core.sleep.config") as mock_cfg:
+        mock_cfg.gc_mode = "off"
+        mock_cfg.gc_threshold = 0.05
+        mock_cfg.gc_grace_days = 7
+        mock_cfg.gc_think_cycle_penalty = 1.5
+        result = run_sleep_cycle(
+            db_path=db_with_embeddings, limit=100,
+            model_fn=lambda _prompt: "unused", background_dream=False,
+        )
+    assert result["dream_generation"] == "failed"
+    assert result["status"] == "partial"
+    assert result["error"] == "dream_failed"
     assert result["dream_id"] is None  # not yet produced (async)
 
 


### PR DESCRIPTION
The public sleep pipeline could not safely support adapters coordinating their own SQLite lifecycle: bounded work could be reported before commit, orphan repair could exceed embedding batch limits or starve later rows, and dreams could persist relationships outside the edge cap. This change preserves the six positional arguments and adds keyword-only controls for embedding ownership, journal policy, and bounded orphan work, with atomic writes and explicit durable-progress results.

Existing callers retain managed-journal and automatic-model defaults. The configured LocalBackend loads its model lazily when orphan encoding needs it. An injected client is authoritative and never falls back to local encoding; adapters can set auto_embed=False to forbid automatic model loading when no client is supplied. Routine index repair preserves model identity; model rotation requires explicit re-embedding. The private cursor table and its recovery contract are documented in docs/sleep-protocol.md.

Validation after maintainer feedback: 574 tests passed locally on Python 3.10, including the actual CLI no-client path, injected-client failure isolation, opt-out, tiny-vector validation, and verified post-commit accounting. New targeted regressions fail against the previous head. Critical Ruff and diff checks passed, and an independent review found no blocking findings. The earlier head passed CI on Python 3.10/3.11/3.12; the revised head is awaiting its own CI results. Hermes-Cashew can consume the tested immutable revision without waiting for a release or canonical merge; updating its existing composite pin is separate work.
