### PR TITLE
feat(integrity): add connection-owned repair API

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ retriever = ContextRetriever("path/to/graph.db", embeddings)
 context = retriever.generate_context(hints=["work", "projects"])
 ```
 
+For adapters that coordinate SQLite themselves, `core.integrity` provides a
+connection-owned read-only audit and bounded targeted repair API. The caller
+owns the backup, maintenance lock, journal policy, transaction, and final
+verification; see [`docs/integrity-repair.md`](docs/integrity-repair.md).
+
 ## Architecture
 
 - **Single SQLite file.** No external servers, no separate indexes. Your entire brain is one portable file.

--- a/core/integrity.py
+++ b/core/integrity.py
@@ -169,6 +169,7 @@ def _base_report(
         "transaction_owner": "caller",
         "committed": False,
         "mutated": False,
+        "mutation_uncertain": False,
         "expected_model": expected_model,
         "expected_dimension": expected_dimension,
         "vec": {
@@ -573,6 +574,8 @@ def repair_integrity(
                 _rollback_savepoint(conn, name)
             except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError):
                 _record(failures, "savepoint_rollback_failed")
+                report["mutated"] = True
+                report["mutation_uncertain"] = True
             _record(failures, type(exc).__name__)
             return False
         try:
@@ -584,6 +587,8 @@ def repair_integrity(
                 _rollback_savepoint(conn, name)
             except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError):
                 _record(failures, "savepoint_rollback_failed")
+                report["mutated"] = True
+                report["mutation_uncertain"] = True
             return False
         report["mutated"] = True
         return True
@@ -657,14 +662,14 @@ def repair_integrity(
 
     if vec_operational and "repair_vec" in selected:
         rows = conn.execute(
-            "SELECT v.node_id, v.embedding, e.vector, n.decayed "
+            "SELECT v.node_id, v.embedding, e.vector, e.model, n.decayed "
             "FROM vec_embeddings v "
             "LEFT JOIN embeddings e ON e.node_id=v.node_id "
             "LEFT JOIN thought_nodes n ON n.id=v.node_id "
             "ORDER BY v.node_id LIMIT ?",
             (min(batch_size, max_items),),
         ).fetchall()
-        for node_id, vector, ordinary, decayed in rows:
+        for node_id, vector, ordinary, ordinary_model, decayed in rows:
             if not item_budget():
                 break
             vector_reason = _decode_vector(vector, vec_dimension)
@@ -674,6 +679,7 @@ def repair_integrity(
                 else "embedding_missing"
             )
             stale = node_id is None or ordinary is None or decayed not in (None, 0)
+            model_compatible = embedding_model is None or ordinary_model == embedding_model
             mismatched = (
                 not stale
                 and vector_reason is None
@@ -682,6 +688,9 @@ def repair_integrity(
             )
             invalid = vector_reason is not None or mismatched
             if not stale and not invalid:
+                continue
+            if invalid and not model_compatible:
+                _record(skipped, "embedding_model_mismatch")
                 continue
             replacement = (
                 ordinary

--- a/core/integrity.py
+++ b/core/integrity.py
@@ -1,0 +1,676 @@
+"""Connection-owned integrity inspection and targeted repair.
+
+Cashew stores ordinary embeddings, a derived sqlite-vec table, and graph
+relationships in one SQLite database.  This module exposes the small repair
+surface that downstream adapters need without taking ownership of the
+connection lifecycle.
+
+The caller owns the connection, outer transaction, journal policy, backup,
+and any process-level maintenance lock.  These functions never open or close
+connections, commit, roll back an outer transaction, or change journal mode.
+Each individual repair is protected by a savepoint so a failed repair cannot
+undo unrelated work in the caller's transaction.
+
+Only information-preserving repairs are enabled by default.  The API never
+tries to reconstruct merged or decayed memories.  Permanence conflicts and
+self-edges are report-only unless an explicit policy/action is supplied.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import sqlite3
+import struct
+from collections.abc import Callable, Iterable, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+import numpy as np
+
+
+_REQUIRED_TABLES = {
+    "thought_nodes",
+    "embeddings",
+    "derivation_edges",
+}
+_VEC_DDL = re.compile(
+    r"^\s*CREATE\s+VIRTUAL\s+TABLE\s+"
+    r"(?:(?:IF\s+NOT\s+EXISTS)\s+)?"
+    r"(?:vec_embeddings|\"vec_embeddings\"|`vec_embeddings`|\[vec_embeddings\])\s+"
+    r"USING\s+vec0(?:\s|\()",
+    re.IGNORECASE,
+)
+_VEC_DIM = re.compile(r"(?:float|int8)\s*\[\s*(\d+)\s*\]", re.IGNORECASE)
+_DEFAULT_ACTIONS = frozenset(
+    {
+        "repair_vec",
+        "repair_embeddings",
+        "remove_orphan_embeddings",
+        "remove_orphan_edges",
+    }
+)
+_KNOWN_ACTIONS = _DEFAULT_ACTIONS | {
+    "remove_self_edges",
+    "promote_core_memories",
+}
+_SAVEPOINT_PREFIX = "cashew_integrity"
+
+
+EmbeddingFn = Callable[[Sequence[str]], Any]
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+
+
+def _vec_schema(conn: sqlite3.Connection) -> tuple[str, int | None, str | None]:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='vec_embeddings'"
+    ).fetchone()
+    if row is None:
+        return "missing", None, "vec_index_missing"
+    ddl = str(row[0] or "")
+    if not _VEC_DDL.match(ddl):
+        return "invalid", None, "vec_schema_invalid"
+    match = _VEC_DIM.search(ddl)
+    if match is None:
+        return "invalid", None, "vec_dimension_unavailable"
+    return "present", int(match.group(1)), None
+
+
+def _load_vec(conn: sqlite3.Connection) -> bool:
+    """Register sqlite-vec on this connection without changing the database."""
+    try:
+        import sqlite_vec
+
+        conn.enable_load_extension(True)
+        try:
+            sqlite_vec.load(conn)
+        finally:
+            conn.enable_load_extension(False)
+        conn.execute("SELECT count(*) FROM vec_embeddings").fetchone()
+        return True
+    except Exception:
+        try:
+            conn.enable_load_extension(False)
+        except sqlite3.Error:
+            pass
+        return False
+
+
+def _decode_vector(blob: object, expected_dimension: int | None) -> str | None:
+    if not isinstance(blob, (bytes, bytearray, memoryview)):
+        return "embedding_blob_invalid"
+    raw = bytes(blob)
+    if not raw or len(raw) % 4:
+        return "embedding_blob_invalid"
+    dimension = len(raw) // 4
+    if expected_dimension is not None and dimension != expected_dimension:
+        return "embedding_dimension_mismatch"
+    try:
+        values = struct.unpack(f"<{dimension}f", raw)
+    except (struct.error, ValueError):
+        return "embedding_blob_invalid"
+    if not all(math.isfinite(value) for value in values):
+        return "embedding_nonfinite"
+    if math.sqrt(sum(value * value for value in values)) <= 1e-12:
+        return "embedding_zero_norm"
+    return None
+
+
+def _normalise_vector(value: object, expected_dimension: int) -> bytes:
+    array = np.asarray(value, dtype=np.float32)
+    if array.shape != (expected_dimension,):
+        raise ValueError("embedding_dimension_mismatch")
+    if not np.all(np.isfinite(array)):
+        raise ValueError("embedding_nonfinite")
+    if float(np.linalg.norm(array)) <= 1e-12:
+        raise ValueError("embedding_zero_norm")
+    return array.tobytes()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _savepoint(conn: sqlite3.Connection, index: int) -> str:
+    name = f"{_SAVEPOINT_PREFIX}_{index}"
+    conn.execute(f"SAVEPOINT {name}")
+    return name
+
+
+def _rollback_savepoint(conn: sqlite3.Connection, name: str) -> None:
+    try:
+        conn.execute(f"ROLLBACK TO SAVEPOINT {name}")
+    finally:
+        conn.execute(f"RELEASE SAVEPOINT {name}")
+
+
+def _release_savepoint(conn: sqlite3.Connection, name: str) -> None:
+    conn.execute(f"RELEASE SAVEPOINT {name}")
+
+
+def _base_report(
+    *,
+    expected_model: str | None,
+    expected_dimension: int | None,
+    vec_status: str,
+    vec_dimension: int | None,
+    vec_reason: str | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "transaction_owner": "caller",
+        "committed": False,
+        "mutated": False,
+        "expected_model": expected_model,
+        "expected_dimension": expected_dimension,
+        "vec": {
+            "status": vec_status,
+            "dimension": vec_dimension,
+        },
+        "counts": {
+            "embeddings": 0,
+            "missing_embeddings": 0,
+            "invalid_embeddings": 0,
+            "orphan_embeddings": 0,
+            "missing_vec": 0,
+            "stale_vec": 0,
+            "orphan_edges": 0,
+            "self_edges": 0,
+            "permanent_and_decayed": 0,
+            "core_memory_not_permanent": 0,
+        },
+        "repairs": {
+            "embeddings_repaired": 0,
+            "vec_rows_inserted": 0,
+            "vec_rows_removed": 0,
+            "orphan_embeddings_removed": 0,
+            "orphan_edges_removed": 0,
+            "self_edges_removed": 0,
+            "core_memories_promoted": 0,
+            "permanence_conflicts_resolved": 0,
+        },
+        "skipped": {},
+        "failures": {},
+        "reasons": [vec_reason] if vec_reason else [],
+        "reasons_by_kind": {},
+        "limits": {
+            "max_items": None,
+            "items_considered": 0,
+            "bounded": True,
+        },
+        "permanence_policy": "report",
+    }
+
+
+def _record(mapping: dict[str, int], reason: str, amount: int = 1) -> None:
+    mapping[reason] = mapping.get(reason, 0) + amount
+
+
+def inspect_integrity(
+    conn: sqlite3.Connection,
+    *,
+    expected_model: str | None = None,
+    expected_dimension: int | None = None,
+) -> dict[str, Any]:
+    """Inspect a database through a supplied connection without mutation.
+
+    The connection remains open and no transaction is committed, rolled back,
+    or otherwise finalized.  The report contains counts only; callers that
+    need privacy-preserving identifiers can add their own redaction boundary.
+    """
+    if not isinstance(conn, sqlite3.Connection):
+        raise TypeError("conn must be a sqlite3.Connection")
+    if expected_dimension is not None and expected_dimension <= 0:
+        raise ValueError("expected_dimension must be positive")
+
+    tables = _tables(conn)
+    missing_tables = sorted(_REQUIRED_TABLES - tables)
+    if missing_tables:
+        return {
+            "schema_version": 1,
+            "status": "unavailable",
+            "mutated": False,
+            "transaction_owner": "caller",
+            "committed": False,
+            "missing_tables": missing_tables,
+            "reasons": ["schema_tables_missing"],
+        }
+
+    vec_status, vec_dimension, vec_reason = _vec_schema(conn)
+    report = _base_report(
+        expected_model=expected_model,
+        expected_dimension=expected_dimension,
+        vec_status=vec_status,
+        vec_dimension=vec_dimension,
+        vec_reason=vec_reason,
+    )
+    counts = report["counts"]
+    rows = conn.execute(
+        "SELECT node_id, vector, model FROM embeddings "
+        "ORDER BY node_id LIMIT 1001"
+    ).fetchall()
+    counts["embeddings"] = len(rows)
+    if len(rows) > 1000:
+        report["reasons"].append("audit_row_cap")
+        rows = rows[:1000]
+    active_nodes = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT id FROM thought_nodes "
+            "WHERE decayed IS NULL OR decayed = 0 LIMIT 1001"
+        ).fetchall()
+    }
+    embedding_ids = {str(row[0]) for row in rows if row[0] is not None}
+    for node_id, blob, model in rows:
+        reason = _decode_vector(blob, expected_dimension)
+        if reason is not None:
+            counts["invalid_embeddings"] += 1
+            _record(report["reasons_by_kind"], reason)
+        if expected_model is not None and model != expected_model:
+            counts["invalid_embeddings"] += 1
+            _record(report["reasons_by_kind"], "embedding_model_mismatch")
+    orphan_count = conn.execute(
+        "SELECT COUNT(*) FROM embeddings e "
+        "LEFT JOIN thought_nodes n ON n.id=e.node_id WHERE n.id IS NULL"
+    ).fetchone()[0]
+    counts["orphan_embeddings"] = int(orphan_count)
+    missing_count = conn.execute(
+        "SELECT COUNT(*) FROM thought_nodes n "
+        "LEFT JOIN embeddings e ON e.node_id=n.id "
+        "WHERE (n.decayed IS NULL OR n.decayed=0) AND e.node_id IS NULL"
+    ).fetchone()[0]
+    counts["missing_embeddings"] = int(missing_count)
+    if vec_status == "present" and _load_vec(conn):
+        vec_ids = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT node_id FROM vec_embeddings LIMIT 1001"
+            ).fetchall()
+            if row[0] is not None
+        }
+        active_embedding_ids = embedding_ids & set(active_nodes)
+        counts["missing_vec"] = len(active_embedding_ids - vec_ids)
+        counts["stale_vec"] = len(vec_ids - active_embedding_ids)
+    elif vec_status == "present":
+        report["reasons"].append("vec_index_unverifiable")
+    counts["orphan_edges"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM derivation_edges e "
+            "LEFT JOIN thought_nodes p ON p.id=e.parent_id "
+            "LEFT JOIN thought_nodes c ON c.id=e.child_id "
+            "WHERE p.id IS NULL OR c.id IS NULL"
+        ).fetchone()[0]
+    )
+    counts["self_edges"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM derivation_edges WHERE parent_id=child_id"
+        ).fetchone()[0]
+    )
+    counts["permanent_and_decayed"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM thought_nodes "
+            "WHERE COALESCE(permanent,0) != 0 AND COALESCE(decayed,0) != 0"
+        ).fetchone()[0]
+    )
+    counts["core_memory_not_permanent"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM thought_nodes "
+            "WHERE node_type='core_memory' AND COALESCE(permanent,0)=0"
+        ).fetchone()[0]
+    )
+    report["status"] = "findings" if any(counts.values()) else "ok"
+    report["uncertainty"] = ["historical_consolidation"]
+    return report
+
+
+def repair_integrity(
+    conn: sqlite3.Connection,
+    *,
+    embedding_fn: EmbeddingFn | None = None,
+    embedding_model: str | None = None,
+    expected_dimension: int | None = None,
+    require_vec_parity: bool = True,
+    actions: Iterable[str] | None = None,
+    permanence_policy: str = "report",
+    batch_size: int = 100,
+    max_items: int = 1000,
+) -> dict[str, Any]:
+    """Apply bounded, targeted repairs using only ``conn``.
+
+    ``conn`` remains open and the caller retains transaction ownership.  This
+    function never commits, rolls back an outer transaction, closes the
+    connection, or changes journal mode.  The caller should take a backup and
+    an exclusive maintenance lease before invoking it, then commit and run a
+    fresh integrity audit afterward.
+
+    ``embedding_fn`` must accept a sequence of node contents and return one
+    vector per input.  It is never constructed or selected by Cashew.  Without
+    it, invalid or missing embeddings are reported as skipped.
+
+    ``permanence_policy`` is report-only by default.  ``preserve_permanent``
+    clears ``decayed`` for permanent nodes; ``preserve_decay`` clears
+    ``permanent``.  The choice is intentionally explicit because the original
+    intended state cannot be reconstructed from contradictory flags.
+    """
+    if not isinstance(conn, sqlite3.Connection):
+        raise TypeError("conn must be a sqlite3.Connection")
+    if expected_dimension is not None and expected_dimension <= 0:
+        return {"status": "rejected", "reason": "invalid_embedding_dimension"}
+    if batch_size <= 0 or max_items <= 0:
+        return {"status": "rejected", "reason": "invalid_repair_bounds"}
+    if permanence_policy not in {"report", "preserve_permanent", "preserve_decay"}:
+        return {"status": "rejected", "reason": "invalid_permanence_policy"}
+    selected = set(_DEFAULT_ACTIONS if actions is None else actions)
+    unknown = sorted(selected - _KNOWN_ACTIONS)
+    if unknown:
+        return {
+            "status": "rejected",
+            "reason": "unknown_repair_action",
+            "actions": unknown,
+        }
+    tables = _tables(conn)
+    if not _REQUIRED_TABLES.issubset(tables):
+        return {
+            "status": "unavailable",
+            "reason": "schema_tables_missing",
+            "missing_tables": sorted(_REQUIRED_TABLES - tables),
+        }
+
+    vec_status, vec_dimension, vec_reason = _vec_schema(conn)
+    report = _base_report(
+        expected_model=embedding_model,
+        expected_dimension=expected_dimension,
+        vec_status=vec_status,
+        vec_dimension=vec_dimension,
+        vec_reason=vec_reason,
+    )
+    report["limits"].update({"max_items": max_items, "batch_size": batch_size})
+    report["permanence_policy"] = permanence_policy
+    counts = report["counts"]
+    repairs = report["repairs"]
+    skipped = report["skipped"]
+    failures = report["failures"]
+    counts["orphan_embeddings"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM embeddings e "
+            "LEFT JOIN thought_nodes n ON n.id=e.node_id WHERE n.id IS NULL"
+        ).fetchone()[0]
+    )
+    counts["missing_embeddings"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM thought_nodes n "
+            "LEFT JOIN embeddings e ON e.node_id=n.id "
+            "WHERE (n.decayed IS NULL OR n.decayed=0) AND e.node_id IS NULL"
+        ).fetchone()[0]
+    )
+    counts["orphan_edges"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM derivation_edges e "
+            "LEFT JOIN thought_nodes p ON p.id=e.parent_id "
+            "LEFT JOIN thought_nodes c ON c.id=e.child_id "
+            "WHERE p.id IS NULL OR c.id IS NULL"
+        ).fetchone()[0]
+    )
+    counts["self_edges"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM derivation_edges WHERE parent_id=child_id"
+        ).fetchone()[0]
+    )
+    counts["permanent_and_decayed"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM thought_nodes "
+            "WHERE COALESCE(permanent,0)!=0 AND COALESCE(decayed,0)!=0"
+        ).fetchone()[0]
+    )
+    counts["core_memory_not_permanent"] = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM thought_nodes "
+            "WHERE node_type='core_memory' AND COALESCE(permanent,0)=0"
+        ).fetchone()[0]
+    )
+    vec_needed = bool(selected & {"repair_vec", "repair_embeddings"})
+    vec_ready = (
+        vec_status == "present"
+        and _load_vec(conn)
+        and (expected_dimension is None or vec_dimension == expected_dimension)
+    )
+    if vec_needed and require_vec_parity and not vec_ready:
+        report["reasons"].append(vec_reason or "vec_index_unverifiable")
+        skipped["vec_repairs"] = max_items
+
+    def item_budget() -> bool:
+        report["limits"]["items_considered"] += 1
+        return report["limits"]["items_considered"] <= max_items
+
+    def run_item(callback: Callable[[], None]) -> bool:
+        index = report["limits"]["items_considered"]
+        name = _savepoint(conn, index)
+        try:
+            callback()
+        except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError) as exc:
+            try:
+                _rollback_savepoint(conn, name)
+            except sqlite3.Error:
+                _record(failures, "savepoint_rollback_failed")
+            _record(failures, type(exc).__name__)
+            return False
+        _release_savepoint(conn, name)
+        report["mutated"] = True
+        return True
+
+    # Remove embedding rows for deleted nodes first.  This is deterministic
+    # and needs no model.  The vec counterpart is removed in the same savepoint.
+    if "remove_orphan_embeddings" in selected:
+        orphan_rows = conn.execute(
+            "SELECT e.node_id FROM embeddings e "
+            "LEFT JOIN thought_nodes n ON n.id=e.node_id "
+            "WHERE n.id IS NULL ORDER BY e.node_id LIMIT ?",
+            (min(batch_size, max_items),),
+        ).fetchall()
+        counts["orphan_embeddings"] = len(orphan_rows)
+        for (node_id,) in orphan_rows:
+            if not item_budget():
+                break
+
+            def remove_orphan(node_id=node_id) -> None:
+                conn.execute("DELETE FROM embeddings WHERE node_id=?", (node_id,))
+                if vec_ready:
+                    conn.execute("DELETE FROM vec_embeddings WHERE node_id=?", (node_id,))
+
+            if run_item(remove_orphan):
+                repairs["orphan_embeddings_removed"] += 1
+
+    # Delete edges with missing endpoints.  Self-edges stay report-only unless
+    # the explicit action is selected.
+    if "remove_orphan_edges" in selected:
+        edge_rows = conn.execute(
+            "SELECT e.parent_id, e.child_id FROM derivation_edges e "
+            "LEFT JOIN thought_nodes p ON p.id=e.parent_id "
+            "LEFT JOIN thought_nodes c ON c.id=e.child_id "
+            "WHERE p.id IS NULL OR c.id IS NULL "
+            "ORDER BY e.parent_id, e.child_id LIMIT ?",
+            (min(batch_size, max_items),),
+        ).fetchall()
+        counts["orphan_edges"] = len(edge_rows)
+        for parent_id, child_id in edge_rows:
+            if not item_budget():
+                break
+
+            def remove_edge(parent_id=parent_id, child_id=child_id) -> None:
+                conn.execute(
+                    "DELETE FROM derivation_edges WHERE parent_id=? AND child_id=?",
+                    (parent_id, child_id),
+                )
+
+            if run_item(remove_edge):
+                repairs["orphan_edges_removed"] += 1
+
+    if "remove_self_edges" in selected:
+        self_rows = conn.execute(
+            "SELECT parent_id FROM derivation_edges WHERE parent_id=child_id LIMIT ?",
+            (min(batch_size, max_items),),
+        ).fetchall()
+        counts["self_edges"] = len(self_rows)
+        for (node_id,) in self_rows:
+            if not item_budget():
+                break
+
+            def remove_self(node_id=node_id) -> None:
+                conn.execute(
+                    "DELETE FROM derivation_edges WHERE parent_id=? AND child_id=?",
+                    (node_id, node_id),
+                )
+
+            if run_item(remove_self):
+                repairs["self_edges_removed"] += 1
+
+    if vec_ready and "repair_vec" in selected:
+        rows = conn.execute(
+            "SELECT v.node_id FROM vec_embeddings v "
+            "LEFT JOIN thought_nodes n ON n.id=v.node_id "
+            "LEFT JOIN embeddings e ON e.node_id=v.node_id "
+            "WHERE n.id IS NULL OR e.node_id IS NULL "
+            "OR n.decayed != 0 LIMIT ?",
+            (min(batch_size, max_items),),
+        ).fetchall()
+        for (node_id,) in rows:
+            if not item_budget():
+                break
+
+            def remove_vec(node_id=node_id) -> None:
+                conn.execute("DELETE FROM vec_embeddings WHERE node_id=?", (node_id,))
+
+            if run_item(remove_vec):
+                repairs["vec_rows_removed"] += 1
+        valid_rows = conn.execute(
+            "SELECT e.node_id, e.vector, e.model FROM embeddings e "
+            "JOIN thought_nodes n ON n.id=e.node_id "
+            "LEFT JOIN vec_embeddings v ON v.node_id=e.node_id "
+            "WHERE (n.decayed IS NULL OR n.decayed=0) AND v.node_id IS NULL "
+            "ORDER BY e.node_id LIMIT ?",
+            (min(batch_size, max_items),),
+        ).fetchall()
+        for node_id, blob, model in valid_rows:
+            if not item_budget():
+                break
+            reason = _decode_vector(blob, expected_dimension)
+            if reason is not None or (
+                embedding_model is not None and model != embedding_model
+            ):
+                _record(skipped, reason or "embedding_model_mismatch")
+                continue
+
+            def insert_vec(node_id=node_id, blob=blob) -> None:
+                conn.execute(
+                    "INSERT INTO vec_embeddings(node_id, embedding) VALUES (?, ?)",
+                    (node_id, blob),
+                )
+
+            if run_item(insert_vec):
+                repairs["vec_rows_inserted"] += 1
+
+    # Re-embed only rows that can be reconstructed from current node content.
+    if "repair_embeddings" in selected:
+        if embedding_fn is None:
+            skipped["embedding_client_unavailable"] = 1
+        elif expected_dimension is None or not embedding_model:
+            skipped["embedding_identity_unavailable"] = 1
+        elif require_vec_parity and not vec_ready:
+            skipped["vec_parity_unavailable"] = 1
+        else:
+            candidates = conn.execute(
+                "SELECT n.id, n.content, e.vector, e.model "
+                "FROM thought_nodes n LEFT JOIN embeddings e ON e.node_id=n.id "
+                "WHERE (n.decayed IS NULL OR n.decayed=0) "
+                "AND n.content IS NOT NULL AND TRIM(n.content) != '' "
+                "ORDER BY n.id LIMIT ?",
+                (min(batch_size, max_items),),
+            ).fetchall()
+            for node_id, content, _old_blob, _old_model in candidates:
+                if not item_budget():
+                    break
+                old_reason = _decode_vector(_old_blob, expected_dimension)
+                if _old_blob is not None and old_reason is None and _old_model == embedding_model:
+                    continue
+                try:
+                    encoded = embedding_fn([str(content)])
+                    blob = _normalise_vector(encoded[0], expected_dimension)
+                except (IndexError, TypeError, ValueError, RuntimeError, OSError) as exc:
+                    _record(skipped, str(exc) or type(exc).__name__)
+                    continue
+
+                def replace_embedding(node_id=node_id, content=content, blob=blob) -> None:
+                    current = conn.execute(
+                        "SELECT content FROM thought_nodes WHERE id=?", (node_id,)
+                    ).fetchone()
+                    if current is None or current[0] != content:
+                        raise RuntimeError("node_content_changed")
+                    now = _now()
+                    conn.execute(
+                        "INSERT OR REPLACE INTO embeddings "
+                        "(node_id, vector, model, updated_at) VALUES (?, ?, ?, ?)",
+                        (node_id, blob, embedding_model, now),
+                    )
+                    if vec_ready:
+                        conn.execute("DELETE FROM vec_embeddings WHERE node_id=?", (node_id,))
+                        conn.execute(
+                            "INSERT INTO vec_embeddings(node_id, embedding) VALUES (?, ?)",
+                            (node_id, blob),
+                        )
+
+                if run_item(replace_embedding):
+                    repairs["embeddings_repaired"] += 1
+
+    # These are intentionally explicit and never part of the default action
+    # set.  The source data cannot tell us which side of the contradiction was
+    # originally intended.
+    if permanence_policy != "report":
+        conflict_rows = conn.execute(
+            "SELECT id FROM thought_nodes "
+            "WHERE COALESCE(permanent,0)!=0 AND COALESCE(decayed,0)!=0 "
+            "ORDER BY id LIMIT ?",
+            (min(batch_size, max_items),),
+        ).fetchall()
+        for (node_id,) in conflict_rows:
+            if not item_budget():
+                break
+
+            def resolve_conflict(node_id=node_id) -> None:
+                column = "decayed" if permanence_policy == "preserve_permanent" else "permanent"
+                conn.execute(f"UPDATE thought_nodes SET {column}=0 WHERE id=?", (node_id,))
+
+            if run_item(resolve_conflict):
+                repairs["permanence_conflicts_resolved"] += 1
+    if "promote_core_memories" in selected:
+        core_rows = conn.execute(
+            "SELECT id FROM thought_nodes "
+            "WHERE node_type='core_memory' AND COALESCE(permanent,0)=0 "
+            "ORDER BY id LIMIT ?",
+            (min(batch_size, max_items),),
+        ).fetchall()
+        for (node_id,) in core_rows:
+            if not item_budget():
+                break
+
+            def promote_core(node_id=node_id) -> None:
+                conn.execute(
+                    "UPDATE thought_nodes SET permanent=1 WHERE id=?", (node_id,)
+                )
+
+            if run_item(promote_core):
+                repairs["core_memories_promoted"] += 1
+
+    report["status"] = "partial" if skipped or failures else "completed"
+    report["uncertainty"] = ["historical_consolidation", "commit_owned_by_caller"]
+    return report
+
+
+__all__ = ["inspect_integrity", "repair_integrity"]

--- a/core/integrity.py
+++ b/core/integrity.py
@@ -182,6 +182,8 @@ def _base_report(
             "orphan_embeddings": 0,
             "missing_vec": 0,
             "stale_vec": 0,
+            "invalid_vec": 0,
+            "vec_mismatched": 0,
             "orphan_edges": 0,
             "self_edges": 0,
             "permanent_and_decayed": 0,
@@ -212,6 +214,59 @@ def _base_report(
 
 def _record(mapping: dict[str, int], reason: str, amount: int = 1) -> None:
     mapping[reason] = mapping.get(reason, 0) + amount
+
+
+def _vectors_match(left: object, right: object, dimension: int) -> bool:
+    try:
+        left_values = np.frombuffer(bytes(left), dtype="<f4")
+        right_values = np.frombuffer(bytes(right), dtype="<f4")
+    except (TypeError, ValueError):
+        return False
+    if left_values.shape != (dimension,) or right_values.shape != (dimension,):
+        return False
+    return bool(np.array_equal(left_values, right_values))
+
+
+def _vec_issues(
+    conn: sqlite3.Connection,
+    *,
+    vec_dimension: int,
+    expected_dimension: int | None,
+) -> tuple[set[str], dict[str, int]]:
+    """Return vec node ids and per-row integrity findings.
+
+    The query is deliberately capped.  A caller that needs a complete audit
+    can repeat it with a profile-specific maintenance policy; repairs use the
+    same cap through ``batch_size``.
+    """
+    vec_ids: set[str] = set()
+    issues: dict[str, int] = {}
+    rows = conn.execute(
+        "SELECT v.node_id, v.embedding, e.vector, n.decayed "
+        "FROM vec_embeddings v "
+        "LEFT JOIN embeddings e ON e.node_id=v.node_id "
+        "LEFT JOIN thought_nodes n ON n.id=v.node_id "
+        "ORDER BY v.node_id LIMIT 1001"
+    ).fetchall()
+    for node_id, vector, ordinary, decayed in rows:
+        if node_id is not None:
+            node_id = str(node_id)
+            vec_ids.add(node_id)
+        if node_id is None or ordinary is None:
+            _record(issues, "vec_orphan")
+            continue
+        if decayed not in (None, 0):
+            _record(issues, "vec_stale_decayed")
+        reason = _decode_vector(vector, vec_dimension)
+        if reason is not None:
+            _record(issues, f"vec_{reason}")
+            continue
+        compare_dimension = expected_dimension or vec_dimension
+        if _decode_vector(ordinary, compare_dimension) is None and not _vectors_match(
+            vector, ordinary, vec_dimension
+        ):
+            _record(issues, "vec_value_mismatch")
+    return vec_ids, issues
 
 
 def inspect_integrity(
@@ -289,16 +344,26 @@ def inspect_integrity(
     ).fetchone()[0]
     counts["missing_embeddings"] = int(missing_count)
     if vec_status == "present" and _load_vec(conn):
-        vec_ids = {
-            str(row[0])
-            for row in conn.execute(
-                "SELECT node_id FROM vec_embeddings LIMIT 1001"
-            ).fetchall()
-            if row[0] is not None
-        }
+        vec_ids, vec_issues = _vec_issues(
+            conn,
+            vec_dimension=vec_dimension or 0,
+            expected_dimension=expected_dimension,
+        )
         active_embedding_ids = embedding_ids & set(active_nodes)
         counts["missing_vec"] = len(active_embedding_ids - vec_ids)
         counts["stale_vec"] = len(vec_ids - active_embedding_ids)
+        counts["invalid_vec"] = sum(
+            value
+            for reason, value in vec_issues.items()
+            if reason.startswith("vec_embedding_")
+        )
+        counts["vec_mismatched"] = vec_issues.get("vec_value_mismatch", 0)
+        for reason, value in vec_issues.items():
+            _record(report["reasons_by_kind"], reason, value)
+        if expected_dimension is not None and vec_dimension != expected_dimension:
+            report["reasons"].append("vec_dimension_mismatch")
+            _record(report["reasons_by_kind"], "vec_dimension_mismatch")
+            counts["invalid_vec"] += 1
     elif vec_status == "present":
         report["reasons"].append("vec_index_unverifiable")
     counts["orphan_edges"] = int(
@@ -326,7 +391,10 @@ def inspect_integrity(
             "WHERE node_type='core_memory' AND COALESCE(permanent,0)=0"
         ).fetchone()[0]
     )
-    report["status"] = "findings" if any(counts.values()) else "ok"
+    anomaly_keys = {
+        key for key in counts if key not in {"embeddings"}
+    }
+    report["status"] = "findings" if any(counts[key] for key in anomaly_keys) else "ok"
     report["uncertainty"] = ["historical_consolidation"]
     return report
 
@@ -383,6 +451,13 @@ def repair_integrity(
             "reason": "schema_tables_missing",
             "missing_tables": sorted(_REQUIRED_TABLES - tables),
         }
+    if not conn.in_transaction:
+        return {
+            "status": "rejected",
+            "reason": "outer_transaction_required",
+            "transaction_owner": "caller",
+            "committed": False,
+        }
 
     vec_status, vec_dimension, vec_reason = _vec_schema(conn)
     report = _base_report(
@@ -436,14 +511,47 @@ def repair_integrity(
             "WHERE node_type='core_memory' AND COALESCE(permanent,0)=0"
         ).fetchone()[0]
     )
-    vec_needed = bool(selected & {"repair_vec", "repair_embeddings"})
+    vec_operational = vec_status == "present" and _load_vec(conn)
     vec_ready = (
-        vec_status == "present"
-        and _load_vec(conn)
+        vec_operational
         and (expected_dimension is None or vec_dimension == expected_dimension)
     )
+    if vec_operational:
+        vec_ids, vec_issues = _vec_issues(
+            conn,
+            vec_dimension=vec_dimension or 0,
+            expected_dimension=expected_dimension,
+        )
+        active_embedding_ids = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT e.node_id FROM embeddings e "
+                "JOIN thought_nodes n ON n.id=e.node_id "
+                "WHERE n.decayed IS NULL OR n.decayed=0 LIMIT 1001"
+            ).fetchall()
+        }
+        counts["missing_vec"] = len(active_embedding_ids - vec_ids)
+        counts["stale_vec"] = len(vec_ids - active_embedding_ids)
+        counts["invalid_vec"] = sum(
+            value
+            for reason, value in vec_issues.items()
+            if reason.startswith("vec_embedding_")
+        )
+        counts["vec_mismatched"] = vec_issues.get("vec_value_mismatch", 0)
+        for reason, value in vec_issues.items():
+            _record(report["reasons_by_kind"], reason, value)
+        if expected_dimension is not None and vec_dimension != expected_dimension:
+            report["reasons"].append("vec_dimension_mismatch")
+            _record(report["reasons_by_kind"], "vec_dimension_mismatch")
+            counts["invalid_vec"] += 1
+    vec_needed = bool(selected & {"repair_vec", "repair_embeddings"})
     if vec_needed and require_vec_parity and not vec_ready:
-        report["reasons"].append(vec_reason or "vec_index_unverifiable")
+        if vec_reason:
+            report["reasons"].append(vec_reason)
+        elif expected_dimension is not None and vec_dimension not in (None, expected_dimension):
+            report["reasons"].append("vec_dimension_mismatch")
+        else:
+            report["reasons"].append("vec_index_unverifiable")
         skipped["vec_repairs"] = max_items
 
     def item_budget() -> bool:
@@ -452,47 +560,61 @@ def repair_integrity(
 
     def run_item(callback: Callable[[], None]) -> bool:
         index = report["limits"]["items_considered"]
-        name = _savepoint(conn, index)
+        try:
+            name = _savepoint(conn, index)
+        except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError) as exc:
+            _record(failures, "savepoint_begin_failed")
+            _record(failures, type(exc).__name__)
+            return False
         try:
             callback()
         except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError) as exc:
             try:
                 _rollback_savepoint(conn, name)
-            except sqlite3.Error:
+            except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError):
                 _record(failures, "savepoint_rollback_failed")
             _record(failures, type(exc).__name__)
             return False
-        _release_savepoint(conn, name)
+        try:
+            _release_savepoint(conn, name)
+        except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError) as exc:
+            _record(failures, "savepoint_release_failed")
+            _record(failures, type(exc).__name__)
+            try:
+                _rollback_savepoint(conn, name)
+            except (OSError, RuntimeError, sqlite3.Error, TypeError, ValueError):
+                _record(failures, "savepoint_rollback_failed")
+            return False
         report["mutated"] = True
         return True
 
-    # Remove embedding rows for deleted nodes first.  This is deterministic
-    # and needs no model.  The vec counterpart is removed in the same savepoint.
     if "remove_orphan_embeddings" in selected:
         orphan_rows = conn.execute(
-            "SELECT e.node_id FROM embeddings e "
+            "SELECT e.rowid, e.node_id FROM embeddings e "
             "LEFT JOIN thought_nodes n ON n.id=e.node_id "
             "WHERE n.id IS NULL ORDER BY e.node_id LIMIT ?",
             (min(batch_size, max_items),),
         ).fetchall()
         counts["orphan_embeddings"] = len(orphan_rows)
-        for (node_id,) in orphan_rows:
+        for rowid, node_id in orphan_rows:
             if not item_budget():
                 break
 
-            def remove_orphan(node_id=node_id) -> None:
-                conn.execute("DELETE FROM embeddings WHERE node_id=?", (node_id,))
-                if vec_ready:
+            def remove_orphan(rowid=rowid, node_id=node_id) -> None:
+                conn.execute("DELETE FROM embeddings WHERE rowid=?", (rowid,))
+                if conn.execute(
+                    "SELECT 1 FROM embeddings WHERE rowid=?", (rowid,)
+                ).fetchone() is not None:
+                    raise RuntimeError("orphan_embedding_not_removed")
+                if vec_ready and node_id is not None:
                     conn.execute("DELETE FROM vec_embeddings WHERE node_id=?", (node_id,))
 
             if run_item(remove_orphan):
                 repairs["orphan_embeddings_removed"] += 1
 
-    # Delete edges with missing endpoints.  Self-edges stay report-only unless
-    # the explicit action is selected.
     if "remove_orphan_edges" in selected:
         edge_rows = conn.execute(
-            "SELECT e.parent_id, e.child_id FROM derivation_edges e "
+            "SELECT e.rowid, e.parent_id, e.child_id FROM derivation_edges e "
             "LEFT JOIN thought_nodes p ON p.id=e.parent_id "
             "LEFT JOIN thought_nodes c ON c.id=e.child_id "
             "WHERE p.id IS NULL OR c.id IS NULL "
@@ -500,15 +622,16 @@ def repair_integrity(
             (min(batch_size, max_items),),
         ).fetchall()
         counts["orphan_edges"] = len(edge_rows)
-        for parent_id, child_id in edge_rows:
+        for rowid, _parent_id, _child_id in edge_rows:
             if not item_budget():
                 break
 
-            def remove_edge(parent_id=parent_id, child_id=child_id) -> None:
-                conn.execute(
-                    "DELETE FROM derivation_edges WHERE parent_id=? AND child_id=?",
-                    (parent_id, child_id),
-                )
+            def remove_edge(rowid=rowid) -> None:
+                conn.execute("DELETE FROM derivation_edges WHERE rowid=?", (rowid,))
+                if conn.execute(
+                    "SELECT 1 FROM derivation_edges WHERE rowid=?", (rowid,)
+                ).fetchone() is not None:
+                    raise RuntimeError("orphan_edge_not_removed")
 
             if run_item(remove_edge):
                 repairs["orphan_edges_removed"] += 1
@@ -532,24 +655,70 @@ def repair_integrity(
             if run_item(remove_self):
                 repairs["self_edges_removed"] += 1
 
-    if vec_ready and "repair_vec" in selected:
+    if vec_operational and "repair_vec" in selected:
         rows = conn.execute(
-            "SELECT v.node_id FROM vec_embeddings v "
-            "LEFT JOIN thought_nodes n ON n.id=v.node_id "
+            "SELECT v.node_id, v.embedding, e.vector, n.decayed "
+            "FROM vec_embeddings v "
             "LEFT JOIN embeddings e ON e.node_id=v.node_id "
-            "WHERE n.id IS NULL OR e.node_id IS NULL "
-            "OR n.decayed != 0 LIMIT ?",
+            "LEFT JOIN thought_nodes n ON n.id=v.node_id "
+            "ORDER BY v.node_id LIMIT ?",
             (min(batch_size, max_items),),
         ).fetchall()
-        for (node_id,) in rows:
+        for node_id, vector, ordinary, decayed in rows:
             if not item_budget():
                 break
+            vector_reason = _decode_vector(vector, vec_dimension)
+            ordinary_reason = (
+                _decode_vector(ordinary, expected_dimension or vec_dimension)
+                if ordinary is not None
+                else "embedding_missing"
+            )
+            stale = node_id is None or ordinary is None or decayed not in (None, 0)
+            mismatched = (
+                not stale
+                and vector_reason is None
+                and ordinary_reason is None
+                and not _vectors_match(vector, ordinary, vec_dimension)
+            )
+            invalid = vector_reason is not None or mismatched
+            if not stale and not invalid:
+                continue
+            replacement = (
+                ordinary
+                if not stale
+                and ordinary_reason is None
+                and vec_ready
+                and expected_dimension in (None, vec_dimension)
+                else None
+            )
 
-            def remove_vec(node_id=node_id) -> None:
-                conn.execute("DELETE FROM vec_embeddings WHERE node_id=?", (node_id,))
+            def replace_vec(node_id=node_id, replacement=replacement) -> None:
+                if node_id is None:
+                    conn.execute("DELETE FROM vec_embeddings WHERE node_id IS NULL")
+                    remaining = conn.execute(
+                        "SELECT 1 FROM vec_embeddings WHERE node_id IS NULL"
+                    ).fetchone()
+                else:
+                    conn.execute(
+                        "DELETE FROM vec_embeddings WHERE node_id=?", (node_id,)
+                    )
+                    remaining = conn.execute(
+                        "SELECT 1 FROM vec_embeddings WHERE node_id=?", (node_id,)
+                    ).fetchone()
+                if remaining is not None:
+                    raise RuntimeError("vec_row_not_removed")
+                if replacement is not None:
+                    conn.execute(
+                        "INSERT INTO vec_embeddings(node_id, embedding) "
+                        "SELECT node_id, ? FROM embeddings WHERE node_id=?",
+                        (replacement, node_id),
+                    )
 
-            if run_item(remove_vec):
+            if run_item(replace_vec):
                 repairs["vec_rows_removed"] += 1
+                if replacement is not None:
+                    repairs["vec_rows_inserted"] += 1
+
         valid_rows = conn.execute(
             "SELECT e.node_id, e.vector, e.model FROM embeddings e "
             "JOIN thought_nodes n ON n.id=e.node_id "
@@ -561,11 +730,13 @@ def repair_integrity(
         for node_id, blob, model in valid_rows:
             if not item_budget():
                 break
-            reason = _decode_vector(blob, expected_dimension)
-            if reason is not None or (
-                embedding_model is not None and model != embedding_model
+            reason = _decode_vector(blob, expected_dimension or vec_dimension)
+            if (
+                reason is not None
+                or not vec_ready
+                or (embedding_model is not None and model != embedding_model)
             ):
-                _record(skipped, reason or "embedding_model_mismatch")
+                _record(skipped, reason or "vec_dimension_mismatch")
                 continue
 
             def insert_vec(node_id=node_id, blob=blob) -> None:
@@ -668,7 +839,40 @@ def repair_integrity(
             if run_item(promote_core):
                 repairs["core_memories_promoted"] += 1
 
-    report["status"] = "partial" if skipped or failures else "completed"
+    remaining_report = inspect_integrity(
+        conn,
+        expected_model=embedding_model,
+        expected_dimension=expected_dimension,
+    )
+    remaining_counts = remaining_report.get("counts", {})
+    report["remaining"] = {
+        key: value
+        for key, value in remaining_counts.items()
+        if key != "embeddings" and value
+    }
+    actionable_keys = set()
+    if "remove_orphan_embeddings" in selected:
+        actionable_keys.add("orphan_embeddings")
+    if "remove_orphan_edges" in selected:
+        actionable_keys.add("orphan_edges")
+    if "repair_vec" in selected:
+        actionable_keys.update(
+            {"missing_vec", "stale_vec", "invalid_vec", "vec_mismatched"}
+        )
+    if "repair_embeddings" in selected:
+        actionable_keys.update({"missing_embeddings", "invalid_embeddings"})
+    if "remove_self_edges" in selected:
+        actionable_keys.add("self_edges")
+    if permanence_policy != "report":
+        actionable_keys.add("permanent_and_decayed")
+    if "promote_core_memories" in selected:
+        actionable_keys.add("core_memory_not_permanent")
+    remaining_actionable = any(
+        remaining_counts.get(key, 0) for key in actionable_keys
+    )
+    report["status"] = (
+        "partial" if skipped or failures or remaining_actionable else "completed"
+    )
     report["uncertainty"] = ["historical_consolidation", "commit_owned_by_caller"]
     return report
 

--- a/docs/integrity-repair.md
+++ b/docs/integrity-repair.md
@@ -1,0 +1,69 @@
+# Connection-owned integrity repair
+
+`core.integrity` provides a small repair boundary for applications that own
+the SQLite lifecycle around a Cashew brain.  It is intended for adapters such
+as Hermes that coordinate more than one process and therefore cannot safely
+delegate connection or journal management to a path-based helper.
+
+## Ownership contract
+
+`inspect_integrity(conn, ...)` and `repair_integrity(conn, ...)` require an
+open `sqlite3.Connection`.  They never open or close that connection, commit
+or roll back an outer transaction, change journal mode, or acquire a process
+lock.  The caller owns:
+
+1. the profile-scoped backup;
+2. an exclusive maintenance lease;
+3. the SQLite journal and busy-timeout policy;
+4. the outer transaction and final commit; and
+5. the post-repair verification audit.
+
+Each individual repair uses a savepoint.  A failed savepoint is rolled back
+without discarding unrelated work in the caller's transaction.  A successful
+repair is still uncommitted until the caller commits.  This is deliberate:
+the caller must be able to classify an ambiguous commit and retain its backup
+for recovery rather than having Cashew silently overwrite the live profile.
+
+The result contains `transaction_owner: "caller"` and `committed: false`.
+`completed` means that all selected work completed within the bound;
+`partial` means that a repair was skipped or failed and the caller must audit
+again.  Commit uncertainty cannot be determined by this API because commit
+belongs to the caller; adapters should report it as `uncertain` and preserve
+their backup when their own commit or postcondition check is ambiguous.
+
+## Safe repair boundary
+
+The default actions remove embeddings whose node no longer exists, remove
+edges whose endpoint no longer exists, repair a missing vec row from a valid
+ordinary embedding, remove stale vec rows, and re-embed a live node only when
+the caller supplies a compatible embedding function, model name, and positive
+dimension.  Every re-embedded node is written to the ordinary and vec tables
+under one savepoint.  Invalid, nonfinite, zero-norm, wrong-dimension, or
+model-mismatched output is rejected before a write.
+
+Work is capped by `max_items` and each query is limited by `batch_size`.
+Repeating the operation after a successful commit is safe and normally
+returns zero additional repairs.
+
+The vec table is never created, dropped, or recreated by this API.  A missing,
+unloadable, or dimension-incompatible vec table is reported as unavailable
+when parity is required.  An ordinary-only repair may opt out with
+`require_vec_parity=False`.
+
+Permanence contradictions and self-edges are report-only by default.  A
+caller must explicitly request `permanence_policy="preserve_permanent"` or
+`"preserve_decay"` before either side of a contradictory flag is changed, and
+must select `remove_self_edges` before self-edges are deleted.
+
+## What cannot be reconstructed
+
+Cashew does not infer deleted or merged facts from the current graph.  It does
+not resurrect every decayed node, recreate the meaning of a historical
+consolidation, or guess whether a contradictory permanence flag was the
+intended one.  A backup and the audit report remain the recovery path for
+those cases.
+
+The embedding function is supplied by the host.  Cashew never constructs an
+LLM or embedding model as part of repair, and it refuses to guess a model or
+dimension from process-global configuration when the caller has not provided
+one.

--- a/docs/integrity-repair.md
+++ b/docs/integrity-repair.md
@@ -37,6 +37,8 @@ bounded pass, including work beyond `batch_size` or `max_items`.  Commit
 uncertainty cannot be determined by this API because commit
 belongs to the caller; adapters should report it as `uncertain` and preserve
 their backup when their own commit or postcondition check is ambiguous.
+If a savepoint rollback itself fails, the result sets `mutated: true`,
+`mutation_uncertain: true`, and records `savepoint_rollback_failed`.
 
 ## Safe repair boundary
 
@@ -58,6 +60,9 @@ float32 parity with the ordinary embedding.  A missing, unloadable, or
 dimension-incompatible vec table is reported as unavailable when parity is
 required.  An ordinary-only repair may opt out with
 `require_vec_parity=False`.
+When an embedding model is supplied, a vec replacement may copy only an
+ordinary embedding carrying that exact model; otherwise the row remains
+skipped for the caller's model-specific repair path.
 
 Permanence contradictions and self-edges are report-only by default.  A
 caller must explicitly request `permanence_policy="preserve_permanent"` or

--- a/docs/integrity-repair.md
+++ b/docs/integrity-repair.md
@@ -18,6 +18,11 @@ lock.  The caller owns:
 4. the outer transaction and final commit; and
 5. the post-repair verification audit.
 
+`repair_integrity` also requires the caller to have begun an outer
+transaction.  It returns `status: "rejected"` with
+`reason: "outer_transaction_required"` when `conn.in_transaction` is false;
+the caller must explicitly begin the transaction before invoking it.
+
 Each individual repair uses a savepoint.  A failed savepoint is rolled back
 without discarding unrelated work in the caller's transaction.  A successful
 repair is still uncommitted until the caller commits.  This is deliberate:
@@ -27,7 +32,9 @@ for recovery rather than having Cashew silently overwrite the live profile.
 The result contains `transaction_owner: "caller"` and `committed: false`.
 `completed` means that all selected work completed within the bound;
 `partial` means that a repair was skipped or failed and the caller must audit
-again.  Commit uncertainty cannot be determined by this API because commit
+again.  The `remaining` mapping records actionable anomalies left after the
+bounded pass, including work beyond `batch_size` or `max_items`.  Commit
+uncertainty cannot be determined by this API because commit
 belongs to the caller; adapters should report it as `uncertain` and preserve
 their backup when their own commit or postcondition check is ambiguous.
 
@@ -45,9 +52,11 @@ Work is capped by `max_items` and each query is limited by `batch_size`.
 Repeating the operation after a successful commit is safe and normally
 returns zero additional repairs.
 
-The vec table is never created, dropped, or recreated by this API.  A missing,
-unloadable, or dimension-incompatible vec table is reported as unavailable
-when parity is required.  An ordinary-only repair may opt out with
+The vec table is never created, dropped, or recreated by this API.  Existing
+vec rows are checked for schema dimension, finite/nonzero values, and exact
+float32 parity with the ordinary embedding.  A missing, unloadable, or
+dimension-incompatible vec table is reported as unavailable when parity is
+required.  An ordinary-only repair may opt out with
 `require_vec_parity=False`.
 
 Permanence contradictions and self-edges are report-only by default.  A

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+import core.integrity as integrity
 from core.integrity import inspect_integrity, repair_integrity
 
 
@@ -114,6 +115,7 @@ def test_orphan_repairs_preserve_outer_transaction_and_are_idempotent(
 
     conn = sqlite3.connect(path)
     # Recreate and commit the repair, then prove a second pass is a no-op.
+    conn.execute("BEGIN")
     second = repair_integrity(
         conn,
         embedding_model="model-a",
@@ -123,6 +125,7 @@ def test_orphan_repairs_preserve_outer_transaction_and_are_idempotent(
     conn.commit()
     assert second["repairs"]["orphan_embeddings_removed"] == 1
     assert second["repairs"]["orphan_edges_removed"] == 1
+    conn.execute("BEGIN")
     again = repair_integrity(
         conn,
         embedding_model="model-a",
@@ -150,6 +153,7 @@ def test_embedding_output_validation_does_not_write_invalid_pairs(
     conn = _create_db(tmp_path / f"invalid-{reason}.db")
     _add_node(conn, "n1", "repair me")
     conn.commit()
+    conn.execute("BEGIN")
 
     result = repair_integrity(
         conn,
@@ -178,6 +182,7 @@ def test_model_mismatch_and_missing_embedding_are_repaired_from_current_content(
         (_blob([1.0, 0.0, 0.0, 0.0]),),
     )
     conn.commit()
+    conn.execute("BEGIN")
     seen: list[str] = []
 
     def embed(texts):
@@ -211,6 +216,7 @@ def test_savepoint_rollback_keeps_other_repairs_and_reports_failure(tmp_path: Pa
         "WHEN NEW.node_id='bad' BEGIN SELECT RAISE(ABORT, 'reject bad'); END"
     )
     conn.commit()
+    conn.execute("BEGIN")
 
     result = repair_integrity(
         conn,
@@ -241,6 +247,7 @@ def test_ambiguous_permanence_and_self_edges_are_report_only_by_default(
         "INSERT INTO derivation_edges VALUES ('n1', 'n1', 1.0, 'self', 'now')"
     )
     conn.commit()
+    conn.execute("BEGIN")
 
     report = repair_integrity(conn, actions=set(), expected_dimension=4)
     assert report["status"] == "completed"
@@ -280,6 +287,7 @@ def test_invalid_arguments_and_schema_states_are_explicit(tmp_path: Path) -> Non
     deceptive = _create_db(tmp_path / "deceptive.db")
     deceptive.execute("CREATE TABLE vec_embeddings (node_id TEXT, embedding BLOB)")
     deceptive.commit()
+    deceptive.execute("BEGIN")
     result = repair_integrity(deceptive, actions={"repair_vec"})
     assert result["status"] == "partial"
     assert "vec_schema_invalid" in result["reasons"]
@@ -327,4 +335,185 @@ def test_real_vec_repairs_are_atomic_when_available(tmp_path: Path) -> None:
     assert conn.execute("SELECT node_id FROM vec_embeddings ORDER BY node_id").fetchall() == [
         ("stale",),
     ]
+    conn.close()
+
+
+def test_null_orphans_are_deleted_by_rowid(tmp_path: Path) -> None:
+    conn = _create_db(tmp_path / "null-orphans.db")
+    _add_node(conn, "live")
+    blob = _blob([1.0, 0.0, 0.0, 0.0])
+    conn.execute(
+        "INSERT INTO embeddings (node_id, vector, model, updated_at) "
+        "VALUES (NULL, ?, 'model-a', 'now')",
+        (blob,),
+    )
+    conn.execute(
+        "INSERT INTO derivation_edges VALUES (NULL, 'live', 1.0, 'bad', 'now')"
+    )
+    conn.commit()
+    conn.execute("BEGIN")
+
+    result = repair_integrity(
+        conn,
+        require_vec_parity=False,
+        actions={"remove_orphan_embeddings", "remove_orphan_edges"},
+    )
+
+    assert result["status"] == "completed"
+    assert result["repairs"]["orphan_embeddings_removed"] == 1
+    assert result["repairs"]["orphan_edges_removed"] == 1
+    assert conn.execute("SELECT COUNT(*) FROM embeddings").fetchone() == (0,)
+    assert conn.execute("SELECT COUNT(*) FROM derivation_edges").fetchone() == (0,)
+    conn.rollback()
+    conn.close()
+
+
+def test_inventory_embeddings_do_not_make_healthy_status_findings(
+    tmp_path: Path,
+) -> None:
+    conn = _create_db(tmp_path / "healthy.db")
+    _add_node(conn, "live")
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('live', ?, 'model-a', 'now')",
+        (_blob([1.0, 0.0, 0.0, 0.0]),),
+    )
+    conn.commit()
+
+    report = inspect_integrity(conn, expected_model="model-a", expected_dimension=4)
+
+    assert report["counts"]["embeddings"] == 1
+    assert report["status"] == "ok"
+    conn.close()
+
+
+def test_real_vec_invalid_and_mismatched_rows_are_replaced(tmp_path: Path) -> None:
+    sqlite_vec = pytest.importorskip("sqlite_vec")
+    conn = _create_db(tmp_path / "vec-invalid.db")
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    conn.execute(
+        "CREATE VIRTUAL TABLE vec_embeddings USING vec0("
+        "node_id TEXT PRIMARY KEY, embedding float[4] distance_metric=cosine)"
+    )
+    ordinary = _blob([1.0, 0.0, 0.0, 0.0])
+    for node_id in ("zero", "nan", "mismatch"):
+        _add_node(conn, node_id)
+        conn.execute(
+            "INSERT INTO embeddings VALUES (?, ?, 'model-a', 'now')",
+            (node_id, ordinary),
+        )
+    conn.execute(
+        "INSERT INTO vec_embeddings VALUES ('zero', ?)",
+        (_blob([0.0, 0.0, 0.0, 0.0]),),
+    )
+    conn.execute(
+        "INSERT INTO vec_embeddings VALUES ('nan', ?)",
+        (struct.pack("<4f", float("nan"), 0.0, 0.0, 0.0),),
+    )
+    conn.execute(
+        "INSERT INTO vec_embeddings VALUES ('mismatch', ?)",
+        (_blob([0.0, 1.0, 0.0, 0.0]),),
+    )
+    conn.commit()
+    before = inspect_integrity(conn, expected_dimension=4)
+    assert before["counts"]["invalid_vec"] == 2
+    assert before["counts"]["vec_mismatched"] == 1
+    assert before["reasons_by_kind"]["vec_embedding_zero_norm"] == 1
+    assert before["reasons_by_kind"]["vec_embedding_nonfinite"] == 1
+    assert before["reasons_by_kind"]["vec_value_mismatch"] == 1
+    wrong_schema_dimension = inspect_integrity(conn, expected_dimension=3)
+    assert wrong_schema_dimension["counts"]["invalid_vec"] >= 1
+    assert "vec_dimension_mismatch" in wrong_schema_dimension["reasons"]
+    conn.execute("BEGIN")
+
+    result = repair_integrity(
+        conn,
+        expected_dimension=4,
+        embedding_model="model-a",
+        actions={"repair_vec"},
+        batch_size=10,
+    )
+
+    assert result["status"] == "completed"
+    assert result["repairs"]["vec_rows_inserted"] == 3
+    assert result["remaining"] == {}
+    assert conn.execute(
+        "SELECT node_id, embedding FROM vec_embeddings ORDER BY node_id"
+    ).fetchall() == [(node_id, ordinary) for node_id in ("mismatch", "nan", "zero")]
+    conn.rollback()
+    conn.close()
+
+
+def test_bounded_repairs_report_remaining_work(tmp_path: Path) -> None:
+    conn = _create_db(tmp_path / "bounded.db")
+    for node_id in ("a", "b", "c"):
+        _add_node(conn, node_id)
+        conn.execute(
+            "INSERT INTO embeddings VALUES (?, ?, 'model-a', 'now')",
+            (f"ghost-{node_id}", _blob([1.0, 0.0, 0.0, 0.0])),
+        )
+        conn.execute(
+            "INSERT INTO derivation_edges VALUES (?, ?, 1.0, 'bad', 'now')",
+            (f"ghost-{node_id}", node_id),
+        )
+    conn.commit()
+    conn.execute("BEGIN")
+
+    result = repair_integrity(
+        conn,
+        require_vec_parity=False,
+        actions={"remove_orphan_embeddings", "remove_orphan_edges"},
+        batch_size=10,
+        max_items=1,
+    )
+
+    assert result["status"] == "partial"
+    assert result["limits"]["items_considered"] == 2
+    assert result["remaining"]["orphan_embeddings"] == 2
+    assert result["remaining"]["orphan_edges"] == 3
+    conn.rollback()
+    conn.close()
+
+
+def test_release_failure_is_structured_and_savepoint_is_rolled_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = _create_db(tmp_path / "release-failure.db")
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('ghost', ?, 'model-a', 'now')",
+        (_blob([1.0, 0.0, 0.0, 0.0]),),
+    )
+    conn.commit()
+    conn.execute("BEGIN")
+
+    def fail_release(_conn, _name):
+        raise sqlite3.OperationalError("synthetic release failure")
+
+    monkeypatch.setattr(integrity, "_release_savepoint", fail_release)
+    result = repair_integrity(
+        conn,
+        require_vec_parity=False,
+        actions={"remove_orphan_embeddings"},
+    )
+
+    assert result["status"] == "partial"
+    assert result["failures"]["savepoint_release_failed"] == 1
+    assert result["repairs"]["orphan_embeddings_removed"] == 0
+    assert conn.execute("SELECT COUNT(*) FROM embeddings").fetchone() == (1,)
+    conn.rollback()
+    conn.close()
+
+
+def test_repairs_require_a_caller_owned_outer_transaction(tmp_path: Path) -> None:
+    conn = _create_db(tmp_path / "transaction-required.db")
+
+    result = repair_integrity(conn, actions=set())
+
+    assert result == {
+        "status": "rejected",
+        "reason": "outer_transaction_required",
+        "transaction_owner": "caller",
+        "committed": False,
+    }
     conn.close()

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,330 @@
+"""Contract tests for the connection-owned integrity API."""
+
+from __future__ import annotations
+
+import sqlite3
+import struct
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from core.integrity import inspect_integrity, repair_integrity
+
+
+def _blob(values: list[float]) -> bytes:
+    return struct.pack(f"<{len(values)}f", *values)
+
+
+def _create_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        PRAGMA user_version = 3;
+        CREATE TABLE thought_nodes (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            node_type TEXT NOT NULL,
+            decayed INTEGER DEFAULT 0,
+            permanent INTEGER DEFAULT 0,
+            access_count INTEGER DEFAULT 0,
+            last_updated TEXT
+        );
+        CREATE TABLE embeddings (
+            node_id TEXT PRIMARY KEY,
+            vector BLOB NOT NULL,
+            model TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE derivation_edges (
+            parent_id TEXT,
+            child_id TEXT,
+            weight REAL,
+            reasoning TEXT,
+            timestamp TEXT,
+            PRIMARY KEY (parent_id, child_id)
+        );
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _add_node(conn: sqlite3.Connection, node_id: str, content: str = "content") -> None:
+    conn.execute(
+        "INSERT INTO thought_nodes (id, content, node_type) VALUES (?, ?, 'fact')",
+        (node_id, content),
+    )
+
+
+def test_inspection_is_query_only_and_keeps_connection_transaction_and_journal(
+    tmp_path: Path,
+) -> None:
+    conn = _create_db(tmp_path / "inspect.db")
+    assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+    _add_node(conn, "n1")
+    conn.commit()
+    conn.execute("INSERT INTO thought_nodes (id, content, node_type) VALUES ('pending', 'x', 'fact')")
+    before_mode = conn.execute("PRAGMA journal_mode").fetchone()[0].lower()
+
+    report = inspect_integrity(conn, expected_model="model-a", expected_dimension=4)
+
+    assert report["status"] == "findings"
+    assert report["transaction_owner"] == "caller"
+    assert report["committed"] is False
+    assert conn.in_transaction is True
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == before_mode
+    assert conn.execute("SELECT 1 FROM thought_nodes WHERE id='pending'").fetchone() == (1,)
+    conn.rollback()
+    conn.close()
+
+
+def test_orphan_repairs_preserve_outer_transaction_and_are_idempotent(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "orphan.db"
+    conn = _create_db(path)
+    _add_node(conn, "live")
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('ghost', ?, 'model-a', 'now')",
+        (_blob([1.0, 0.0, 0.0, 0.0]),),
+    )
+    conn.execute(
+        "INSERT INTO derivation_edges VALUES ('ghost', 'live', 1.0, 'bad', 'now')"
+    )
+    conn.commit()
+    conn.execute(
+        "INSERT INTO thought_nodes (id, content, node_type) VALUES ('caller', 'keep', 'fact')"
+    )
+
+    first = repair_integrity(
+        conn,
+        embedding_model="model-a",
+        expected_dimension=4,
+        actions={"remove_orphan_embeddings", "remove_orphan_edges"},
+    )
+    assert first["status"] == "completed"
+    assert first["mutated"] is True
+    assert first["committed"] is False
+    assert conn.execute("SELECT 1 FROM thought_nodes WHERE id='caller'").fetchone() == (1,)
+    # The caller can still roll back all work, including the repair.
+    conn.rollback()
+    assert conn.execute("SELECT 1 FROM embeddings WHERE node_id='ghost'").fetchone() == (1,)
+    conn.close()
+
+    conn = sqlite3.connect(path)
+    # Recreate and commit the repair, then prove a second pass is a no-op.
+    second = repair_integrity(
+        conn,
+        embedding_model="model-a",
+        expected_dimension=4,
+        actions={"remove_orphan_embeddings", "remove_orphan_edges"},
+    )
+    conn.commit()
+    assert second["repairs"]["orphan_embeddings_removed"] == 1
+    assert second["repairs"]["orphan_edges_removed"] == 1
+    again = repair_integrity(
+        conn,
+        embedding_model="model-a",
+        expected_dimension=4,
+        actions={"remove_orphan_embeddings", "remove_orphan_edges"},
+    )
+    assert again["mutated"] is False
+    assert again["repairs"]["orphan_embeddings_removed"] == 0
+    assert again["repairs"]["orphan_edges_removed"] == 0
+    conn.rollback()
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    ("value", "reason"),
+    [
+        (np.zeros(4, dtype=np.float32), "embedding_zero_norm"),
+        (np.array([np.nan, 0, 0, 1], dtype=np.float32), "embedding_nonfinite"),
+        (np.ones(3, dtype=np.float32), "embedding_dimension_mismatch"),
+    ],
+)
+def test_embedding_output_validation_does_not_write_invalid_pairs(
+    tmp_path: Path, value: np.ndarray, reason: str
+) -> None:
+    conn = _create_db(tmp_path / f"invalid-{reason}.db")
+    _add_node(conn, "n1", "repair me")
+    conn.commit()
+
+    result = repair_integrity(
+        conn,
+        embedding_fn=lambda _texts: np.asarray([value]),
+        embedding_model="model-a",
+        expected_dimension=4,
+        require_vec_parity=False,
+        actions={"repair_embeddings"},
+    )
+
+    assert result["status"] == "partial"
+    assert result["skipped"][reason] == 1
+    assert conn.execute("SELECT COUNT(*) FROM embeddings").fetchone() == (0,)
+    conn.rollback()
+    conn.close()
+
+
+def test_model_mismatch_and_missing_embedding_are_repaired_from_current_content(
+    tmp_path: Path,
+) -> None:
+    conn = _create_db(tmp_path / "reembed.db")
+    _add_node(conn, "missing", "new text")
+    _add_node(conn, "stale", "old text")
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('stale', ?, 'old-model', 'now')",
+        (_blob([1.0, 0.0, 0.0, 0.0]),),
+    )
+    conn.commit()
+    seen: list[str] = []
+
+    def embed(texts):
+        seen.extend(texts)
+        return np.asarray([[0.0, 1.0, 0.0, 0.0] for _ in texts], dtype=np.float32)
+
+    result = repair_integrity(
+        conn,
+        embedding_fn=embed,
+        embedding_model="model-a",
+        expected_dimension=4,
+        require_vec_parity=False,
+        actions={"repair_embeddings"},
+    )
+    conn.commit()
+
+    assert result["status"] == "completed"
+    assert result["repairs"]["embeddings_repaired"] == 2
+    assert set(seen) == {"new text", "old text"}
+    assert conn.execute("SELECT COUNT(*) FROM embeddings").fetchone() == (2,)
+    assert conn.execute("SELECT DISTINCT model FROM embeddings").fetchone() == ("model-a",)
+    conn.close()
+
+
+def test_savepoint_rollback_keeps_other_repairs_and_reports_failure(tmp_path: Path) -> None:
+    conn = _create_db(tmp_path / "savepoint.db")
+    _add_node(conn, "bad", "bad")
+    _add_node(conn, "good", "good")
+    conn.execute(
+        "CREATE TRIGGER reject_bad BEFORE INSERT ON embeddings "
+        "WHEN NEW.node_id='bad' BEGIN SELECT RAISE(ABORT, 'reject bad'); END"
+    )
+    conn.commit()
+
+    result = repair_integrity(
+        conn,
+        embedding_fn=lambda texts: np.asarray(
+            [[1.0, 0.0, 0.0, 0.0] for _ in texts], dtype=np.float32
+        ),
+        embedding_model="model-a",
+        expected_dimension=4,
+        require_vec_parity=False,
+        actions={"repair_embeddings"},
+    )
+
+    assert result["status"] == "partial"
+    assert result["repairs"]["embeddings_repaired"] == 1
+    assert result["failures"]
+    assert conn.execute("SELECT node_id FROM embeddings").fetchall() == [("good",)]
+    conn.rollback()
+    conn.close()
+
+
+def test_ambiguous_permanence_and_self_edges_are_report_only_by_default(
+    tmp_path: Path,
+) -> None:
+    conn = _create_db(tmp_path / "ambiguous.db")
+    _add_node(conn, "n1")
+    conn.execute("UPDATE thought_nodes SET permanent=1, decayed=1 WHERE id='n1'")
+    conn.execute(
+        "INSERT INTO derivation_edges VALUES ('n1', 'n1', 1.0, 'self', 'now')"
+    )
+    conn.commit()
+
+    report = repair_integrity(conn, actions=set(), expected_dimension=4)
+    assert report["status"] == "completed"
+    assert report["counts"]["permanent_and_decayed"] == 1
+    assert report["counts"]["self_edges"] == 1
+    assert conn.execute("SELECT decayed, permanent FROM thought_nodes").fetchone() == (1, 1)
+    assert conn.execute("SELECT COUNT(*) FROM derivation_edges").fetchone() == (1,)
+
+    fixed = repair_integrity(
+        conn,
+        actions={"remove_self_edges", "promote_core_memories"},
+        permanence_policy="preserve_permanent",
+        expected_dimension=4,
+    )
+    assert fixed["repairs"]["self_edges_removed"] == 1
+    assert fixed["repairs"]["permanence_conflicts_resolved"] == 1
+    conn.commit()
+    assert conn.execute("SELECT decayed FROM thought_nodes").fetchone() == (0,)
+    assert conn.execute("SELECT COUNT(*) FROM derivation_edges").fetchone() == (0,)
+    conn.close()
+
+
+def test_invalid_arguments_and_schema_states_are_explicit(tmp_path: Path) -> None:
+    conn = _create_db(tmp_path / "states.db")
+    assert repair_integrity(conn, batch_size=0)["status"] == "rejected"
+    assert repair_integrity(conn, actions={"invented"})["status"] == "rejected"
+    conn.close()
+
+    incomplete = sqlite3.connect(tmp_path / "incomplete.db")
+    incomplete.execute("CREATE TABLE thought_nodes (id TEXT PRIMARY KEY)")
+    incomplete.commit()
+    report = inspect_integrity(incomplete)
+    assert report["status"] == "unavailable"
+    assert repair_integrity(incomplete)["status"] == "unavailable"
+    incomplete.close()
+
+    deceptive = _create_db(tmp_path / "deceptive.db")
+    deceptive.execute("CREATE TABLE vec_embeddings (node_id TEXT, embedding BLOB)")
+    deceptive.commit()
+    result = repair_integrity(deceptive, actions={"repair_vec"})
+    assert result["status"] == "partial"
+    assert "vec_schema_invalid" in result["reasons"]
+    deceptive.close()
+
+
+def test_real_vec_repairs_are_atomic_when_available(tmp_path: Path) -> None:
+    sqlite_vec = pytest.importorskip("sqlite_vec")
+    conn = _create_db(tmp_path / "real-vec.db")
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    conn.execute(
+        "CREATE VIRTUAL TABLE vec_embeddings USING vec0("
+        "node_id TEXT PRIMARY KEY, embedding float[4] distance_metric=cosine)"
+    )
+    _add_node(conn, "valid")
+    _add_node(conn, "stale")
+    blob = _blob([1.0, 0.0, 0.0, 0.0])
+    conn.execute("INSERT INTO embeddings VALUES ('valid', ?, 'model-a', 'now')", (blob,))
+    conn.execute("INSERT INTO embeddings VALUES ('stale', ?, 'model-a', 'now')", (blob,))
+    conn.execute("INSERT INTO vec_embeddings VALUES ('stale', ?)", (blob,))
+    conn.commit()
+    # Establish the caller-owned outer transaction before invoking repair;
+    # releasing a savepoint without an outer transaction necessarily commits
+    # that savepoint in SQLite.
+    conn.execute("BEGIN")
+
+    result = repair_integrity(
+        conn,
+        expected_dimension=4,
+        embedding_model="model-a",
+        actions={"repair_vec"},
+    )
+    assert result["status"] == "completed"
+    assert result["repairs"]["vec_rows_inserted"] == 1
+    assert result["repairs"]["vec_rows_removed"] == 0
+    assert conn.execute("SELECT node_id FROM vec_embeddings ORDER BY node_id").fetchall() == [
+        ("stale",),
+        ("valid",),
+    ]
+    # The API never commits; the caller can still roll back the complete
+    # ordinary-table and sqlite-vec change as one transaction.
+    conn.rollback()
+    assert conn.execute("SELECT node_id FROM vec_embeddings ORDER BY node_id").fetchall() == [
+        ("stale",),
+    ]
+    conn.close()

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -445,6 +445,45 @@ def test_real_vec_invalid_and_mismatched_rows_are_replaced(tmp_path: Path) -> No
     conn.close()
 
 
+def test_real_vec_repair_does_not_copy_old_model_vector(tmp_path: Path) -> None:
+    sqlite_vec = pytest.importorskip("sqlite_vec")
+    conn = _create_db(tmp_path / "vec-old-model.db")
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    conn.execute(
+        "CREATE VIRTUAL TABLE vec_embeddings USING vec0("
+        "node_id TEXT PRIMARY KEY, embedding float[4] distance_metric=cosine)"
+    )
+    _add_node(conn, "old")
+    ordinary = _blob([1.0, 0.0, 0.0, 0.0])
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('old', ?, 'old-model', 'now')", (ordinary,)
+    )
+    conn.execute(
+        "INSERT INTO vec_embeddings VALUES ('old', ?)",
+        (_blob([0.0, 0.0, 0.0, 0.0]),),
+    )
+    conn.commit()
+    conn.execute("BEGIN")
+
+    result = repair_integrity(
+        conn,
+        expected_dimension=4,
+        embedding_model="new-model",
+        actions={"repair_vec"},
+    )
+
+    assert result["status"] == "partial"
+    assert result["skipped"]["embedding_model_mismatch"] == 1
+    assert result["remaining"]["invalid_vec"] == 1
+    assert conn.execute(
+        "SELECT embedding FROM vec_embeddings WHERE node_id='old'"
+    ).fetchone() == (_blob([0.0, 0.0, 0.0, 0.0]),)
+    conn.rollback()
+    conn.close()
+
+
 def test_bounded_repairs_report_remaining_work(tmp_path: Path) -> None:
     conn = _create_db(tmp_path / "bounded.db")
     for node_id in ("a", "b", "c"):
@@ -501,6 +540,40 @@ def test_release_failure_is_structured_and_savepoint_is_rolled_back(
     assert result["failures"]["savepoint_release_failed"] == 1
     assert result["repairs"]["orphan_embeddings_removed"] == 0
     assert conn.execute("SELECT COUNT(*) FROM embeddings").fetchone() == (1,)
+    conn.rollback()
+    conn.close()
+
+
+def test_rollback_failure_reports_mutation_uncertainty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = _create_db(tmp_path / "rollback-uncertain.db")
+    conn.execute(
+        "INSERT INTO embeddings VALUES ('ghost', ?, 'model-a', 'now')",
+        (_blob([1.0, 0.0, 0.0, 0.0]),),
+    )
+    conn.commit()
+    conn.execute("BEGIN")
+
+    def fail_release(_conn, _name):
+        raise sqlite3.OperationalError("synthetic release failure")
+
+    def fail_rollback(_conn, _name):
+        raise sqlite3.OperationalError("synthetic rollback failure")
+
+    monkeypatch.setattr(integrity, "_release_savepoint", fail_release)
+    monkeypatch.setattr(integrity, "_rollback_savepoint", fail_rollback)
+    result = repair_integrity(
+        conn,
+        require_vec_parity=False,
+        actions={"remove_orphan_embeddings"},
+    )
+
+    assert result["status"] == "partial"
+    assert result["mutated"] is True
+    assert result["mutation_uncertain"] is True
+    assert result["failures"]["savepoint_release_failed"] == 1
+    assert result["failures"]["savepoint_rollback_failed"] == 1
     conn.rollback()
     conn.close()
 


### PR DESCRIPTION
## Summary

Add a small public integrity boundary for adapters that own the Cashew SQLite connection, transaction, backup, and maintenance lock.

- add `inspect_integrity(conn, ...)` for bounded, query-only reports;
- add `repair_integrity(conn, ...)` for bounded targeted repairs using caller-owned connections;
- require an active caller-owned outer transaction for repairs;
- keep savepoint rollback local to each repair and never commit, close, rollback an outer transaction, or change journal mode;
- delete NULL orphan embeddings and edges by rowid and verify the target row is gone;
- repair only reconstructible state by default: orphan embeddings and edges, missing/stale sqlite-vec rows, and caller-supplied compatible re-embeddings;
- validate existing sqlite-vec rows for schema dimension, finite/nonzero values, and exact float32 parity with ordinary embeddings;
- replace invalid or mismatched vec rows only from an ordinary embedding whose model matches the requested model, otherwise leave the row and report partial work;
- report remaining actionable work and return `partial` when bounds, skipped work, or failures leave invariants unresolved;
- expose `mutation_uncertain: true` when a savepoint rollback itself fails;
- keep permanence conflicts, self-edges, historical consolidation, and deleted/merged facts report-only unless an explicit policy/action is selected;
- document the ownership contract and non-reconstructible cases;
- add ordinary SQLite and real sqlite-vec contract tests covering validation, transaction ownership, rollback, idempotency, bounds, schema rejection, NULL cleanup, release failure, model mismatch, and atomic dual writes.

This remains independent of PR #136 and does not modify `core/sleep.py`. It is based on current upstream main at `dd57ef029cf9a6dce0b8145d335a55202dd1bac4`.

Related downstream integration: magnus919/hermes-cashew#206.

## Validation

- `ruff check core/integrity.py tests/test_integrity.py`
- `.venv/bin/pytest -q tests/test_integrity.py` (18 passed)
- `.venv/bin/pytest -q` (517 passed)
- `python3 -m py_compile core/integrity.py tests/test_integrity.py`
- `git diff --check`

Latest commit: `cb940f34c15460b87831748b2e702334c1c5fbd0`

Signed-off-by: Magnus Hedemark <magnus919@pm.me>
